### PR TITLE
[do not merge] 4400_ssrc_fog_x airframe: TELEM1 baudrate to 3M

### DIFF
--- a/ROMFS/px4fmu_common/init.d/airframes/4400_ssrc_fog_x
+++ b/ROMFS/px4fmu_common/init.d/airframes/4400_ssrc_fog_x
@@ -37,7 +37,7 @@ then
 	# RTPS/MAV on TELEMETRY 1
 	param set MAV_0_CONFIG 0
 	param set RTPS_MAV_CONFIG 101
-	param set SER_TEL1_BAUD 1000000
+	param set SER_TEL1_BAUD 3000000
 
 	# Enable LL40LS in i2c
 	param set SENS_EN_LL40LS 2


### PR DESCRIPTION
To fix issue in fog drone with 2.6MBit/s data stream from PX4->ROS2, the UART baudrate is increased from 1M to 3M
