### PR TITLE
Increase UART baudrate after successful tests with 2Mb

### DIFF
--- a/ROMFS/px4fmu_common/init.d/airframes/4400_ssrc_fog_x
+++ b/ROMFS/px4fmu_common/init.d/airframes/4400_ssrc_fog_x
@@ -36,7 +36,7 @@ param set-default BAT1_V_LOAD_DROP 0.1
 # RTPS/MAV on TELEMETRY 2
 param set-default MAV_0_CONFIG 0
 param set-default RTPS_MAV_CONFIG 102
-param set-default SER_TEL2_BAUD 1000000
+param set-default SER_TEL2_BAUD 2000000
 
 # Enable LL40LS in i2c
 param set-default SENS_EN_LL40LS 2


### PR DESCRIPTION
In the lab we could see that some messages were missing from topic _fmu/mission_result/out_.
After we increased baudrate from 1Mb to 2Mb we could see that the amount of missing messages was considerably smaller and we were able to make bigger amount of successful flights.