### PR TITLE
Fix ll40ls driver further

### DIFF
--- a/src/drivers/distance_sensor/ll40ls/LidarLiteI2C.cpp
+++ b/src/drivers/distance_sensor/ll40ls/LidarLiteI2C.cpp
@@ -421,14 +421,17 @@ LidarLiteI2C::collect()
 		}
 
 		uint8_t ll40ls_peak_strength = val[0];
-		// If peak strength is under the acceptance limit, just don't report
-		if (ll40ls_peak_strength < LL40LS_PEAK_STRENGTH_LOW || ll40ls_peak_strength > LL40LS_PEAK_STRENGTH_HIGH) {
+
+		// The LL40LS reports 1 cm distance when the measurement is invalid. Don't report this upwards at all, since the value itself is meaningless
+		if (distance_m < LL40LS_MIN_DISTANCE) {
 			perf_end(_sample_perf);
 			return OK;
 		}
 
 		// For v2 and v3 use ll40ls_signal_strength (a relative measure, i.e. peak strength to noise!) to reject potentially ambiguous measurements
-		if (ll40ls_signal_strength <= LL40LS_SIGNAL_STRENGTH_LOW || distance_m < LL40LS_MIN_DISTANCE) {
+		if (ll40ls_signal_strength < LL40LS_SIGNAL_STRENGTH_LOW ||
+		    ll40ls_peak_strength < LL40LS_PEAK_STRENGTH_LOW ||
+		    ll40ls_peak_strength > LL40LS_PEAK_STRENGTH_HIGH) {
 			signal_quality = 0;
 
 		} else {


### PR DESCRIPTION
Improve 316ccf60b "ll40ls: Don't report the measurement if peak strength is outside limits"

- Don't report invalid measurements, for which the sensor ouputs 1cm distance; these are not relevant for anything
- For "valid" measurements with distance and peak values out of range, report them with 0 quality

Signed-off-by: Jukka Laitinen <jukkax@ssrc.tii.ae>

Please use [PX4 Discuss](http://discuss.px4.io/) or [Slack](http://slack.px4.io/) to align on pull requests if necessary. You can then open draft pull requests to get early feedback.

**Describe problem solved by this pull request**
A clear and concise description of the problem this proposed change will solve.
E.g. For this use case I ran into...

**Describe your solution**
A clear and concise description of what you have implemented.

**Describe possible alternatives**
A clear and concise description of alternative solutions or features you've considered.

**Test data / coverage**
How was it tested? What cases were covered? Logs uploaded to https://review.px4.io/ and screenshots of the important plot parts.

**Additional context**
Add any other related context or media.
