### PR TITLE
Create pf crypto backend stub

### DIFF
--- a/platforms/nuttx/src/bootloader/microchip/mpfs/main.c
+++ b/platforms/nuttx/src/bootloader/microchip/mpfs/main.c
@@ -188,8 +188,6 @@ static int load_sdcard_images(const char *name, uint64_t loadaddr)
 {
 	struct stat file_stat;
 
-	_alert("Loading %s\n", name);
-
 	int mmcsd_fd = open(name, O_RDONLY);
 
 	if (mmcsd_fd > 0) {
@@ -197,11 +195,13 @@ static int load_sdcard_images(const char *name, uint64_t loadaddr)
 		size_t got = read(mmcsd_fd, (void *)loadaddr, file_stat.st_size);
 
 		if (got > 0 && got == (size_t)file_stat.st_size) {
+			_alert("Loading %s OK\n", name);
 			close(mmcsd_fd);
 			return 0;
 		}
 	}
 
+	_alert("Loading %s failed\n", name);
 	close(mmcsd_fd);
 	return -1;
 }

--- a/platforms/nuttx/src/px4/common/nuttx_random.c
+++ b/platforms/nuttx/src/px4/common/nuttx_random.c
@@ -41,6 +41,4 @@ size_t px4_get_secure_random(uint8_t *out,
 	arc4random_buf(out, outlen);
 	return outlen;
 }
-#else
-#error CONFIG_CRYPTO_RANDOM_POOL has to be defined
 #endif

--- a/src/drivers/pfsoc_crypto/CMakeLists.txt
+++ b/src/drivers/pfsoc_crypto/CMakeLists.txt
@@ -1,0 +1,51 @@
+
+############################################################################
+#
+#   Copyright (c) 2022 Technology Innoavation Institute. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+# 1. Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in
+#    the documentation and/or other materials provided with the
+#    distribution.
+# 3. Neither the name PX4 nor the names of its contributors may be
+#    used to endorse or promote products derived from this software
+#    without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+# OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+# AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+# ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+#
+############################################################################
+
+px4_add_library(crypto_backend crypto.c)
+
+target_link_libraries(crypto_backend
+	PUBLIC
+		keystore_backend
+)
+
+target_link_libraries(crypto_backend
+	PRIVATE
+		monocypher
+)
+target_include_directories(crypto_backend PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
+
+# This interface library can be used to get the backend headers
+add_library(crypto_backend_interface INTERFACE)
+target_link_libraries(crypto_backend_interface INTERFACE keystore_backend_interface)
+target_include_directories(crypto_backend_interface INTERFACE ${CMAKE_CURRENT_SOURCE_DIR})

--- a/src/drivers/pfsoc_crypto/Kconfig
+++ b/src/drivers/pfsoc_crypto/Kconfig
@@ -1,0 +1,6 @@
+menuconfig DRIVERS_PFSOC_CRYPTO
+	bool "pfsoc_crypto"
+	depends on BOARD_CRYPTO
+	default n
+	---help---
+		Enable support for pfsoc_crypto

--- a/src/drivers/pfsoc_crypto/crypto.c
+++ b/src/drivers/pfsoc_crypto/crypto.c
@@ -1,0 +1,202 @@
+/****************************************************************************
+ *
+ *   Copyright (c) 2020 Technology Innovation Institute. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+/**
+ * @file crypto.c
+ *
+ * Implementation for PF SOC FPGA crypto engine.
+ *
+ */
+
+#include <inttypes.h>
+#include <stdbool.h>
+
+#include <px4_platform_common/crypto_backend.h>
+#include <lib/crypto/monocypher/src/optional/monocypher-ed25519.h>
+
+/*
+ * For now, this is just a dummy up/down counter for tracking open/close calls
+ */
+static int crypto_open_count = 0;
+
+typedef struct {
+	uint8_t nonce[24];
+	uint64_t ctr;
+} chacha20_context_t;
+
+void crypto_init()
+{
+	keystore_init();
+}
+
+crypto_session_handle_t crypto_open(px4_crypto_algorithm_t algorithm)
+{
+	crypto_session_handle_t ret;
+	ret.keystore_handle = keystore_open();
+
+	if (keystore_session_handle_valid(ret.keystore_handle)) {
+		ret.algorithm = algorithm;
+		ret.handle = ++crypto_open_count;
+
+	} else {
+		ret.handle = 0;
+		ret.context = NULL;
+		ret.algorithm = CRYPTO_NONE;
+		return ret;
+	}
+
+	switch (algorithm) {
+	default:
+		ret.context = NULL;
+	}
+
+	return ret;
+}
+
+void crypto_close(crypto_session_handle_t *handle)
+{
+
+	// Not open?
+	if (!crypto_session_handle_valid(*handle)) {
+		return;
+	}
+
+	crypto_open_count--;
+	handle->handle = 0;
+	keystore_close(&handle->keystore_handle);
+	handle->context = NULL;
+}
+
+bool crypto_signature_check(crypto_session_handle_t handle,
+			    uint8_t  key_index,
+			    const uint8_t  *signature,
+			    const uint8_t *message,
+			    size_t message_size)
+{
+	bool ret = false;
+	size_t keylen = 0;
+	uint8_t public_key[32];
+
+	if (crypto_session_handle_valid(handle)) {
+		keylen = keystore_get_key(handle.keystore_handle, key_index, public_key, sizeof(public_key));
+	}
+
+	if (keylen == 0) {
+		return false;
+	}
+
+	switch (handle.algorithm) {
+	case CRYPTO_ED25519:
+		ret = crypto_ed25519_check(signature, public_key, message, message_size) == 0;
+		break;
+
+	default:
+		ret = false;
+	}
+
+	return ret;
+}
+
+bool crypto_encrypt_data(crypto_session_handle_t handle,
+			 uint8_t  key_idx,
+			 const uint8_t *message,
+			 size_t message_size,
+			 uint8_t *cipher,
+			 size_t *cipher_size)
+{
+
+	bool ret = false;
+
+	if (!crypto_session_handle_valid(handle)) {
+		return ret;
+	}
+
+	switch (handle.algorithm) {
+	default:
+		break;
+	}
+
+	return ret;
+}
+
+bool crypto_generate_key(crypto_session_handle_t handle,
+			 uint8_t idx, bool persistent)
+{
+	bool ret = false;
+
+	switch (handle.algorithm) {
+	default:
+		break;
+	}
+
+	if (ret && persistent) {
+		/* Store the generated key persistently */
+	}
+
+	return ret;
+}
+
+bool crypto_get_encrypted_key(crypto_session_handle_t handle,
+			      uint8_t key_idx,
+			      uint8_t *key,
+			      size_t *max_len,
+			      uint8_t encryption_key_idx)
+{
+	bool ret = false;
+	return ret;
+}
+
+
+bool crypto_get_nonce(crypto_session_handle_t handle,
+		      uint8_t *nonce,
+		      size_t *nonce_len)
+{
+	switch (handle.algorithm) {
+	default:
+		*nonce_len = 0;
+	}
+
+	return true;
+}
+
+size_t crypto_get_min_blocksize(crypto_session_handle_t handle, uint8_t key_idx)
+{
+	size_t ret;
+
+	switch (handle.algorithm) {
+	default:
+		ret = 1;
+	}
+
+	return ret;
+}

--- a/src/drivers/pfsoc_crypto/crypto_backend_definitions.h
+++ b/src/drivers/pfsoc_crypto/crypto_backend_definitions.h
@@ -1,0 +1,47 @@
+/****************************************************************************
+ *
+ *   Copyright (c) 2022 Technology Innovation Institute. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+#pragma once
+
+#include <stdbool.h>
+#include <keystore_backend_definitions.h>
+
+typedef struct {
+	int handle;
+	px4_crypto_algorithm_t algorithm;
+	keystore_session_handle_t keystore_handle;
+	void *context;
+} crypto_session_handle_t;
+
+static inline void crypto_session_handle_init(crypto_session_handle_t *handle) {handle->handle = 0;}
+static inline bool crypto_session_handle_valid(crypto_session_handle_t handle) {return handle.handle > 0 && keystore_session_handle_valid(handle.keystore_handle);}

--- a/src/drivers/stub_keystore/Kconfig
+++ b/src/drivers/stub_keystore/Kconfig
@@ -1,7 +1,6 @@
 menu "stub_keystore configuration"
 	menuconfig DRIVERS_STUB_KEYSTORE
 	bool "stub_keystore"
-	depends on DRIVERS_SW_CRYPTO
 	default n
 	---help---
 		Enable support for stub_keystore


### PR DESCRIPTION
This is a stub implementation to start creating driver for PF SOC crypto module.

I left monocypher signature check in this module still so that we can take it into use in bootloader already.
