### PR TITLE
board_ctrl: Clean up usage of VBUS, nARMED from user/kernelspace

### DIFF
--- a/boards/px4/fmu-v5/src/board_config.h
+++ b/boards/px4/fmu-v5/src/board_config.h
@@ -43,16 +43,12 @@
  * Included Files
  ****************************************************************************************************/
 
+#include <px4_platform/board_ctrl.h>
 #include <px4_platform_common/px4_config.h>
 #include <nuttx/compiler.h>
 #include <stdint.h>
 
 #include <stm32_gpio.h>
-
-#if !defined(CONFIG_BUILD_FLAT)
-#include <sys/boardctl.h>
-#include <px4_platform/board_ctrl.h>
-#endif
 
 /****************************************************************************************************
  * Definitions
@@ -230,20 +226,8 @@
 #define BOARD_INDICATE_EXTERNAL_LOCKOUT_STATE(enabled)  px4_arch_configgpio((enabled) ? GPIO_nARMED : GPIO_nARMED_INIT)
 #define BOARD_GET_EXTERNAL_LOCKOUT_STATE() px4_arch_gpioread(GPIO_nARMED)
 #else
-static inline void board_indicate_external_lockout_state(bool enable)
-{
-	platformioclockoutstate_t state = {enable};
-	boardctl(PLATFORMIOCINDICATELOCKOUT, (uintptr_t)&state);
-}
-
-static inline bool board_get_external_lockout_state(void)
-{
-	platformioclockoutstate_t state = {false};
-	boardctl(PLATFORMIOCGETLOCKOUT, (uintptr_t)&state);
-	return state.enabled;
-}
-#define BOARD_INDICATE_EXTERNAL_LOCKOUT_STATE(enabled) board_indicate_external_lockout_state(enabled)
-#define BOARD_GET_EXTERNAL_LOCKOUT_STATE() board_get_external_lockout_state()
+#define BOARD_INDICATE_EXTERNAL_LOCKOUT_STATE(enabled) boardctrl_indicate_external_lockout_state(enabled)
+#define BOARD_GET_EXTERNAL_LOCKOUT_STATE() boardctrl_get_external_lockout_state()
 #endif
 
 /* PWM

--- a/platforms/common/CMakeLists.txt
+++ b/platforms/common/CMakeLists.txt
@@ -40,6 +40,7 @@ if(NOT "${PX4_BOARD}" MATCHES "io-v2" AND NOT "${PX4_BOARD_LABEL}" MATCHES "boot
 endif()
 
 add_library(px4_platform
+	board_common.c
 	board_identity.c
 	events.cpp
 	external_reset_lockout.cpp

--- a/platforms/common/board_common.c
+++ b/platforms/common/board_common.c
@@ -1,6 +1,6 @@
 /****************************************************************************
  *
- *   Copyright (C) 2020 Technology Innovation Institute. All rights reserved.
+ *   Copyright (C) 2022 Technology Innovation Institute. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -35,9 +35,7 @@
  * Included Files
  ****************************************************************************/
 
-#include <nuttx/config.h>
-
-#include <stdbool.h>
+#include <px4_platform_common/micro_hal.h>
 
 #include "board_config.h"
 
@@ -45,32 +43,12 @@
  * Public Functions
  ****************************************************************************/
 
-#if defined(GPIO_OTGFS_VBUS)
+#if defined(GPIO_OTGFS_VBUS) && \
+    (defined(CONFIG_BUILD_FLAT) || !defined(__PX4_NUTTX))
+
+/* Default implementation for POSIX and flat NUTTX if the VBUS pin exists */
 int board_read_VBUS_state(void)
 {
 	return px4_arch_gpioread(GPIO_OTGFS_VBUS);
 }
 #endif
-
-int boardctrl_read_VBUS_state(void)
-{
-	return board_read_VBUS_state();
-}
-
-void boardctrl_indicate_external_lockout_state(bool enable)
-{
-#if defined(GPIO_nARMED)
-	px4_arch_configgpio((enable) ? GPIO_nARMED : GPIO_nARMED_INIT);
-#else
-	UNUSED(enable);
-#endif
-}
-
-bool boardctrl_get_external_lockout_state(void)
-{
-#if defined(GPIO_nARMED)
-	return px4_arch_gpioread(GPIO_nARMED);
-#else
-	return false;
-#endif
-}

--- a/platforms/common/include/px4_platform_common/board_common.h
+++ b/platforms/common/include/px4_platform_common/board_common.h
@@ -504,18 +504,7 @@ static inline bool board_rc_invert_input(const char *device, bool invert) { retu
  *
  ************************************************************************************/
 
-#if defined(__PX4_NUTTX) && !defined(CONFIG_BUILD_FLAT)
-inline static int board_read_VBUS_state(void)
-{
-	platformiocvbusstate_t state = {false};
-	boardctl(PLATFORMIOCVBUSSTATE, (uintptr_t)&state);
-	return state.ret;
-}
-#elif defined(GPIO_OTGFS_VBUS)
-#  define board_read_VBUS_state() (px4_arch_gpioread(GPIO_OTGFS_VBUS) ? 0 : 1)
-#else
 int board_read_VBUS_state(void);
-#endif
 
 /************************************************************************************
  * Name: board_on_reset

--- a/platforms/nuttx/src/px4/common/board_ioctl.c
+++ b/platforms/nuttx/src/px4/common/board_ioctl.c
@@ -1,0 +1,188 @@
+/****************************************************************************
+ *
+ *   Copyright (C) 2020 Technology Innovation Institute. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+/**
+ * @file board_ioctl.c
+ *
+ * Provide a kernel-userspace boardctl_ioctl interface
+ */
+
+#include <px4_platform_common/px4_config.h>
+#include <px4_platform_common/defines.h>
+#include <px4_platform/board_ctrl.h>
+#include "board_config.h"
+
+#include <nuttx/lib/builtin.h>
+#include <NuttX/kernel_builtin/kernel_builtin_proto.h>
+
+FAR const struct builtin_s g_kernel_builtins[] = {
+#include <NuttX/kernel_builtin/kernel_builtin_list.h>
+};
+
+const int g_n_kernel_builtins = sizeof(g_kernel_builtins) / sizeof(struct builtin_s);
+
+static struct {
+	ioctl_ptr_t ioctl_func;
+} ioctl_ptrs[MAX_IOCTL_PTRS];
+
+/************************************************************************************
+ * Name: px4_register_boardct_ioctl
+ *
+ * Description:
+ *   an interface function for kernel services to register an ioct handler for user side
+ *
+ ************************************************************************************/
+
+int px4_register_boardct_ioctl(unsigned base, ioctl_ptr_t func)
+{
+	unsigned i = IOCTL_BASE_TO_IDX(base);
+	int ret = PX4_ERROR;
+
+	if (i < MAX_IOCTL_PTRS) {
+		ioctl_ptrs[i].ioctl_func = func;
+		ret = PX4_OK;
+	}
+
+	return ret;
+}
+
+/************************************************************************************
+ * Name: board_ioctl
+ *
+ * Description:
+ *   implements board_ioctl for userspace-kernel interface
+ *
+ ************************************************************************************/
+
+int board_ioctl(unsigned int cmd, uintptr_t arg)
+{
+	unsigned i = IOCTL_BASE_TO_IDX(cmd);
+	int ret = -EINVAL;
+
+	if (i < MAX_IOCTL_PTRS && ioctl_ptrs[i].ioctl_func) {
+		ret = ioctl_ptrs[i].ioctl_func(cmd, arg);
+	}
+
+	return ret;
+}
+
+/************************************************************************************
+ * Name: launch_kernel_builtin
+ *
+ * Description:
+ *   launches a kernel-side build-in module
+ *
+ ************************************************************************************/
+
+static int launch_kernel_builtin(int argc, char **argv)
+{
+	int i;
+	FAR const struct builtin_s *builtin = NULL;
+
+	for (i = 0; i < g_n_kernel_builtins; i++) {
+		if (!strcmp(g_kernel_builtins[i].name, argv[0])) {
+			builtin = &g_kernel_builtins[i];
+			break;
+		}
+	}
+
+	if (builtin) {
+		/* This is running in the userspace thread, created by nsh, and
+		   called via boardctl. Call the main directly */
+		return builtin->main(argc, argv);
+	}
+
+	return ENOENT;
+}
+
+/************************************************************************************
+ * Name: platform_ioctl
+ *
+ * Description:
+ *   handle all miscellaneous platform level ioctls
+ *
+ ************************************************************************************/
+
+static int platform_ioctl(unsigned int cmd, unsigned long arg)
+{
+	int ret = PX4_OK;
+
+	switch (cmd) {
+	case PLATFORMIOCLAUNCH: {
+			platformioclaunch_t *data = (platformioclaunch_t *)arg;
+			data->ret = launch_kernel_builtin(data->argc, data->argv);
+		}
+		break;
+
+	case PLATFORMIOCVBUSSTATE: {
+			platformiocvbusstate_t *data = (platformiocvbusstate_t *)arg;
+			data->ret = boardctrl_read_VBUS_state();
+		}
+		break;
+
+	case PLATFORMIOCINDICATELOCKOUT: {
+			platformioclockoutstate_t *data = (platformioclockoutstate_t *)arg;
+			boardctrl_indicate_external_lockout_state(data->enabled);
+		}
+		break;
+
+	case PLATFORMIOCGETLOCKOUT: {
+			platformioclockoutstate_t *data = (platformioclockoutstate_t *)arg;
+			data->enabled = boardctrl_get_external_lockout_state();
+		}
+		break;
+
+	default:
+		ret = -ENOTTY;
+		break;
+	}
+
+	return ret;
+}
+
+/************************************************************************************
+ * Name: kernel_ioctl_initialize
+ *
+ * Description:
+ *   initializes the kernel-side ioctl interface
+ *
+ ************************************************************************************/
+
+void kernel_ioctl_initialize(void)
+{
+	for (int i = 0; i < MAX_IOCTL_PTRS; i++) {
+		ioctl_ptrs[i].ioctl_func = NULL;
+	}
+
+	px4_register_boardct_ioctl(_PLATFORMIOCBASE, platform_ioctl);
+}

--- a/platforms/nuttx/src/px4/common/include/px4_platform/board_ctrl.h
+++ b/platforms/nuttx/src/px4/common/include/px4_platform/board_ctrl.h
@@ -36,6 +36,8 @@
 
 #include <px4_platform_common/defines.h>
 
+#include <stdbool.h>
+
 /* Encode the px4 boardctl ioctls in the following way:
  * the highest 4-bits identifies the boardctl's used by this if
  * the next 4-bits identifies the module which handles the ioctl
@@ -96,5 +98,10 @@ void kernel_ioctl_initialize(void);
 
 /* Function to register a px4 boardctl handler */
 int px4_register_boardct_ioctl(unsigned base, ioctl_ptr_t func);
+
+/* Define common boardctrl prototypes for user and kernel */
+int boardctrl_read_VBUS_state(void);
+void boardctrl_indicate_external_lockout_state(bool enable);
+bool boardctrl_get_external_lockout_state(void);
 
 __END_DECLS

--- a/platforms/nuttx/src/px4/common/px4_protected_layers.cmake
+++ b/platforms/nuttx/src/px4/common/px4_protected_layers.cmake
@@ -6,13 +6,15 @@ add_library(px4_layer
 	board_fat_dma_alloc.c
 	tasks.cpp
 	console_buffer_usr.cpp
-	usr_mcu_version.cpp
 	cdc_acm_check.cpp
 	${PX4_SOURCE_DIR}/platforms/posix/src/px4/common/print_load.cpp
 	${PX4_SOURCE_DIR}/platforms/posix/src/px4/common/cpuload.cpp
-	usr_hrt.cpp
 	px4_userspace_init.cpp
 	px4_usr_crypto.cpp
+	px4_mtd.cpp
+	usr_board_ctrl.c
+	usr_hrt.cpp
+	usr_mcu_version.cpp
 )
 
 target_link_libraries(px4_layer
@@ -25,10 +27,12 @@ target_link_libraries(px4_layer
 
 # Build the interface library between user and kernel side
 add_library(px4_board_ctrl
-		board_ctrl.c
+	board_ctrl.c
+	board_ioctl.c
 )
 
 add_dependencies(px4_board_ctrl nuttx_context px4_kernel_builtin_list_target)
+target_compile_options(px4_board_ctrl PRIVATE -D__KERNEL__)
 
 target_link_libraries(px4_layer
 	PUBLIC
@@ -38,7 +42,7 @@ target_link_libraries(px4_layer
 # Build the kernel side px4_kernel_layer
 
 add_library(px4_kernel_layer
-		${KERNEL_SRCS}
+	${KERNEL_SRCS}
 )
 
 target_link_libraries(px4_kernel_layer
@@ -59,6 +63,5 @@ if (DEFINED PX4_CRYPTO)
 	target_link_libraries(px4_layer PUBLIC crypto_backend_interface)
 endif()
 
-target_compile_options(px4_kernel_layer PRIVATE -D__KERNEL__)
-
 add_dependencies(px4_kernel_layer prebuild_targets)
+target_compile_options(px4_kernel_layer PRIVATE -D__KERNEL__)

--- a/platforms/nuttx/src/px4/common/usr_board_ctrl.c
+++ b/platforms/nuttx/src/px4/common/usr_board_ctrl.c
@@ -1,6 +1,6 @@
 /****************************************************************************
  *
- *   Copyright (C) 2020 Technology Innovation Institute. All rights reserved.
+ *   Copyright (C) 2022 Technology Innovation Institute. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -31,46 +31,33 @@
  *
  ****************************************************************************/
 
-/****************************************************************************
- * Included Files
- ****************************************************************************/
-
 #include <nuttx/config.h>
 
-#include <stdbool.h>
+#include <px4_platform/board_ctrl.h>
 
-#include "board_config.h"
+#include <sys/boardctl.h>
 
-/****************************************************************************
- * Public Functions
- ****************************************************************************/
-
-#if defined(GPIO_OTGFS_VBUS)
 int board_read_VBUS_state(void)
 {
-	return px4_arch_gpioread(GPIO_OTGFS_VBUS);
+	return boardctrl_read_VBUS_state();
 }
-#endif
 
 int boardctrl_read_VBUS_state(void)
 {
-	return board_read_VBUS_state();
+	platformiocvbusstate_t state = {false};
+	boardctl(PLATFORMIOCVBUSSTATE, (uintptr_t)&state);
+	return state.ret;
 }
 
 void boardctrl_indicate_external_lockout_state(bool enable)
 {
-#if defined(GPIO_nARMED)
-	px4_arch_configgpio((enable) ? GPIO_nARMED : GPIO_nARMED_INIT);
-#else
-	UNUSED(enable);
-#endif
+	platformioclockoutstate_t state = {enable};
+	boardctl(PLATFORMIOCINDICATELOCKOUT, (uintptr_t)&state);
 }
 
 bool boardctrl_get_external_lockout_state(void)
 {
-#if defined(GPIO_nARMED)
-	return px4_arch_gpioread(GPIO_nARMED);
-#else
-	return false;
-#endif
+	platformioclockoutstate_t state = {false};
+	boardctl(PLATFORMIOCGETLOCKOUT, (uintptr_t)&state);
+	return state.enabled;
 }


### PR DESCRIPTION
Move logic implemented in the header files to source files, this way
it will be simpler to define which is compiled to kernel space and
which to user space

Also allows to remove some headers that pull in half the universe
from the board definitions (which should just be pin definitions and
no functionality)
