### PR TITLE
mpfs/bootloader: Fix bootloader softlock if SD card is missing

### DIFF
--- a/platforms/nuttx/src/bootloader/microchip/mpfs/main.c
+++ b/platforms/nuttx/src/bootloader/microchip/mpfs/main.c
@@ -872,11 +872,6 @@ bootloader_main(void)
 	    (reset_reason & BOARD_RESET_REASON_DEBUGGER_MASK) == 0) {
 
 		/*
-		 * Don't even try to boot before dropping to the bootloader.
-		 */
-		loading_status = INTERRUPTED;
-
-		/*
 		 * Don't drop out of the bootloader until something has been uploaded.
 		 */
 		timeout = 0;


### PR DESCRIPTION
If the SD card is not mounted, the bootloader will softlock in
flash_func_erase_sector() where loading_status is tested, and if
the value is not FAIL/DONE the bootloader_main process will sleep
forever.

This happens because the task that was supposed to wake it up (loader_main)
has already exited because it had no work to be done due to the SD card
missing.
