### PR TITLE
icicle: Put ToC to the beginning of the firmware image

### DIFF
--- a/boards/ssrc/icicle/nuttx-config/scripts/script.ld
+++ b/boards/ssrc/icicle/nuttx-config/scripts/script.ld
@@ -20,30 +20,21 @@
 
 MEMORY
 {
-  progmem (rx) : ORIGIN = 0xAFB00000, LENGTH = 3072K  /* w/ cache */
+  toc     (rx) : ORIGIN = 0xAFB00000, LENGTH = 4K /* Image header */
+  progmem (rx) : ORIGIN = 0xAFB00000, LENGTH = 3072K - 4K /* w/ cache */
   sram   (rwx) : ORIGIN = 0xAFE00000, LENGTH = 2048K  /* w/ cache */
 }
 
 OUTPUT_ARCH("riscv")
 
 ENTRY(_stext)
-
 EXTERN(__start)
-EXTERN(_main_toc)
 
 SECTIONS
 {
     .text : {
         _stext = ABSOLUTE(.);
         *(.start .start.*)
-        /*
-        This signature provides the bootloader with a way to delay booting
-        */
-        . = 0x400;
-        _bootdelay_signature = ABSOLUTE(.);
-        FILL(0x01ecc2925d7d05c5)
-        . += 8;
-        *(.main_toc)
         *(.text .text.*)
         *(.fixup)
         *(.gnu.warning)
@@ -103,19 +94,4 @@ SECTIONS
     .debug_line 0 : { *(.debug_line) }
     .debug_pubnames 0 : { *(.debug_pubnames) }
     .debug_aranges 0 : { *(.debug_aranges) }
-    .ramfunc : {
-        _sramfuncs = .;
-        *(.ramfunc  .ramfunc.*)
-        . = ALIGN(4);
-        _eramfuncs = .;
-    } > sram AT > progmem
-
-    _framfuncs = LOADADDR(.ramfunc);
-
-    /* Start of the image signature. This
-     *  has to be in the end of the image
-     */
-     .signature : {
-         _boot_signature = ALIGN(4);
-     } > progmem
 }

--- a/boards/ssrc/icicle/nuttx-config/scripts/toc.ld
+++ b/boards/ssrc/icicle/nuttx-config/scripts/toc.ld
@@ -1,0 +1,59 @@
+/****************************************************************************
+ * boards/risc-v/icicle/mpfs/scripts/ld.script
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+MEMORY
+{
+  progmem      (r) : ORIGIN = 0xAFB00000, LENGTH = 5M
+}
+
+OUTPUT_ARCH("riscv")
+
+ENTRY(_app_start)
+
+EXTERN(_main_toc)
+
+SECTIONS
+{
+    .firmware : {
+        _fw_start = ABSOLUTE(.);
+
+        /*
+        This signature provides the bootloader with a way to delay booting
+        */
+        _bootdelay_signature = ABSOLUTE(.);
+        FILL(0x01ecc2925d7d05c5)
+        . += 8;
+
+        /* The ToC itself */
+        *(.main_toc)
+        . = 0x1000;
+
+        /* The application firmware payload itself */
+        _app_start = ABSOLUTE(.);
+        *(.firmware)
+        _app_end = ABSOLUTE(.);
+
+        /* Start of the image signature. This
+         *  has to be in the end of the image
+         */
+        _boot_signature = ALIGN(4);
+        _fw_end = ABSOLUTE(.);
+    } > progmem
+}

--- a/boards/ssrc/icicle/src/hw_config.h
+++ b/boards/ssrc/icicle/src/hw_config.h
@@ -62,7 +62,7 @@
 #define SERIAL1_DEV    0x04
 
 #define APP_LOAD_ADDRESS               0xAFB00000llu
-#define FLASH_START_ADDRESS APP_LOAD_ADDRESS
+#define FLASH_START_ADDRESS            APP_LOAD_ADDRESS
 #define BOOTLOADER_DELAY               5000
 #define INTERFACE_USB                  1
 #define INTERFACE_USB_CONFIG           "/dev/ttyACM0"
@@ -70,7 +70,8 @@
 //#define USE_VBUS_PULL_DOWN
 #define INTERFACE_USART                1
 #define INTERFACE_USART_CONFIG         "/dev/ttyS1,2000000"
-#define BOOT_DELAY_ADDRESS             0x00000400
+#define BOOT_DELAY_ADDRESS             0x00000000
+#define TOC_AREA_SIZE                  0x1000
 #define BOARD_TYPE                     1500
 #define _FLASH_KBYTES                  3072
 #define BOARD_FLASH_SIZE               (_FLASH_KBYTES * 1024)

--- a/boards/ssrc/icicle/src/toc.c
+++ b/boards/ssrc/icicle/src/toc.c
@@ -33,21 +33,23 @@
 #include <image_toc.h>
 
 /* (Maximum) size of the signature */
+
 #define SIGNATURE_SIZE 64
 
 /* Boot image starts at __start and ends at
- * the beginning of signature
+ * the beginning of signature, but for protected/kernel mode we don't know
+ * their locations. Assume binary file start and binary file end ?
 */
+extern const uintptr_t _app_start;
+extern const uintptr_t _app_end;
 
-extern uint32_t  __start;
-extern const int *_boot_signature;
-
-#define BOOT_ADDR &__start
-#define BOOT_END ((const void *)&_boot_signature)
+#define BOOT_ADDR &_app_start
+#define BOOT_END ((const void *)&_app_end)
 
 /* Boot signature start and end are defined by the
  * signature definition below
 */
+extern const uintptr_t _boot_signature;
 
 #define BOOTSIG_ADDR ((const void *)&_boot_signature)
 #define BOOTSIG_END ((const void *)((const uint8_t *)BOOTSIG_ADDR+SIGNATURE_SIZE))

--- a/platforms/nuttx/CMakeLists.txt
+++ b/platforms/nuttx/CMakeLists.txt
@@ -134,12 +134,14 @@ file(RELATIVE_PATH PX4_BINARY_DIR_REL ${CMAKE_CURRENT_BINARY_DIR} ${PX4_BINARY_D
 # because even relative linker script paths are different for linux, mac and windows
 CYGPATH(NUTTX_CONFIG_DIR NUTTX_CONFIG_DIR_CYG)
 
-if((DEFINED ENV{SIGNING_TOOL}) AND (NOT NUTTX_DIR MATCHES "external"))
+if((DEFINED ENV{SIGNING_TOOL}) AND (NOT "${PX4_BOARD_LABEL}" STREQUAL "bootloader") AND (NOT NUTTX_DIR MATCHES "external"))
 	set(PX4_BINARY_OUTPUT ${PX4_BINARY_DIR}/${PX4_CONFIG}_unsigned.bin)
 
+	add_subdirectory(toc)
+
 	add_custom_command(OUTPUT ${PX4_BINARY_DIR_REL}/${PX4_CONFIG}.bin
-		COMMAND $ENV{SIGNING_TOOL} $ENV{SIGNING_ARGS} ${PX4_BINARY_OUTPUT} ${PX4_BINARY_DIR}/${PX4_CONFIG}.bin
-		DEPENDS ${PX4_BINARY_OUTPUT}
+		COMMAND $ENV{SIGNING_TOOL} $ENV{SIGNING_ARGS} ${PX4_BINARY_DIR}/toc.bin ${PX4_BINARY_DIR}/${PX4_CONFIG}.bin
+		DEPENDS toc_bin
 		WORKING_DIRECTORY ${PX4_SOURCE_DIR}
 	)
 else()
@@ -303,6 +305,8 @@ else()
 	endif()
 
 endif()
+
+add_custom_target(px4_binary DEPENDS ${PX4_BINARY_OUTPUT})
 
 # create .px4 with parameter and airframe metadata
 if (TARGET parameters_xml AND TARGET airframes_xml)

--- a/platforms/nuttx/src/bootloader/common/image_toc.c
+++ b/platforms/nuttx/src/bootloader/common/image_toc.c
@@ -52,7 +52,7 @@
 
 bool find_toc(const image_toc_entry_t **toc_entries, uint8_t *len)
 {
-	const uintptr_t toc_start_u32 = APP_LOAD_ADDRESS + BOOT_DELAY_ADDRESS + 8;
+	const uintptr_t toc_start_u32 = FLASH_START_ADDRESS + BOOT_DELAY_ADDRESS + 8;
 	const image_toc_start_t *toc_start = (const image_toc_start_t *)toc_start_u32;
 	const image_toc_entry_t *entry = (const image_toc_entry_t *)(toc_start_u32 + sizeof(image_toc_start_t));
 
@@ -76,7 +76,7 @@ bool find_toc(const image_toc_entry_t **toc_entries, uint8_t *len)
 		 */
 
 		if (i <= MAX_TOC_ENTRIES && i > 0 &&
-		    (uintptr_t)entry[0].start == APP_LOAD_ADDRESS &&
+		    (uintptr_t)entry[0].start >= FLASH_START_ADDRESS &&
 		    (uintptr_t)entry[0].end <= (FLASH_END_ADDRESS - sizeof(uintptr_t)) &&
 		    (uintptr_t)entry[0].end > (uintptr_t)entry[0].start) {
 			sig_idx = entry[0].signature_idx;

--- a/platforms/nuttx/toc/CMakeLists.txt
+++ b/platforms/nuttx/toc/CMakeLists.txt
@@ -1,0 +1,65 @@
+############################################################################
+#
+#   Copyright (c) 2022 Technology Innovation Institute. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+# 1. Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in
+#    the documentation and/or other materials provided with the
+#    distribution.
+# 3. Neither the name PX4 nor the names of its contributors may be
+#    used to endorse or promote products derived from this software
+#    without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+# OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+# AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+# ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+#
+############################################################################
+
+add_executable(toc
+	fw_image.c
+	${PX4_BOARD_DIR}/src/toc.c # The board specific ToC file
+)
+
+set(TOC_NAME ${PX4_BINARY_DIR}/toc.elf)
+set_target_properties(toc PROPERTIES OUTPUT_NAME ${TOC_NAME})
+
+target_compile_options(toc PRIVATE -DPX4_UNSIGNED_FIRMWARE=${PX4_BINARY_OUTPUT})
+add_dependencies(toc px4_binary)
+
+target_link_libraries(toc PRIVATE
+
+	-nostartfiles
+	-nodefaultlibs
+	-nostdlib
+	-nostdinc++
+
+	-fno-exceptions
+	-fno-rtti
+
+	-Wl,--script=${NUTTX_CONFIG_DIR}/scripts/${SCRIPT_PREFIX}toc.ld
+	-Wl,--warn-common
+)
+
+set(TOC_BINARY_OUTPUT ${PX4_BINARY_DIR}/toc.bin)
+
+add_custom_command(OUTPUT ${TOC_BINARY_OUTPUT}
+	COMMAND ${CMAKE_OBJCOPY} -O binary ${TOC_NAME} ${TOC_BINARY_OUTPUT}
+	DEPENDS toc
+)
+add_custom_target(toc_bin DEPENDS ${TOC_BINARY_OUTPUT})


### PR DESCRIPTION
This allows signinig the protected mode binary, as the requirement for the
linker defined symbol "_boot_signature" is removed. The problem is that
the ToC goes to the kernel binary, while the signature is appended to
the user binary, but the ToC needs the location of the signature which
cannot be known when the kernel is linked.

This fix reserves 256 bytes from the beginning of the program memory
for the ToC (which is more like a firmware header now):
- The first element is a trampoline to the application. The bootloader
  assumes that the application head is the beginning of the program
  memory.
- The second element is the boot delay signature (do we even use this ?)
- The third element is the ToC
- After the ToC, the _unsigned_ px4 binary is injected

Finally, a binary file containing the ToC + px4 firmware is created, and
this is signed, which is the final firmware image.

It is still unclear whether this approach will work for ARM targets, which
expect the reset vector at a certain location (usually, beginning of FLASH).
