### PR TITLE
4400_ssrc_fog_x: Change mission computer link from TELEM1 to TELEM2

### DIFF
--- a/ROMFS/px4fmu_common/init.d/airframes/4400_ssrc_fog_x
+++ b/ROMFS/px4fmu_common/init.d/airframes/4400_ssrc_fog_x
@@ -36,15 +36,15 @@ then
 
 	# RTPS/MAV on TELEMETRY 1
 	param set-default MAV_0_CONFIG 0
-	param set-default RTPS_MAV_CONFIG 101
-	param set-default SER_TEL1_BAUD 1000000
+	param set-default RTPS_MAV_CONFIG 102
+	param set-default SER_TEL2_BAUD 1000000
 
 	# Enable LL40LS in i2c
 	param set-default SENS_EN_LL40LS 2
 
 	# LEDs on TELEMETRY 2
-	param set-default SER_TEL2_BAUD 57600
-	param set-default MAV_1_CONFIG 102
+	param set-default SER_TEL1_BAUD 57600
+	param set-default MAV_1_CONFIG 101
 	param set-default MAV_1_MODE 7
 	param set-default MAV_1_RATE 1000
 

--- a/ssrc_config/indoor_lighthouse/config.txt
+++ b/ssrc_config/indoor_lighthouse/config.txt
@@ -42,12 +42,6 @@ param set MPC_TKO_RAMP_T 1.0
 # Limit upward movement speed for safety
 param set MPC_Z_VEL_MAX_UP 1.0
 
-# LEDS
-param set SER_TEL2_BAUD 57600
-param set MAV_1_CONFIG 102
-param set MAV_1_MODE 7
-param set MAV_1_RATE 1000
-
 # Smoothing trajectory a bit when using AutoLineSmoothVel
 param set MPC_JERK_AUTO 8
 param set MPC_ACC_HOR 3


### PR DESCRIPTION
- TELEM2 link if the  high speed link to MC
- TELEM1 is for leds
- Removed the LED settings from "indoor microsd config", these are in defaults already

Signed-off-by: Jukka Laitinen <jukkax@ssrc.tii.ae>

Please use [PX4 Discuss](http://discuss.px4.io/) or [Slack](http://slack.px4.io/) to align on pull requests if necessary. You can then open draft pull requests to get early feedback.

**Describe problem solved by this pull request**
A clear and concise description of the problem this proposed change will solve.
E.g. For this use case I ran into...

**Describe your solution**
A clear and concise description of what you have implemented.

**Describe possible alternatives**
A clear and concise description of alternative solutions or features you've considered.

**Test data / coverage**
How was it tested? What cases were covered? Logs uploaded to https://review.px4.io/ and screenshots of the important plot parts.

**Additional context**
Add any other related context or media.
