### PR TITLE
atomic: Implement generic atomic code block class

### DIFF
--- a/platforms/nuttx/src/px4/common/CMakeLists.txt
+++ b/platforms/nuttx/src/px4/common/CMakeLists.txt
@@ -44,6 +44,7 @@ if(NOT PX4_BOARD MATCHES "io-v2")
 		gpio.c
 		print_load.cpp
 		tasks.cpp
+		px4_atomic.cpp
 		px4_nuttx_impl.cpp
 		px4_init.cpp
 		px4_manifest.cpp

--- a/platforms/nuttx/src/px4/common/include/px4_platform/atomic_block.h
+++ b/platforms/nuttx/src/px4/common/include/px4_platform/atomic_block.h
@@ -1,0 +1,59 @@
+/****************************************************************************
+ *
+ *   Copyright (C) 2022 Technology Innovation Institute. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+#pragma once
+
+#include <stdint.h>
+
+#include <nuttx/irq.h>
+
+#include <px4_platform_common/sem.h>
+
+namespace px4
+{
+
+class atomic_block
+{
+public:
+	atomic_block();
+	~atomic_block();
+	void start();
+	void finish();
+private:
+	union {
+		px4_sem_t _lock;
+		irqstate_t _irqlock;
+	};
+};
+
+}

--- a/platforms/nuttx/src/px4/common/px4_atomic.cpp
+++ b/platforms/nuttx/src/px4/common/px4_atomic.cpp
@@ -1,0 +1,59 @@
+/****************************************************************************
+ *
+ *   Copyright (C) 2022 Technology Innovation Institute. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+#include <px4_platform/atomic_block.h>
+
+namespace px4
+{
+
+atomic_block::atomic_block(void)
+{
+	_irqlock = 0;
+}
+
+atomic_block::~atomic_block(void)
+{
+
+}
+
+void atomic_block::start(void)
+{
+	_irqlock = enter_critical_section();
+}
+
+void atomic_block::finish(void)
+{
+	leave_critical_section(_irqlock);
+}
+
+}

--- a/platforms/nuttx/src/px4/common/px4_protected_layers.cmake
+++ b/platforms/nuttx/src/px4/common/px4_protected_layers.cmake
@@ -12,6 +12,7 @@ add_library(px4_layer
 	px4_userspace_init.cpp
 	px4_usr_crypto.cpp
 	px4_mtd.cpp
+	usr_atomic.cpp
 	usr_board_ctrl.c
 	usr_hrt.cpp
 	usr_mcu_version.cpp

--- a/platforms/nuttx/src/px4/common/usr_atomic.cpp
+++ b/platforms/nuttx/src/px4/common/usr_atomic.cpp
@@ -1,0 +1,59 @@
+/****************************************************************************
+ *
+ *   Copyright (C) 2022 Technology Innovation Institute. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+#include <px4_platform/atomic_block.h>
+
+namespace px4
+{
+
+atomic_block::atomic_block(void)
+{
+	px4_sem_init(&_lock, 0, 1);
+}
+
+atomic_block::~atomic_block(void)
+{
+	px4_sem_destroy(&_lock);
+}
+
+void atomic_block::start(void)
+{
+	do {} while (px4_sem_wait(&_lock) != 0);
+}
+
+void atomic_block::finish(void)
+{
+	px4_sem_post(&_lock);
+}
+
+}


### PR DESCRIPTION
Implement a generic atomic code block class, that can be used from
user-/kernelspace. The declaration of the class is always the same while
the implementation differs.

This is needed as many modules from both user-/kernelspace use atomic.h