### PR TITLE
flashparams: Fix a null-pointer dereference crash

### DIFF
--- a/src/lib/parameters/flashparams/flashfs.c
+++ b/src/lib/parameters/flashparams/flashfs.c
@@ -875,11 +875,13 @@ parameter_flashfs_write(flash_file_token_t token, uint8_t *buffer, size_t buf_si
 				}
 
 				pf = (flash_entry_header_t *) current_sector->address;
+
+				if (!blank_check(pf, total_size)) {
+					rv = erase_sector(current_sector, pf);
+				}
+
 			}
 
-			if (!blank_check(pf, total_size)) {
-				rv = erase_sector(current_sector, pf);
-			}
 		}
 
 		flash_entry_header_t *pn = (flash_entry_header_t *)(buffer - sizeof(flash_entry_header_t));


### PR DESCRIPTION
Fix a potential crash caused by calling erase_sector with a null
sector_descriptor (current_sector == 0).

Signed-off-by: Jukka Laitinen <jukkax@ssrc.tii.ae>

Please use [PX4 Discuss](http://discuss.px4.io/) or [Slack](http://slack.px4.io/) to align on pull requests if necessary. You can then open draft pull requests to get early feedback.

**Describe problem solved by this pull request**
A clear and concise description of the problem this proposed change will solve.
E.g. For this use case I ran into...

**Describe your solution**
A clear and concise description of what you have implemented.

**Describe possible alternatives**
A clear and concise description of alternative solutions or features you've considered.

**Test data / coverage**
How was it tested? What cases were covered? Logs uploaded to https://review.px4.io/ and screenshots of the important plot parts.

**Additional context**
Add any other related context or media.
