### PR TITLE
Disable RTPS_MAV UART config to enable ethernet connection

### DIFF
--- a/ROMFS/px4fmu_common/init.d/airframes/4400_ssrc_fog_x
+++ b/ROMFS/px4fmu_common/init.d/airframes/4400_ssrc_fog_x
@@ -33,10 +33,8 @@ param set-default BAT1_V_EMPTY 3.6
 param set-default BAT1_V_DIV 18.1
 param set-default BAT1_V_LOAD_DROP 0.1
 
-# RTPS/MAV on TELEMETRY 2
-param set-default MAV_0_CONFIG 0
-param set-default RTPS_MAV_CONFIG 102
-param set-default SER_TEL2_BAUD 2000000
+# Enable ethernet for PX4<->MC
+param set-default RTPS_MAV_CONFIG 0
 
 # Enable LL40LS in i2c
 param set-default SENS_EN_LL40LS 2


### PR DESCRIPTION
FOG drones switched to use ethernet in mission computer side for FC<->MC connection. This requires PX4 side RTPS_MAV_CONFIG param to be cleared to enable ethernet for MC connection.