### PR TITLE
boards/icicle: Add board_read_VBUS_state

### DIFF
--- a/boards/ssrc/icicle/src/init.c
+++ b/boards/ssrc/icicle/src/init.c
@@ -285,3 +285,8 @@ __EXPORT int board_app_initialize(uintptr_t arg)
 
 	return OK;
 }
+
+int board_read_VBUS_state(void)
+{
+	return 0;
+}


### PR DESCRIPTION
The board should implement this dummy function, don't know why it didn't