### PR TITLE
Store gps device_id generated from gps id of hil_gps message

### DIFF
--- a/src/modules/simulator/simulator.h
+++ b/src/modules/simulator/simulator.h
@@ -256,6 +256,7 @@ private:
 	static constexpr int MAX_GPS = 3;
 	uORB::PublicationMulti<sensor_gps_s>	*_sensor_gps_pubs[MAX_GPS] {};
 	uint8_t _gps_ids[MAX_GPS] {};
+	uint32_t _gps_dev_ids[MAX_GPS] {};
 	std::default_random_engine _gen{};
 
 	// uORB subscription handlers

--- a/src/modules/simulator/simulator_mavlink.cpp
+++ b/src/modules/simulator/simulator_mavlink.cpp
@@ -458,6 +458,7 @@ void Simulator::handle_message_hil_gps(const mavlink_message_t *msg)
 		// New publishers will be created based on the HIL_GPS ID's being different or not
 		for (size_t i = 0; i < sizeof(_gps_ids) / sizeof(_gps_ids[0]); i++) {
 			if (_sensor_gps_pubs[i] && _gps_ids[i] == hil_gps.id) {
+				gps.device_id = _gps_dev_ids[i];
 				_sensor_gps_pubs[i]->publish(gps);
 				break;
 			}
@@ -472,6 +473,7 @@ void Simulator::handle_message_hil_gps(const mavlink_message_t *msg)
 				device_id.devid_s.address = i;
 				device_id.devid_s.devtype = DRV_GPS_DEVTYPE_SIM;
 				gps.device_id = device_id.devid;
+				_gps_dev_ids[i] = device_id.devid;
 
 				_sensor_gps_pubs[i]->publish(gps);
 				break;


### PR DESCRIPTION
Simulator generates new device_id value for each new gps id detected
from received hil_gps message. Generated device_id is not stored
but latter sensor_gps messages for the same gps device has device_id
value zero. This patch stores the generated device_id and use the
value in next messages.
