### PR TITLE
Add default flight models and kill switch channel

### DIFF
--- a/ssrc_config/indoor_lighthouse/config.txt
+++ b/ssrc_config/indoor_lighthouse/config.txt
@@ -45,3 +45,10 @@ param set MPC_Z_VEL_MAX_UP 1.0
 # Smoothing trajectory a bit when using AutoLineSmoothVel
 param set MPC_JERK_AUTO 8
 param set MPC_ACC_HOR 3
+
+# Default Flight Modes and Kill Switch
+param set COM_FLTMODE1 0
+param set COM_FLTMODE4 2
+param set COM_FLTMODE6 11
+param set RC_MAP_FLTMODE 5
+param set RC_MAP_KILL_SW 7


### PR DESCRIPTION
I'm adding this PR in order to have the flight modes pre-defined and also the mode channel and kill switch channel.
I believe that leaving the user to set this up is unnecessary, considering this is the same for all the drones we use.
That way, the user would only need to deal with Radio and Sensors Calibration after provisioning, because these are the only parameters that might change from drone to drone.