### PR TITLE
Enable cicd on ml_develop branch

### DIFF
--- a/.github/workflows/tiiuae-pixhawk.yaml
+++ b/.github/workflows/tiiuae-pixhawk.yaml
@@ -111,7 +111,6 @@ jobs:
     name: upload builds to Artifactory
     runs-on: ubuntu-latest
     needs: [pixhawk4, saluki-v1, px4fwupdater]
-    if: github.event_name == 'push'
     steps:
       - name: Download pixhawk artifacts
         uses: actions/download-artifact@v2

--- a/.github/workflows/tiiuae-pixhawk.yaml
+++ b/.github/workflows/tiiuae-pixhawk.yaml
@@ -129,8 +129,6 @@ jobs:
         run: |
           jf c add --url "$RT_URL" --user "$RT_USER" --password "$RT_API_KEY"
           jf rt ping
-          sudo touch newfile.txt
-          jf rt u newfile.txt $ARTIFACTORY_GEN_REPO
           set -exu
           pkg=$(find bin -name 'px4_fmu-v5_ssrc*.px4')
           px5_pkg=$(find bin -name 'px4_fmu-v5x_ssrc*.px4')
@@ -146,7 +144,7 @@ jobs:
                      "$pkg" \
                      "$ARTIFACTORY_GEN_REPO/builds/px4-firmware/pixhawk/$pkg_name"
           jfrog rt u --target-props COMMIT="$GITHUB_SHA" \
-                     --build-name "$BUILD_NAME_PX4" \gen-public-local
+                     --build-name "$BUILD_NAME_PX4"
                      --build-number "$GITHUB_SHA" \
                      "$px5_pkg" \
                      "$ARTIFACTORY_GEN_REPO/builds/px4-firmware/pixhawk/$px5_pkg_name"

--- a/.github/workflows/tiiuae-pixhawk.yaml
+++ b/.github/workflows/tiiuae-pixhawk.yaml
@@ -121,7 +121,7 @@ jobs:
       - name: Upload px4-firmware build to Artifactory
         env:
           RT_USER: ${{ secrets.RT_USER }}
-          RT_API_KEY: ${{ secrets.RT_API_KEY }}
+          RT_API_KEY: ${{ secrets.RT_APIKEY }}
           RT_URL: ${{ secrets.RT_URL }}
           ARTIFACTORY_GEN_REPO: gen-public-local
           BUILD_NAME_PX4: px4-firmware

--- a/.github/workflows/tiiuae-pixhawk.yaml
+++ b/.github/workflows/tiiuae-pixhawk.yaml
@@ -86,7 +86,7 @@ jobs:
         id: containermeta # referenced from later step
         uses: docker/metadata-action@v3
         with:
-          images: ghcr.io/tiiuae/px4-firmware
+          images: artifactory.ssrcdevops.tii.ae/tiiuae/px4-firmware
           tags: |
             type=ref,event=branch
             type=ref,event=pr

--- a/.github/workflows/tiiuae-pixhawk.yaml
+++ b/.github/workflows/tiiuae-pixhawk.yaml
@@ -1,7 +1,6 @@
 name: tiiuae-pixhawk
 
-on:
-   workflow_dispatch:
+on: [workflow_dispatch]
 
 jobs:
   pixhawk4:

--- a/.github/workflows/tiiuae-pixhawk.yaml
+++ b/.github/workflows/tiiuae-pixhawk.yaml
@@ -144,7 +144,7 @@ jobs:
                      "$pkg" \
                      "$ARTIFACTORY_GEN_REPO/builds/px4-firmware/pixhawk/$pkg_name"
           jfrog rt u --target-props COMMIT="$GITHUB_SHA" \
-                     --build-name "$BUILD_NAME_PX4"
+                     --build-name "$BUILD_NAME_PX4" \
                      --build-number "$GITHUB_SHA" \
                      "$px5_pkg" \
                      "$ARTIFACTORY_GEN_REPO/builds/px4-firmware/pixhawk/$px5_pkg_name"

--- a/.github/workflows/tiiuae-pixhawk.yaml
+++ b/.github/workflows/tiiuae-pixhawk.yaml
@@ -118,14 +118,17 @@ jobs:
           name: pixhawk
           path: bin
       - uses: jfrog/setup-jfrog-cli@v2
-        env:
-          JF_ARTIFACTORY_1: ${{ secrets.RT_TOKEN }}
       - name: Upload px4-firmware build to Artifactory
         env:
+          RT_USER: ${{ secrets.RT_USER }}
+          RT_API_KEY: ${{ secrets.RT_API_KEY }}
+          RT_URL: ${{ secrets.RT_URL }}
           ARTIFACTORY_GEN_REPO: gen-public-local
           BUILD_NAME_PX4: px4-firmware
           CI: true
         run: |
+          jf c add --url "$RT_URL" --user "$RT_USER" --password "$RT_API_KEY"
+          jf rt ping
           set -exu
           pkg=$(find bin -name 'px4_fmu-v5_ssrc*.px4')
           px5_pkg=$(find bin -name 'px4_fmu-v5x_ssrc*.px4')

--- a/.github/workflows/tiiuae-pixhawk.yaml
+++ b/.github/workflows/tiiuae-pixhawk.yaml
@@ -35,7 +35,7 @@ jobs:
       - name: Checkout px4-firmware
         uses: actions/checkout@v2
         with:
-          # token: ${{ secrets.GH_REPO_TOKEN }}
+          token: ${{ secrets.GH_REPO_TOKEN }}
           submodules: recursive
           path: px4-firmware
           fetch-depth: 0

--- a/.github/workflows/tiiuae-pixhawk.yaml
+++ b/.github/workflows/tiiuae-pixhawk.yaml
@@ -129,6 +129,8 @@ jobs:
         run: |
           jf c add --url "$RT_URL" --user "$RT_USER" --password "$RT_API_KEY"
           jf rt ping
+          sudo touch newfile.txt
+          jf rt u newfile.txt $ARTIFACTORY_GEN_REPO
           set -exu
           pkg=$(find bin -name 'px4_fmu-v5_ssrc*.px4')
           px5_pkg=$(find bin -name 'px4_fmu-v5x_ssrc*.px4')

--- a/.github/workflows/tiiuae-pixhawk.yaml
+++ b/.github/workflows/tiiuae-pixhawk.yaml
@@ -1,10 +1,7 @@
 name: tiiuae-pixhawk
 
 on:
-  push:
-    branches: [ rel7_hotfix ]
-  pull_request:
-    branches: [ rel7_hotfix ]
+   workflow_dispatch:
 
 jobs:
   pixhawk4:
@@ -35,12 +32,11 @@ jobs:
   saluki-v1:
     name: build saluki-v1
     runs-on: ubuntu-latest
-    if: github.event.pull_request.head.repo.full_name == github.repository || github.event_name == 'push'
     steps:
       - name: Checkout px4-firmware
         uses: actions/checkout@v2
         with:
-          token: ${{ secrets.GH_REPO_TOKEN }}
+          # token: ${{ secrets.GH_REPO_TOKEN }}
           submodules: recursive
           path: px4-firmware
           fetch-depth: 0
@@ -100,13 +96,13 @@ jobs:
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v1
         with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          registry: artifactory.ssrcdevops.tii.ae
+          username: ${{ secrets.RT_USER }}
+          password: ${{ secrets.RT_APIKEY }}
       - name: Firmware flasher - Build and push
         uses: docker/build-push-action@v2
         with:
-          push: ${{ github.event_name == 'push' }}
+          push: true
           context: .
           file: px4-firmware/Tools/px_uploader.Dockerfile
           tags: ${{ steps.containermeta.outputs.tags }}
@@ -125,7 +121,7 @@ jobs:
           path: bin
       - uses: jfrog/setup-jfrog-cli@v2
         env:
-          JF_ARTIFACTORY_1: ${{ secrets.ARTIFACTORY_TOKEN }}
+          JF_ARTIFACTORY_1: ${{ secrets.RT_TOKEN }}
       - name: Upload px4-firmware build to Artifactory
         env:
           ARTIFACTORY_GEN_REPO: gen-public-local
@@ -147,7 +143,7 @@ jobs:
                      "$pkg" \
                      "$ARTIFACTORY_GEN_REPO/builds/px4-firmware/pixhawk/$pkg_name"
           jfrog rt u --target-props COMMIT="$GITHUB_SHA" \
-                     --build-name "$BUILD_NAME_PX4" \
+                     --build-name "$BUILD_NAME_PX4" \gen-public-local
                      --build-number "$GITHUB_SHA" \
                      "$px5_pkg" \
                      "$ARTIFACTORY_GEN_REPO/builds/px4-firmware/pixhawk/$px5_pkg_name"

--- a/.gitmodules
+++ b/.gitmodules
@@ -76,4 +76,4 @@
 	branch = px4
 [submodule "boards/ssrc/saluki-v1"]
 	path = boards/ssrc/saluki-v1
-	url = ../saluki-v1.git
+	url = https://github.com/tiiuae/saluki-v1.git


### PR DESCRIPTION
**What is this PR for**
Enable cicd on ml_develop branch to push generated builds and docker image to ssrcdevops artifactory.  

**Describe your solution**
Reconfigured existing cicd code to use ssrcdevops jfrog container registry and generic repositories. Enabled manual trigger on the workflow. Added required github secrets. Edited gitmodules for directly referring the private repository using token. 

**Test data / coverage**
 Forked the repository and tested code on second account. Added required github secrets. Edited gitmodules for directly referring the private repository using token. Created PR.