### PR TITLE
Fix GyroFFT default fallback.

### DIFF
--- a/src/modules/gyro_fft/GyroFFT.cpp
+++ b/src/modules/gyro_fft/GyroFFT.cpp
@@ -135,6 +135,11 @@ bool GyroFFT::init()
 		buffers_allocated = AllocateBuffers<256>();
 		_param_imu_gyro_fft_len.set(256);
 		_param_imu_gyro_fft_len.commit();
+		_rfft_q15.fftLenReal = 256;
+		_rfft_q15.twidCoefRModifier = 32U;
+		_rfft_q15.pCfft = &arm_cfft_sR_q15_len128;
+		PX4_INFO("Setting IMU_GYRO_FFT_LEN=%" PRId32 ", as default", _param_imu_gyro_fft_len.get());
+
 		break;
 	}
 


### PR DESCRIPTION
The original code was resetting only the parameter, but it wasn't updating _rfft_q15 attributes, so the changes were not really acting as it should.