### PR TITLE
Remove px4_work_queue from the kernel side LD command

### DIFF
--- a/platforms/nuttx/CMakeLists.txt
+++ b/platforms/nuttx/CMakeLists.txt
@@ -171,7 +171,6 @@ if (NOT CONFIG_BUILD_FLAT)
 		-Wl,--start-group
 			${nuttx_libs}
 			${kernel_module_libraries}
-			px4_work_queue # TODO, this shouldn't be needed here?
 		-Wl,--end-group
 
 		m


### PR DESCRIPTION
The comment is right, it is not needed -> get rid of it
