### PR TITLE
 indoor config.txt: disable magnetometer 

### DIFF
--- a/ssrc_config/indoor_lighthouse/config.txt
+++ b/ssrc_config/indoor_lighthouse/config.txt
@@ -9,6 +9,8 @@ param set CAL_MAG0_PRIO 1
 param set CAL_MAG1_PRIO 0
 param set CAL_MAG2_PRIO 0
 param set CAL_MAG3_PRIO 0
+param set EKF2_MAG_TYPE 5
+param set SYS_HAS_MAG 0
 
 # Set waypoint acceptance radius to 0.5m
 param set NAV_ACC_RAD 0.5

--- a/ssrc_config/indoor_lighthouse/config.txt
+++ b/ssrc_config/indoor_lighthouse/config.txt
@@ -4,6 +4,12 @@
 # Disable internal compass
 param set GPS_1_CONFIG 0
 
+# Disable magnetometer
+param set CAL_MAG0_PRIO 1
+param set CAL_MAG1_PRIO 0
+param set CAL_MAG2_PRIO 0
+param set CAL_MAG3_PRIO 0
+
 # Set waypoint acceptance radius to 0.5m
 param set NAV_ACC_RAD 0.5
 


### PR DESCRIPTION
This disables the magnetometer by default in the indoor configuration
file.

This resolves the toilet bowl effect, where the magnetometer is
conflicting with data from the motion capture system.

Co-authored-by: Humaid <humaid@ssrc.tii.ae>
Co-authored-by: Pedro <pedro@ssrc.tii.ae>