### PR TITLE
ssrc_configs: Fine tune MPC_JERK_AUTO and MPC_ACC_HOR for indoor flight

### DIFF
--- a/ssrc_config/indoor_lighthouse/config.txt
+++ b/ssrc_config/indoor_lighthouse/config.txt
@@ -46,3 +46,7 @@ param set SER_TEL2_BAUD 57600
 param set MAV_1_CONFIG 102
 param set MAV_1_MODE 7
 param set MAV_1_RATE 1000
+
+# Smoothing trajectory a bit when using AutoLineSmoothVel
+param set MPC_JERK_AUTO 8
+param set MPC_ACC_HOR 3


### PR DESCRIPTION
This makes indoor flight with waypoints very close to each other a bit smoother

Adding these parameters only for the config.txt file on sdcard for indoors testing; this needs to be re-evaluated for high-speed outdoor flights. Most probably we need to do something with the flight task code itself to navigate properly with this kind of set of waypoints very close to each other