### PR TITLE
Fix gps start

### DIFF
--- a/ROMFS/px4fmu_common/init.d/airframes/4400_ssrc_fog_x
+++ b/ROMFS/px4fmu_common/init.d/airframes/4400_ssrc_fog_x
@@ -57,3 +57,6 @@ param set-default CBRK_IO_SAFETY 0
 
 # Set default for disarm after land to 4s
 param set-default COM_DISARM_LAND 4.0
+
+# Enable satellite info by default
+param set-default GPS_SAT_INFO 1

--- a/src/drivers/gps/module.yaml
+++ b/src/drivers/gps/module.yaml
@@ -7,9 +7,10 @@ serial_config:
         group: GPS
       label: Secondary GPS
 
-    - command: gps start -d ${SERIAL_DEV} -b p:${BAUD_PARAM} -s ${DUAL_GPS_ARGS}
+    - command: gps start -d ${SERIAL_DEV} -b p:${BAUD_PARAM} ${DUAL_GPS_ARGS}
       port_config_param:
         name: GPS_1_CONFIG
         group: GPS
         default: GPS1
       label: Main GPS
+


### PR DESCRIPTION
We had earlier an own startup parameter -s for enabling satellite info. Now this parameter is unrecognized and breaks the gps start. So revert the earlier change.

PX4 has changed this into parameter "GPS_SAT_INFO", which we can now set enabled by default