### PR TITLE
When using micrortps and mavlink on uart, launch mavlink in "normal" …

### DIFF
--- a/src/modules/micrortps_bridge/micrortps_client/module.yaml
+++ b/src/modules/micrortps_bridge/micrortps_client/module.yaml
@@ -2,7 +2,7 @@ module_name: RTPS
 serial_config:
     - command: |
         protocol_splitter start ${SERIAL_DEV}
-        mavlink start -d /dev/mavlink -b p:${BAUD_PARAM} -m onboard -r 5000 -x
+        mavlink start -d /dev/mavlink -b p:${BAUD_PARAM} -x
         micrortps_client start -d /dev/rtps -b p:${BAUD_PARAM} -l -1
       port_config_param:
         name: RTPS_MAV_CONFIG


### PR DESCRIPTION
…mode

This is required for HIL simulation to work on the same mavlink instance.

Also, the high resolution sensor output data is not needed on mavlink,
as we use RTPS for the purpose.

This should be configurable by a parameter, but just fixing it is sufficient
for now.

Signed-off-by: Jukka Laitinen <jukkax@ssrc.tii.ae>

Please use [PX4 Discuss](http://discuss.px4.io/) or [Slack](http://slack.px4.io/) to align on pull requests if necessary. You can then open draft pull requests to get early feedback.

**Describe problem solved by this pull request**
A clear and concise description of the problem this proposed change will solve.
E.g. For this use case I ran into...

**Describe your solution**
A clear and concise description of what you have implemented.

**Describe possible alternatives**
A clear and concise description of alternative solutions or features you've considered.

**Test data / coverage**
How was it tested? What cases were covered? Logs uploaded to https://review.px4.io/ and screenshots of the important plot parts.

**Additional context**
Add any other related context or media.
