### PR TITLE
Use fog ros baseimage for sitl

### DIFF
--- a/packaging/Dockerfile.sitl
+++ b/packaging/Dockerfile.sitl
@@ -1,4 +1,4 @@
-FROM ghcr.io/tiiuae/tii-ubuntu-ros:galactic
+FROM ghcr.io/tiiuae/fog-ros-baseimage:sha-3dcb78d
 
 # Install PX4 SITL
 WORKDIR /packages


### PR DESCRIPTION
Update px4_sitl container (used in simulation) to use fog-ros-baseimage to get correct fastdds version in use.