### PR TITLE
Disable MAV_0 and MAV_2 by default for airframe 4400

### DIFF
--- a/ROMFS/px4fmu_common/init.d/airframes/4400_ssrc_fog_x
+++ b/ROMFS/px4fmu_common/init.d/airframes/4400_ssrc_fog_x
@@ -48,6 +48,10 @@ param set-default MAV_1_CONFIG 101
 param set-default MAV_1_MODE 7
 param set-default MAV_1_RATE 1000
 
+# Disable MAV_0 and MAV_2
+param set-default MAV_0_CONFIG 0
+param set-default MAV_2_CONFIG 0
+
 # Enable safety switch
 param set-default CBRK_IO_SAFETY 0
 


### PR DESCRIPTION
Disable unused MAV_0 and MAV_2 by default for airframe 4400