### PR TITLE
boards/ssrc/icicle: Clean up linker scripts

### DIFF
--- a/boards/ssrc/icicle/nuttx-config/scripts/bootloader_script.ld
+++ b/boards/ssrc/icicle/nuttx-config/scripts/bootloader_script.ld
@@ -115,7 +115,7 @@ SECTIONS
 
     .text : {
         _stext = ABSOLUTE(.);
-        *mpfs_head.o
+        *(.start .start.*)
         *(.text .text.*)
         *(.fixup)
         *(.gnu.warning)

--- a/boards/ssrc/icicle/nuttx-config/scripts/script.ld
+++ b/boards/ssrc/icicle/nuttx-config/scripts/script.ld
@@ -35,8 +35,7 @@ SECTIONS
 {
     .text : {
         _stext = ABSOLUTE(.);
-        *mpfs_head.o
-
+        *(.start .start.*)
         /*
         This signature provides the bootloader with a way to delay booting
         */
@@ -45,8 +44,6 @@ SECTIONS
         FILL(0x01ecc2925d7d05c5)
         . += 8;
         *(.main_toc)
-        *riscv_vectors.o
-        *riscv_exception_common.o
         *(.text .text.*)
         *(.fixup)
         *(.gnu.warning)

--- a/boards/ssrc/icicle/src/toc.c
+++ b/boards/ssrc/icicle/src/toc.c
@@ -35,7 +35,7 @@
 /* (Maximum) size of the signature */
 #define SIGNATURE_SIZE 64
 
-/* Boot image starts at _vectors and ends at
+/* Boot image starts at __start and ends at
  * the beginning of signature
 */
 


### PR DESCRIPTION
There is no need to force object linkage manually, if the correct
section is used.

Also fix typo in toc.c, the image starts from __start, not _vectors
(copy & paste artifact from ARM).