### PR TITLE
Disable Multi EKF for 4400_ssrc_fog_x sitl

### DIFF
--- a/ROMFS/px4fmu_common/init.d-posix/airframes/4400_ssrc_fog_x
+++ b/ROMFS/px4fmu_common/init.d-posix/airframes/4400_ssrc_fog_x
@@ -32,4 +32,10 @@ then
 	param set MAV_0_CONFIG 0
 	param set RTPS_MAV_CONFIG 101
 	param set SER_TEL1_BAUD 460800
+
+	# Disable Multi-EKF
+	param set EKF2_MULTI_IMU 0
+	param set SENS_IMU_MODE 1
+	param set EKF2_MULTI_MAG 0
+	param set SENS_MAG_MODE 1
 fi


### PR DESCRIPTION
There is something wrong with publishing sensor_combined when Multi EKF is used

This breaks receiving the sensor data to ROS via fastRTPS

Also the real drone doesn't use Multi-EKF, so it is better to disable also for simulation for us

Signed-off-by: Jukka Laitinen <jukkax@ssrc.tii.ae>

Please use [PX4 Discuss](http://discuss.px4.io/) or [Slack](http://slack.px4.io/) to align on pull requests if necessary. You can then open draft pull requests to get early feedback.

**Describe problem solved by this pull request**
A clear and concise description of the problem this proposed change will solve.
E.g. For this use case I ran into...

**Describe your solution**
A clear and concise description of what you have implemented.

**Describe possible alternatives**
A clear and concise description of alternative solutions or features you've considered.

**Test data / coverage**
How was it tested? What cases were covered? Logs uploaded to https://review.px4.io/ and screenshots of the important plot parts.

**Additional context**
Add any other related context or media.
