### PR TITLE
boards/fmuv5/x: Fix multiple alignment issues

### DIFF
--- a/boards/px4/fmu-v5/nuttx-config/scripts/script.ld
+++ b/boards/px4/fmu-v5/nuttx-config/scripts/script.ld
@@ -104,20 +104,20 @@ SECTIONS
 	PROVIDE(_boot_signature = 0);
 
 	/* Make a hole for the ToC and signature */
-	toc (NOLOAD) : {
+	.toc (NOLOAD) : {
 		*(.main_toc)
 		*(.main_toc_sig)
 		FILL(0xff);
-		. = ALIGN(8);
+		. = ALIGN(0x1000);
 	} > FLASH_AXIM
 
 	.vectors : {
 		_stext = ABSOLUTE(.);
 		*(.vectors)
+		. = ALIGN(32);
 	} > FLASH_AXIM
 
 	.text : {
-		. = ALIGN(32);
 		/*
 		This signature provides the bootloader with a way to delay booting
 		*/

--- a/boards/px4/fmu-v5/nuttx-config/scripts/toc.ld
+++ b/boards/px4/fmu-v5/nuttx-config/scripts/toc.ld
@@ -35,7 +35,7 @@ SECTIONS
         KEEP(*(.main_toc));
         /* Padd the rest */
         FILL(0xff);
-        . = ALIGN(8);
+        . = 0x1000 - 64;
         _toc_end = ABSOLUTE(.);
     } > progmem
 
@@ -51,6 +51,7 @@ SECTIONS
         /* The application firmware payload */
         _app_start = ABSOLUTE(.);
         *(.firmware)
+        . = ALIGN(4);
         _app_end = ABSOLUTE(.);
     } > progmem
 

--- a/boards/px4/fmu-v5x/nuttx-config/scripts/script.ld
+++ b/boards/px4/fmu-v5x/nuttx-config/scripts/script.ld
@@ -104,20 +104,20 @@ SECTIONS
 	PROVIDE(_boot_signature = 0);
 
 	/* Make a hole for the ToC and signature */
-	toc (NOLOAD) : {
+	.toc (NOLOAD) : {
 		*(.main_toc)
 		*(.main_toc_sig)
 		FILL(0xff);
-		. = ALIGN(8);
+		. = ALIGN(0x1000);
 	} > FLASH_AXIM
 
 	.vectors : {
 		_stext = ABSOLUTE(.);
 		*(.vectors)
+		. = ALIGN(32);
 	} > FLASH_AXIM
 
 	.text : {
-		. = ALIGN(32);
 		/*
 		This signature provides the bootloader with a way to delay booting
 		*/

--- a/boards/px4/fmu-v5x/nuttx-config/scripts/toc.ld
+++ b/boards/px4/fmu-v5x/nuttx-config/scripts/toc.ld
@@ -35,7 +35,7 @@ SECTIONS
         KEEP(*(.main_toc));
         /* Padd the rest */
         FILL(0xff);
-        . = ALIGN(8);
+        . = 0x1000 - 64;
         _toc_end = ABSOLUTE(.);
     } > progmem
 
@@ -51,6 +51,7 @@ SECTIONS
         /* The application firmware payload */
         _app_start = ABSOLUTE(.);
         *(.firmware)
+        . = ALIGN(4);
         _app_end = ABSOLUTE(.);
     } > progmem
 


### PR DESCRIPTION
- The vector table needs to be aligned correctly, depends on the amount of interrupts. 4K should be enough for this target.
- Padd the firmware to the correct size, the signature must start at a 4B alignment.
- The firmware end address needs to be aligned as well, because the calculated signature size is the firmware size + the additional padding