### PR TITLE
pwm_esc.cpp: Replace direct call to task_delete()

### DIFF
--- a/src/drivers/pwm_esc/pwm_esc.cpp
+++ b/src/drivers/pwm_esc/pwm_esc.cpp
@@ -245,7 +245,7 @@ PWMESC::~PWMESC()
 
 	/* well, kill it anyway, though this will probably crash */
 	if (_task != -1) {
-		task_delete(_task);
+		px4_task_delete(_task);
 	}
 
 	/* deallocate perfs */


### PR DESCRIPTION
task_delete() API is not always available, so forward the call to px4_task_delete() which knows what to do.
