### PR TITLE
Add ssrc_fog_x as SITL target

### DIFF
--- a/ROMFS/px4fmu_common/init.d-posix/airframes/4400_ssrc_fog_x
+++ b/ROMFS/px4fmu_common/init.d-posix/airframes/4400_ssrc_fog_x
@@ -1,0 +1,35 @@
+#!/bin/sh
+#
+# @name SSRC Quad X on holybro x500 frame
+#
+# @type Quadrotor x
+# @class Copter
+#
+# @maintainer Jukka Laitinen <jukkax@ssrc.tii.ae>
+#
+# @board px4_fmu-v2 exclude
+# @board bitcraze_crazyflie exclude
+#
+
+. ${R}etc/init.d/rc.mc_defaults
+
+set MIXER quad_x
+set PWM_OUT 1234
+
+if [ $AUTOCNF = yes ]
+then
+	param set IMU_GYRO_CUTOFF 60
+	param set IMU_DGYRO_CUTOFF 30
+	param set MC_ROLLRATE_P 0.14
+	param set MC_PITCHRATE_P 0.14
+	param set MC_ROLLRATE_I 0.3
+	param set MC_PITCHRATE_I 0.3
+	param set MC_ROLLRATE_D 0.004
+	param set MC_PITCHRATE_D 0.004
+
+	param set BAT_N_CELLS 4
+
+	param set MAV_0_CONFIG 0
+	param set RTPS_MAV_CONFIG 101
+	param set SER_TEL1_BAUD 460800
+fi

--- a/ROMFS/px4fmu_common/init.d-posix/airframes/CMakeLists.txt
+++ b/ROMFS/px4fmu_common/init.d-posix/airframes/CMakeLists.txt
@@ -69,6 +69,7 @@ px4_add_romfs_files(
 	1070_boat
 	3010_quadrotor_x
 	3011_hexarotor_x
+	4400_ssrc_fog_x
 	17001_tf-g1
 	2507_cloudship
 	6011_typhoon_h480

--- a/platforms/posix/cmake/sitl_target.cmake
+++ b/platforms/posix/cmake/sitl_target.cmake
@@ -96,7 +96,7 @@ set(models none shell
 	plane plane_cam plane_catapult plane_lidar techpod
 	standard_vtol tailsitter tiltrotor
 	rover r1_rover boat cloudship
-	uuv_hippocampus uuv_bluerov2_heavy)
+	uuv_hippocampus uuv_bluerov2_heavy ssrc_fog_x)
 set(worlds none empty baylands ksql_airport mcmillan_airfield sonoma_raceway warehouse windy)
 set(all_posix_vmd_make_targets)
 foreach(viewer ${viewers})


### PR DESCRIPTION
Signed-off-by: Jari Nippula <jarix@ssrc.tii.ae>

**Describe problem solved by this pull request**
PX4_SITL build target missing for SSRC Fog drone

**Describe your solution**
ssrc_fog_x build target and airframe added into PX4_SITL

**Describe possible alternatives**

**Test data / coverage**

**Additional context**

