### PR TITLE
Update boards/ssrc/saluki-v1 submodule for power brick configuration

### DIFF
--- a/ROMFS/px4fmu_common/init.d/airframes/4400_ssrc_fog_x
+++ b/ROMFS/px4fmu_common/init.d/airframes/4400_ssrc_fog_x
@@ -31,7 +31,6 @@ param set-default BAT1_N_CELLS 4
 param set-default BAT1_V_CHARGED 4.2
 param set-default BAT1_V_EMPTY 3.6
 param set-default BAT1_V_DIV 18.1
-param set-default BAT1_V_LOAD_DROP 0.1
 
 # Enable ethernet for PX4<->MC
 param set-default RTPS_MAV_CONFIG 0


### PR DESCRIPTION
Also remove the default BAT1_V_LOAD_DROP and use the same default value as for
pixhawk 5x

Signed-off-by: Jukka Laitinen <jukkax@ssrc.tii.ae>

