### PR TITLE
Fix sdcard logging when crypto is used but algorithm is set to NONE

### DIFF
--- a/src/modules/logger/log_writer_file.cpp
+++ b/src/modules/logger/log_writer_file.cpp
@@ -86,6 +86,7 @@ LogWriterFile::~LogWriterFile()
 bool LogWriterFile::init_logfile_encryption(const char *filename)
 {
 	if (_algorithm == CRYPTO_NONE) {
+		_min_blocksize = 1;
 		return true;
 	}
 


### PR DESCRIPTION
If the board supports encrypting logfiles, but the parameter SDCARD_ALGORITHM is set to NONE,
the log should be written to the sdcard in plaintext format. This fixes a bug which caused
logger to hang in mutex instead.

Signed-off-by: Jukka Laitinen <jukkax@ssrc.tii.ae>

