### PR TITLE
Dynamic HITL enabling support

### DIFF
--- a/ssrc_config/HIL/config.txt
+++ b/ssrc_config/HIL/config.txt
@@ -1,0 +1,55 @@
+# Default parameter set for HITL (partly derived from indoor flying parameters)
+
+#####################################
+# HITL configuration
+#
+
+# Set HITL flag
+param set SYS_HITL 1
+
+# HIL on TELEMETRY 2
+param set SER_TEL2_BAUD 2000000
+param set MAV_1_CONFIG 102
+param set MAV_1_MODE 2
+param set MAV_1_RATE 200000
+
+# disable some checks to allow to fly
+# - with usb
+param set CBRK_USB_CHK 197848
+# - without real battery
+param set CBRK_SUPPLY_CHK 894281
+# - without safety switch
+param set COM_PREARM_MODE 0
+param set CBRK_IO_SAFETY 22027
+
+
+#####################################
+# Configs from indoor flight setup
+#
+
+# Set waypoint acceptance radius to 0.5m
+param set NAV_ACC_RAD 0.5
+
+# Set height acceptance radius to 0.3m
+param set NAV_MC_ALT_RAD 0.3
+
+# Cruise speed
+param set MPC_XY_CRUISE 0.5
+
+# Track trajectory more aggressively (default 0.5)
+param set MPC_XY_TRAJ_P 0.7
+
+# Increase velocity controller P gain
+param set MPC_XY_VEL_P_ACC 2.4
+
+# Make it accelerate faster upwards at takeoff
+param set MPC_TKO_RAMP_T 1.0
+
+# Limit upward movement speed for safety
+param set MPC_Z_VEL_MAX_UP 1.0
+
+# Smoothing trajectory a bit when using AutoLineSmoothVel
+param set MPC_JERK_AUTO 8
+param set MPC_ACC_HOR 3
+
+

--- a/ssrc_config/HIL/config.txt
+++ b/ssrc_config/HIL/config.txt
@@ -22,6 +22,9 @@ param set CBRK_SUPPLY_CHK 894281
 param set COM_PREARM_MODE 0
 param set CBRK_IO_SAFETY 22027
 
+# Disable RC controller check
+param set NAV_RCL_ACT 0
+
 
 #####################################
 # Configs from indoor flight setup

--- a/ssrc_config/HIL/spawn_ssrc_hil_drone.sh
+++ b/ssrc_config/HIL/spawn_ssrc_hil_drone.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+jinja_gen_script="./Tools/sitl_gazebo/scripts/jinja_gen.py"
+sdf_jinja_template="./Tools/sitl_gazebo/models/ssrc_fog_x/ssrc_fog_x.sdf.jinja"
+workdir="./Tools/sitl_gazebo/"
+
+echo "Generate ssrc_fog_x_hitl.sdf"
+python3 $jinja_gen_script $sdf_jinja_template $workdir \
+	--serial_enabled 1 \
+	--serial_device /dev/ttyUSB0 \
+	--serial_baudrate 2000000 \
+	--hil_mode 1 \
+	--lockstep 0 \
+	--output-file /tmp/ssrc_fog_x_hitl.sdf
+
+echo "Spawning ssrc_fog_x_hitl"
+
+gz model --spawn-file=/tmp/ssrc_fog_x_hitl.sdf --model-name=sadci01 -x 0.0 -y 0.0 -z 0.0


### PR DESCRIPTION
Enable HITL support for ssrc_fog_x drone model.
Tools/sitl_gazebo contains fixed jinja script and ssrc_fog_x model to support dynamic spawning of HITL simulation.
New ssrc_config file created for HITL case and script to spawn ssrc_fog_x model with HITL setup into simulation world. Script configures model to connect pixhawk4/PX4 via serial port: /dev/ttyUSB0 -> TELEM2
