### PR TITLE
Test disable additional mavlink

### DIFF
--- a/boards/px4/fmu-v5x/init/rc.board_mavlink
+++ b/boards/px4/fmu-v5x/init/rc.board_mavlink
@@ -21,4 +21,4 @@ then
 fi
 
 # Start MC maintenance mavlink to ethernet interface
-mavlink start -c 192.168.200.100 -u 14543 -o 14542 -r 2000000 -m magic -x
+#mavlink start -c 192.168.200.100 -u 14543 -o 14542 -r 2000000 -m magic -x


### PR DESCRIPTION
Mavlink issues with latest px4 firmware. Need to test whether this additional mavlink instance causes the connection breaks.