### PR TITLE
nuttx/tasks.cpp: Use libc procedures to exit, kill and ask for process name

### DIFF
--- a/platforms/nuttx/src/px4/common/tasks.cpp
+++ b/platforms/nuttx/src/px4/common/tasks.cpp
@@ -93,11 +93,5 @@ int px4_task_delete(int pid)
 
 const char *px4_get_taskname(void)
 {
-#if CONFIG_TASK_NAME_SIZE > 0 && (defined(__KERNEL__) || defined(CONFIG_BUILD_FLAT))
-	FAR struct tcb_s	*thisproc = nxsched_self();
-
-	return thisproc->name;
-#else
-	return "app";
-#endif
+	return getprogname();
 }

--- a/platforms/nuttx/src/px4/common/tasks.cpp
+++ b/platforms/nuttx/src/px4/common/tasks.cpp
@@ -88,7 +88,18 @@ int px4_task_spawn_cmd(const char *name, int scheduler, int priority, int stack_
 
 int px4_task_delete(int pid)
 {
-	return task_delete(pid);
+	int ret = OK;
+
+	if (pid == getpid()) {
+		// Commit suicide
+		exit(EXIT_SUCCESS);
+
+	} else {
+		// Politely ask someone else to kill themselves
+		ret = kill(pid, SIGKILL);
+	}
+
+	return ret;
 }
 
 const char *px4_get_taskname(void)


### PR DESCRIPTION
Use libc procedures to exit, kill and ask for process name, instead of fiddling around with the tcb directly.
