### PR TITLE
PX4_SITL: Start logging on arming instead of from bootup

### DIFF
--- a/ROMFS/px4fmu_common/init.d-posix/airframes/4400_ssrc_fog_x
+++ b/ROMFS/px4fmu_common/init.d-posix/airframes/4400_ssrc_fog_x
@@ -38,4 +38,7 @@ then
 	param set SENS_IMU_MODE 1
 	param set EKF2_MULTI_MAG 0
 	param set SENS_MAG_MODE 1
+
+	# Logger used only while flying
+	param set SDLOG_MODO 0
 fi


### PR DESCRIPTION
PX4_SITL: Change logging mode to start and stop loggign on arming/disarming instead of start logging on bootup.
This prevents to fill-up disk space in simulation where drone is just spawned into simulation but not used.