### PR TITLE
px4_sitl: entrypoint check PX4_SIM_USE_TCP_SERVER env variable to

### DIFF
--- a/packaging/entrypoint.sh
+++ b/packaging/entrypoint.sh
@@ -2,7 +2,7 @@
 
 source /opt/ros/galactic/setup.bash
 
-if [ "$1" == "sim_tcp_server" ]; then
+if [ "$1" == "sim_tcp_server" ] || [ "$PX4_SIM_USE_TCP_SERVER" != "" ]; then
     px4 -d "/px4_sitl_etc" -w sitl_${PX4_SIM_MODEL} -s /px4_sitl_etc/init.d-posix/rcS.sim_tcp_server
 else
     px4 -d "/px4_sitl_etc" -w sitl_${PX4_SIM_MODEL} -s /px4_sitl_etc/init.d-posix/rcS


### PR DESCRIPTION
Add **PX4_SIM_USE_TCP_SERVER** environment variable when running px4_sitl container to enable TCP server connection for gazebo mavlink plugin.
