### PR TITLE
DP-2269 gazebo mavlink plugin receiving in separate thread

### DIFF
--- a/ROMFS/px4fmu_common/init.d-posix/CMakeLists.txt
+++ b/ROMFS/px4fmu_common/init.d-posix/CMakeLists.txt
@@ -39,5 +39,6 @@ px4_add_romfs_files(
 	px4-rc.rtps
 	px4-rc.simulator
 	rc.replay
+	rcS.sim_tcp_server
 	rcS
 )

--- a/ROMFS/px4fmu_common/init.d-posix/px4-rc.simulator
+++ b/ROMFS/px4fmu_common/init.d-posix/px4-rc.simulator
@@ -9,9 +9,14 @@ simulator_udp_port=$((14560+px4_instance))
 # If both are empty use localhost for simulator
 if [ -z "${PX4_SIM_HOSTNAME}" ]; then
   if [ -z "${PX4_SIM_HOST_ADDR}" ]; then
-    #    simulator start -c $simulator_tcp_port
-    #    simulator start -u $simulator_udp_port
-    simulator start -s $simulator_tcp_port
+    if [ -z "${PX4_SIM_USE_TCP_SERVER}" ]; then
+      # Use default UDP protocol for mavlink msg transport with simulator
+      simulator start -u $simulator_udp_port
+    else
+      # Use TCP server for mavlink msg transport with simulator
+      echo "PX4 SIM USE TCP SERVER"
+      simulator start -s $simulator_tcp_port
+    fi
   else
     echo "PX4 SIM HOST: $PX4_SIM_HOST_ADDR"
     simulator start -t $PX4_SIM_HOST_ADDR $simulator_tcp_port

--- a/ROMFS/px4fmu_common/init.d-posix/px4-rc.simulator
+++ b/ROMFS/px4fmu_common/init.d-posix/px4-rc.simulator
@@ -9,9 +9,9 @@ simulator_udp_port=$((14560+px4_instance))
 # If both are empty use localhost for simulator
 if [ -z "${PX4_SIM_HOSTNAME}" ]; then
   if [ -z "${PX4_SIM_HOST_ADDR}" ]; then
-    echo "PX4 SIM HOST: localhost"
     #    simulator start -c $simulator_tcp_port
-    simulator start -u $simulator_udp_port
+    #    simulator start -u $simulator_udp_port
+    simulator start -s $simulator_tcp_port
   else
     echo "PX4 SIM HOST: $PX4_SIM_HOST_ADDR"
     simulator start -t $PX4_SIM_HOST_ADDR $simulator_tcp_port

--- a/ROMFS/px4fmu_common/init.d-posix/rcS.sim_tcp_server
+++ b/ROMFS/px4fmu_common/init.d-posix/rcS.sim_tcp_server
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+# search path for sourcing rcS
+PATH="$PATH:${R}etc/init.d-posix"
+
+# Define TCP server
+export PX4_SIM_USE_TCP_SERVER=1
+
+# Continue to the main startup script
+. rcS

--- a/packaging/entrypoint.sh
+++ b/packaging/entrypoint.sh
@@ -2,4 +2,8 @@
 
 source /opt/ros/galactic/setup.bash
 
-px4 -d "/px4_sitl_etc" -w sitl_${PX4_SIM_MODEL} -s /px4_sitl_etc/init.d-posix/rcS
+if [ "$1" == "sim_tcp_server" ]; then
+    px4 -d "/px4_sitl_etc" -w sitl_${PX4_SIM_MODEL} -s /px4_sitl_etc/init.d-posix/rcS.sim_tcp_server
+else
+    px4 -d "/px4_sitl_etc" -w sitl_${PX4_SIM_MODEL} -s /px4_sitl_etc/init.d-posix/rcS
+fi

--- a/src/modules/simulator/simulator.cpp
+++ b/src/modules/simulator/simulator.cpp
@@ -69,7 +69,6 @@ int Simulator::start(int argc, char *argv[])
 	_instance = new Simulator();
 
 	if (_instance) {
-
 		if (argc == 5 && strcmp(argv[3], "-u") == 0) {
 			_instance->set_ip(InternetProtocol::UDP);
 			_instance->set_port(atoi(argv[4]));
@@ -78,6 +77,13 @@ int Simulator::start(int argc, char *argv[])
 		if (argc == 5 && strcmp(argv[3], "-c") == 0) {
 			_instance->set_ip(InternetProtocol::TCP);
 			_instance->set_port(atoi(argv[4]));
+		}
+
+		if (argc == 5 && strcmp(argv[3], "-s") == 0) {
+			PX4_INFO("Simulator TCP Server mode");
+			_instance->set_ip(InternetProtocol::TCP);
+			_instance->set_port(atoi(argv[4]));
+			_instance->set_server_mode();
 		}
 
 		if (argc == 6 && strcmp(argv[3], "-t") == 0) {

--- a/src/modules/simulator/simulator.h
+++ b/src/modules/simulator/simulator.h
@@ -125,6 +125,7 @@ public:
 	void set_port(unsigned port) { _port = port; }
 	void set_hostname(std::string hostname) { _hostname = hostname; }
 	void set_tcp_remote_ipaddr(char *tcp_remote_ipaddr) { _tcp_remote_ipaddr = tcp_remote_ipaddr; }
+	void set_server_mode() { _server_mode = true; }
 
 #if defined(ENABLE_LOCKSTEP_SCHEDULER)
 	bool has_initialized() { return _has_initialized.load(); }
@@ -208,6 +209,8 @@ private:
 	InternetProtocol _ip{InternetProtocol::UDP};
 
 	std::string _hostname{""};
+
+	bool _server_mode{false};
 
 	char *_tcp_remote_ipaddr{nullptr};
 

--- a/src/modules/simulator/simulator_mavlink.cpp
+++ b/src/modules/simulator/simulator_mavlink.cpp
@@ -71,6 +71,7 @@
 static int openUart(const char *uart_name, int baud);
 #endif
 
+static int _tcp_server_fd;
 static int _fd;
 static unsigned char _buf[2048];
 static sockaddr_in _srcaddr;
@@ -782,6 +783,7 @@ void Simulator::run()
 
 	if (_ip == InternetProtocol::UDP) {
 
+		// UDP 'server' mode
 		if ((_fd = socket(AF_INET, SOCK_DGRAM, 0)) < 0) {
 			PX4_ERR("Creating UDP socket failed: %s", strerror(errno));
 			return;
@@ -810,8 +812,70 @@ void Simulator::run()
 
 		PX4_INFO("Simulator connected on UDP port %u.", _port);
 
+	} else if (_server_mode) {
+
+		// TCP Server mode
+		PX4_INFO("TCP Server: Waiting for simulator to connect on TCP port %u", _port);
+
+		if ((_tcp_server_fd = socket(AF_INET, SOCK_STREAM, 0)) < 0) {
+			PX4_ERR("TCP Server: Creating TCP socket failed: %s", strerror(errno));
+			return;
+		}
+
+		int yes = 1;
+		int ret = setsockopt(_tcp_server_fd, IPPROTO_TCP, TCP_NODELAY, (char *) &yes, sizeof(int));
+
+		if (ret != 0) {
+			PX4_ERR("TCP Server: setsockopt failed: %s", strerror(errno));
+		}
+
+		struct linger nolinger {};
+		nolinger.l_onoff = 1;
+		nolinger.l_linger = 0;
+
+		ret = setsockopt(_tcp_server_fd, SOL_SOCKET, SO_LINGER, &nolinger, sizeof(nolinger));
+		if (ret != 0) {
+			PX4_ERR("TCP Server: setsockopt failed: %s", strerror(errno));
+		}
+
+		// The socket reuse is necessary for reconnecting to the same address
+		// if the socket does not close but gets stuck in TIME_WAIT. This can happen
+		// if the server is suddenly closed.
+		int socket_reuse = 1;
+		ret = setsockopt(_tcp_server_fd, SOL_SOCKET, SO_REUSEADDR, &socket_reuse, sizeof(socket_reuse));
+		if (ret != 0) {
+			PX4_ERR("TCP Server: setsockopt failed: %s", strerror(errno));
+		}
+
+		// Same as above but for a given port
+		ret = setsockopt(_tcp_server_fd, SOL_SOCKET, SO_REUSEPORT, &socket_reuse, sizeof(socket_reuse));
+		if (ret != 0) {
+			PX4_ERR("TCP Server: setsockopt failed: %s", strerror(errno));
+		}
+
+		socklen_t myaddr_len = sizeof(_myaddr);
+		if (bind(_tcp_server_fd, (struct sockaddr *)&_myaddr, myaddr_len) < 0) {
+			PX4_ERR("TCP Server: Bind for TCP port %u failed: %s", _port, strerror(errno));
+			::close(_tcp_server_fd);
+			return;
+		}
+
+		if (listen(_tcp_server_fd, 0) < 0) {
+			PX4_ERR("TCP Server: listen failed: %s", strerror(errno));
+		}
+
+		while (true) {
+			_fd = accept(_tcp_server_fd, (struct sockaddr *)&_srcaddr, (socklen_t *)&_addrlen);
+			if (_fd >= 0) {
+				break;
+			}
+			PX4_WARN("TCP Server: Accepting client connection failed: %s", strerror(errno));
+		}
+		PX4_INFO("TCP Server: Accepting TCP client connection from %s:%u",inet_ntoa(_srcaddr.sin_addr), ntohs(_srcaddr.sin_port) );
+
 	} else {
 
+		// TCP Client mode
 		PX4_INFO("Waiting for simulator to accept connection on TCP port %u", _port);
 
 		while (true) {


### PR DESCRIPTION
PX4_SITL simulator to support TCP Server mode (set default)

sitl_gazebo mavlink plugin improvements
 - Support TCP client mode
 - TCP/UDP message sending and receiving moved to separate threads. Messages transferred between main thread and sender/receiver threads via message queues
