### PR TITLE
Fix io safety

### DIFF
--- a/ROMFS/px4fmu_common/init.d/airframes/4400_ssrc_fog_x
+++ b/ROMFS/px4fmu_common/init.d/airframes/4400_ssrc_fog_x
@@ -57,4 +57,7 @@ then
 	# Set battery load drop value to match
 	# the "default" battery used in this drone
 	param set BAT_V_LOAD_DROP 0.1
+
+	# Enable safety switch
+	param set CBRK_IO_SAFETY 0
 fi

--- a/ROMFS/px4fmu_common/init.d/airframes/4400_ssrc_fog_x
+++ b/ROMFS/px4fmu_common/init.d/airframes/4400_ssrc_fog_x
@@ -60,4 +60,7 @@ then
 
 	# Enable safety switch
 	param set CBRK_IO_SAFETY 0
+
+	# Set default for disarm after land to 4s
+	param set COM_DISARM_LAND 4.0
 fi


### PR DESCRIPTION
Enable safety switch by default when ssrc_fog_x airframe is selected