### PR TITLE
4400_ssrc_fog_x Set range finder as default HGT source

### DIFF
--- a/ROMFS/px4fmu_common/init.d/airframes/4400_ssrc_fog_x
+++ b/ROMFS/px4fmu_common/init.d/airframes/4400_ssrc_fog_x
@@ -39,17 +39,14 @@ param set-default RTPS_MAV_CONFIG 0
 # Enable LL40LS in i2c
 param set-default SENS_EN_LL40LS 2
 
+# Set EKF to use range finder as main height source
+param set-default EKF2_HGT_MODE 2
+
 # LEDs on TELEMETRY 1
 param set-default SER_TEL1_BAUD 57600
 param set-default MAV_1_CONFIG 101
 param set-default MAV_1_MODE 7
 param set-default MAV_1_RATE 1000
-
-# Disable multi ekf for now
-param set-default EKF2_MULTI_IMU 0
-param set-default SENS_IMU_MODE 1
-param set-default EKF2_MULTI_MAG 0
-param set-default SENS_MAG_MODE 1
 
 # Enable safety switch
 param set-default CBRK_IO_SAFETY 0


### PR DESCRIPTION
Also remove the multi-ekf parameter settings, just use the defaults

Signed-off-by: Jukka Laitinen <jukkax@ssrc.tii.ae>

