### PR TITLE
[DO NOT MERGE] DP-3394 flight time counter read write

### DIFF
--- a/Tools/px_uploader.entrypoint
+++ b/Tools/px_uploader.entrypoint
@@ -1,4 +1,6 @@
 #!/bin/sh -eu
 
-/bin/px_uploader.py --udp-addr=192.168.200.101 --udp-port=14541 --port=/dev/px4serial --baud-flightstack=57600,115200,1000000,2000000 --baud-bootloader=2000000 --use-protocol-splitter-format px4_fmu-v5_ssrc-*.px4 px4_fmu-v5x_ssrc-*.px4 ssrc_saluki-v1_default-*.px4
-/bin/px4-post-update-init -a :14540 $1
+/bin/px4-post-update-init --address :14540 --section read_flight_time
+/bin/px_uploader.py --port=/dev/px4serial --udp-addr=192.168.200.101 --baud-flightstack=57600,115200,1000000,2000000 --baud-bootloader=2000000 px4_fmu-v5_ssrc-*.px4 px4_fmu-v5x_ssrc-*.px4 ssrc_saluki-v1_default-*.px4
+/bin/px4-post-update-init --address :14540 --section all
+/bin/px4-post-update-init --address :14540 --section write_flight_time


### PR DESCRIPTION
Support for save/restore of PX4 flight time counter param values during FW update.
Px4-firmware docker image entrypoint script does:
1. Read the flight time counter value from PX4 params and store it into tmp file
2. Updates firmware
3. Reset all params to firmware defaults
4. Write flight time counter value stored into tmp file back to PX4 params
