### PR TITLE
Fix the protocol_splitter receive buffer getting full case

### DIFF
--- a/src/drivers/protocol_splitter/protocol_splitter.cpp
+++ b/src/drivers/protocol_splitter/protocol_splitter.cpp
@@ -154,10 +154,32 @@ public:
 
 int ReadBuffer::read(int fd)
 {
+
 	if (sizeof(buffer) == buf_size) {
-		// This happens if one consumer does not read the data, or not fast enough.
-		// TODO: add a mechanism to thrown away data if a user is no longer reading.
+		/* This happens if there is no valid data in the buffer or when one of
+		 * the clients (rtps or mavlink) stops reading and that packet is stuck
+		 * in the buffer. Always make room to the buffer so that reading client
+		* doesn't end up in busyloop, reading 0 bytes of data on each round
+		*/
+
+		size_t drop = 0;
+
+		/* If there is a mavlink packet, set drop to beginning of that.
+		 * In case there are rtps packets or garbage before, that will be
+		 * dropped
+		 */
+		if (start_mavlink < end_mavlink) { drop = start_mavlink; }
+
+		/* If there is an rtps packet, and it starts later than the mavlink ones
+		 * drop the mavlink ones (and possible garbage)
+		 */
+		if (start_rtps < end_rtps && start_rtps > start_mavlink) { drop = start_rtps; }
+
 		PX4_DEBUG("Buffer full: %zu %zu %zu %zu", start_mavlink, end_mavlink, start_rtps, end_rtps);
+
+		/* if there are no packets in the buffer, drop the whole buffer */
+
+		remove(0, drop > 0 ? drop : buf_size);
 	}
 
 	int bytes_available = 0;


### PR DESCRIPTION
Always make room in the receive buffer for reading out data. Otherwise the
client may end up in busyloop, when there is no valid data in the buffer to read.
The poll may still return 1, in case there is new data in the actual input
device (socket or uart buffer).

The problem is easy to re-produce by writing random (garbage) data to mavlink through protocol splitter.
