### PR TITLE
Fix typo in SITL logger mode change

### DIFF
--- a/ROMFS/px4fmu_common/init.d-posix/airframes/4400_ssrc_fog_x
+++ b/ROMFS/px4fmu_common/init.d-posix/airframes/4400_ssrc_fog_x
@@ -40,5 +40,5 @@ then
 	param set SENS_MAG_MODE 1
 
 	# Logger used only while flying
-	param set SDLOG_MODO 0
+	param set SDLOG_MODE 0
 fi


### PR DESCRIPTION
Fixing the typo in SITL logger mode change

Original change was done to prevent SW simulation container to run out of disk quota while just keeping simulation running without flying the drone.