### PR TITLE
px4_platform_common/atomic.h: fetch_add/sub were really fetch_inc/dec

### DIFF
--- a/platforms/common/include/px4_platform_common/atomic.h
+++ b/platforms/common/include/px4_platform_common/atomic.h
@@ -128,7 +128,8 @@ public:
 
 		if (!__atomic_always_lock_free(sizeof(T), 0)) {
 			irqstate_t flags = enter_critical_section();
-			T ret = _value++;
+			T ret = _value;
+			_value += num;
 			leave_critical_section(flags);
 			return ret;
 
@@ -149,7 +150,8 @@ public:
 
 		if (!__atomic_always_lock_free(sizeof(T), 0)) {
 			irqstate_t flags = enter_critical_section();
-			T ret = _value--;
+			T ret = _value;
+			_value -= num;
 			leave_critical_section(flags);
 			return ret;
 


### PR DESCRIPTION
fetch_add/sub were not really inc/dec for the __atomic_always_lock_free == true branch. This fixes them so that the arg "num" is actually used.