### PR TITLE
mixer_module: Fix linking of mixer_module

### DIFF
--- a/src/lib/mixer_module/CMakeLists.txt
+++ b/src/lib/mixer_module/CMakeLists.txt
@@ -51,7 +51,7 @@ px4_add_library(mixer_module
 
 add_dependencies(mixer_module output_functions_header)
 target_compile_options(mixer_module PRIVATE ${MAX_CUSTOM_OPT_LEVEL})
-
+target_link_libraries(mixer_module PRIVATE mixer)
 
 px4_add_functional_gtest(SRC mixer_module_tests.cpp LINKLIBS mixer_module mixer)
 


### PR DESCRIPTION
The module has a hard dependency on mixer library, so link them together
