### PR TITLE
Riscv compilation fixes

### DIFF
--- a/platforms/nuttx/cmake/Platform/Generic-riscv64-unknown-elf-gcc-rv64gc.cmake
+++ b/platforms/nuttx/cmake/Platform/Generic-riscv64-unknown-elf-gcc-rv64gc.cmake
@@ -1,9 +1,9 @@
 
 if(CONFIG_ARCH_DPFPU)
 	message(STATUS "Enabling double FP precision hardware instructions")
-	set(cpu_flags "-march=rv64gc -mabi=lp64d -mcmodel=medany")
+	set(cpu_flags "-march=rv64gc -mabi=lp64d -mcmodel=medany -Wl,--no-relax")
 else()
-	set(cpu_flags "-march=rv64imac -mabi=lp64 -mcmodel=medany")
+	set(cpu_flags "-march=rv64imac -mabi=lp64 -mcmodel=medany -Wl,--no-relax")
 endif()
 
 set(CMAKE_C_FLAGS "${cpu_flags}" CACHE STRING "" FORCE)


### PR DESCRIPTION
This is a set of two unrelated patches, one fixes crypto library in the way which saves ~30KB for saluki bootloader.

The second one removes risc-v relaxations; these were the source of all the weird GP related linking problems