### PR TITLE
boards/icicle: Remove ddrstorage section from bootloader

### DIFF
--- a/boards/ssrc/icicle/nuttx-config/scripts/bootloader_script.ld
+++ b/boards/ssrc/icicle/nuttx-config/scripts/bootloader_script.ld
@@ -74,7 +74,6 @@
 
 MEMORY
 {
-    ddr  (rx)     : ORIGIN = 0x80000000, LENGTH = 4M          /* w/ cache */
     envm (rx)     : ORIGIN = 0x20220100, LENGTH = 128K - 256  /* 256 reserved for hss headers */
     l2lim  (rwx)  : ORIGIN = 0x08000000, LENGTH = 1024k
     l2zerodevice (rwx) : ORIGIN = 0x0A000000, LENGTH = 512k
@@ -88,10 +87,6 @@ EXTERN(__start)
 
 SECTIONS
 {
-    .ddrstorage : {
-      *(.ddrstorage)
-    } > ddr
-
     .l2_scratchpad : ALIGN(0x10)
     {
         __l2_scratchpad_load = LOADADDR(.l2_scratchpad);

--- a/platforms/nuttx/CMakeLists.txt
+++ b/platforms/nuttx/CMakeLists.txt
@@ -291,7 +291,7 @@ else()
 	# for opensbi bootloader, strip the l2lim & ddr sections
 	if (CONFIG_OPENSBI AND "${PX4_BOARD_LABEL}" STREQUAL "bootloader")
 		add_custom_command(OUTPUT ${PX4_BINARY_OUTPUT}
-			COMMAND ${CMAKE_OBJCOPY} -R .text.sbi -R .l2_scratchpad -R .ddrstorage ${PX4_BINARY_DIR_REL}/${FW_NAME} ${PX4_BINARY_DIR_REL}/${FW_NAME_FLASH}
+			COMMAND ${CMAKE_OBJCOPY} -R .l2_scratchpad ${PX4_BINARY_DIR_REL}/${FW_NAME} ${PX4_BINARY_DIR_REL}/${FW_NAME_FLASH}
 			COMMAND ${CMAKE_OBJCOPY} -O binary ${PX4_BINARY_DIR_REL}/${FW_NAME_FLASH} ${PX4_BINARY_OUTPUT}
 			DEPENDS px4
 		)


### PR DESCRIPTION
Depends on NuttX change https://github.com/tiiuae/nuttx/pull/51
