### PR TITLE
px4_platform_common/atomic.h: Use IRQ locks only when REALLY needed

### DIFF
--- a/src/drivers/imu/analog_devices/adis16448/ADIS16448.hpp
+++ b/src/drivers/imu/analog_devices/adis16448/ADIS16448.hpp
@@ -51,7 +51,7 @@
 #include <uORB/topics/sensor_baro.h>
 #include <lib/geo/geo.h>
 #include <lib/perf/perf_counter.h>
-#include <px4_platform_common/atomic.h>
+#include <px4_platform_common/atomic_from_isr.h>
 #include <px4_platform_common/i2c_spi_buses.h>
 
 using namespace Analog_Devices_ADIS16448;
@@ -114,7 +114,7 @@ private:
 	hrt_abstime _last_config_check_timestamp{0};
 	int _failure_count{0};
 
-	px4::atomic<hrt_abstime> _drdy_timestamp_sample{0};
+	px4::atomic_from_isr<hrt_abstime> _drdy_timestamp_sample{0};
 	bool _data_ready_interrupt_enabled{false};
 
 	bool _check_crc{false}; // CRC-16 not supported on earlier models (eg ADIS16448AMLZ)

--- a/src/drivers/imu/analog_devices/adis16470/ADIS16470.hpp
+++ b/src/drivers/imu/analog_devices/adis16470/ADIS16470.hpp
@@ -48,7 +48,7 @@
 #include <lib/drivers/gyroscope/PX4Gyroscope.hpp>
 #include <lib/geo/geo.h>
 #include <lib/perf/perf_counter.h>
-#include <px4_platform_common/atomic.h>
+#include <px4_platform_common/atomic_from_isr.h>
 #include <px4_platform_common/i2c_spi_buses.h>
 
 using namespace Analog_Devices_ADIS16470;
@@ -107,7 +107,7 @@ private:
 	hrt_abstime _last_config_check_timestamp{0};
 	int _failure_count{0};
 
-	px4::atomic<hrt_abstime> _drdy_timestamp_sample{0};
+	px4::atomic_from_isr<hrt_abstime> _drdy_timestamp_sample{0};
 	bool _data_ready_interrupt_enabled{false};
 
 	bool _self_test_passed{false};

--- a/src/drivers/imu/bosch/bmi055/BMI055.hpp
+++ b/src/drivers/imu/bosch/bmi055/BMI055.hpp
@@ -36,6 +36,7 @@
 #include <drivers/drv_hrt.h>
 #include <lib/drivers/device/spi.h>
 #include <lib/perf/perf_counter.h>
+#include <px4_platform_common/atomic_from_isr.h>
 #include <px4_platform_common/i2c_spi_buses.h>
 
 static constexpr int16_t combine(uint8_t msb, uint8_t lsb) { return (msb << 8u) | lsb; }
@@ -66,7 +67,7 @@ protected:
 	hrt_abstime _temperature_update_timestamp{0};
 	int _failure_count{0};
 
-	px4::atomic<hrt_abstime> _drdy_timestamp_sample{0};
+	px4::atomic_from_isr<hrt_abstime> _drdy_timestamp_sample{0};
 	bool _data_ready_interrupt_enabled{false};
 
 	enum class STATE : uint8_t {

--- a/src/drivers/imu/bosch/bmi088/BMI088.hpp
+++ b/src/drivers/imu/bosch/bmi088/BMI088.hpp
@@ -36,6 +36,7 @@
 #include <drivers/drv_hrt.h>
 #include <lib/drivers/device/spi.h>
 #include <lib/perf/perf_counter.h>
+#include <px4_platform_common/atomic_from_isr.h>
 #include <px4_platform_common/i2c_spi_buses.h>
 
 static constexpr int16_t combine(uint8_t msb, uint8_t lsb) { return (msb << 8u) | lsb; }
@@ -66,7 +67,7 @@ protected:
 	hrt_abstime _temperature_update_timestamp{0};
 	int _failure_count{0};
 
-	px4::atomic<hrt_abstime> _drdy_timestamp_sample{0};
+	px4::atomic_from_isr<hrt_abstime> _drdy_timestamp_sample{0};
 	bool _data_ready_interrupt_enabled{false};
 
 	enum class STATE : uint8_t {

--- a/src/drivers/imu/bosch/bmi088_i2c/BMI088.hpp
+++ b/src/drivers/imu/bosch/bmi088_i2c/BMI088.hpp
@@ -36,6 +36,7 @@
 #include <drivers/drv_hrt.h>
 #include <lib/drivers/device/i2c.h>
 #include <lib/perf/perf_counter.h>
+#include <px4_platform_common/atomic_from_isr.h>
 #include <px4_platform_common/i2c_spi_buses.h>
 
 static constexpr int16_t combine(uint8_t msb, uint8_t lsb) { return (msb << 8u) | lsb; }
@@ -72,7 +73,7 @@ protected:
 	int _total_failure_count{0};
 
 
-	px4::atomic<hrt_abstime> _drdy_timestamp_sample{0};
+	px4::atomic_from_isr<hrt_abstime> _drdy_timestamp_sample{0};
 	bool _data_ready_interrupt_enabled{false};
 
 	enum class STATE : uint8_t {

--- a/src/drivers/imu/invensense/icm20602/ICM20602.hpp
+++ b/src/drivers/imu/invensense/icm20602/ICM20602.hpp
@@ -48,7 +48,7 @@
 #include <lib/drivers/gyroscope/PX4Gyroscope.hpp>
 #include <lib/geo/geo.h>
 #include <lib/perf/perf_counter.h>
-#include <px4_platform_common/atomic.h>
+#include <px4_platform_common/atomic_from_isr.h>
 #include <px4_platform_common/i2c_spi_buses.h>
 
 using namespace InvenSense_ICM20602;
@@ -140,7 +140,7 @@ private:
 	hrt_abstime _last_config_check_timestamp{0};
 	int _failure_count{0};
 
-	px4::atomic<hrt_abstime> _drdy_timestamp_sample{0};
+	px4::atomic_from_isr<hrt_abstime> _drdy_timestamp_sample{0};
 	bool _data_ready_interrupt_enabled{false};
 
 	enum class STATE : uint8_t {

--- a/src/drivers/imu/invensense/icm20608g/ICM20608G.hpp
+++ b/src/drivers/imu/invensense/icm20608g/ICM20608G.hpp
@@ -48,7 +48,7 @@
 #include <lib/drivers/gyroscope/PX4Gyroscope.hpp>
 #include <lib/geo/geo.h>
 #include <lib/perf/perf_counter.h>
-#include <px4_platform_common/atomic.h>
+#include <px4_platform_common/atomic_from_isr.h>
 #include <px4_platform_common/i2c_spi_buses.h>
 
 using namespace InvenSense_ICM20608G;
@@ -138,7 +138,7 @@ private:
 	hrt_abstime _temperature_update_timestamp{0};
 	int _failure_count{0};
 
-	px4::atomic<hrt_abstime> _drdy_timestamp_sample{0};
+	px4::atomic_from_isr<hrt_abstime> _drdy_timestamp_sample{0};
 	int32_t _drdy_count{0};
 	bool _data_ready_interrupt_enabled{false};
 

--- a/src/drivers/imu/invensense/icm20649/ICM20649.hpp
+++ b/src/drivers/imu/invensense/icm20649/ICM20649.hpp
@@ -48,7 +48,7 @@
 #include <lib/drivers/gyroscope/PX4Gyroscope.hpp>
 #include <lib/geo/geo.h>
 #include <lib/perf/perf_counter.h>
-#include <px4_platform_common/atomic.h>
+#include <px4_platform_common/atomic_from_isr.h>
 #include <px4_platform_common/i2c_spi_buses.h>
 
 using namespace InvenSense_ICM20649;
@@ -152,7 +152,7 @@ private:
 
 	enum REG_BANK_SEL_BIT _last_register_bank {REG_BANK_SEL_BIT::USER_BANK_0};
 
-	px4::atomic<hrt_abstime> _drdy_timestamp_sample{0};
+	px4::atomic_from_isr<hrt_abstime> _drdy_timestamp_sample{0};
 	int32_t _drdy_count{0};
 	bool _data_ready_interrupt_enabled{false};
 

--- a/src/drivers/imu/invensense/icm20689/ICM20689.hpp
+++ b/src/drivers/imu/invensense/icm20689/ICM20689.hpp
@@ -48,7 +48,7 @@
 #include <lib/drivers/gyroscope/PX4Gyroscope.hpp>
 #include <lib/geo/geo.h>
 #include <lib/perf/perf_counter.h>
-#include <px4_platform_common/atomic.h>
+#include <px4_platform_common/atomic_from_isr.h>
 #include <px4_platform_common/i2c_spi_buses.h>
 
 using namespace InvenSense_ICM20689;
@@ -138,7 +138,7 @@ private:
 	hrt_abstime _temperature_update_timestamp{0};
 	int _failure_count{0};
 
-	px4::atomic<hrt_abstime> _drdy_timestamp_sample{0};
+	px4::atomic_from_isr<hrt_abstime> _drdy_timestamp_sample{0};
 	int32_t _drdy_count{0};
 	bool _data_ready_interrupt_enabled{false};
 

--- a/src/drivers/imu/invensense/icm20948/ICM20948.hpp
+++ b/src/drivers/imu/invensense/icm20948/ICM20948.hpp
@@ -48,7 +48,7 @@
 #include <lib/drivers/gyroscope/PX4Gyroscope.hpp>
 #include <lib/geo/geo.h>
 #include <lib/perf/perf_counter.h>
-#include <px4_platform_common/atomic.h>
+#include <px4_platform_common/atomic_from_isr.h>
 #include <px4_platform_common/i2c_spi_buses.h>
 
 #include "ICM20948_AK09916.hpp"
@@ -169,7 +169,7 @@ private:
 
 	enum REG_BANK_SEL_BIT _last_register_bank {REG_BANK_SEL_BIT::USER_BANK_0};
 
-	px4::atomic<hrt_abstime> _drdy_timestamp_sample{0};
+	px4::atomic_from_isr<hrt_abstime> _drdy_timestamp_sample{0};
 	int32_t _drdy_count{0};
 	bool _data_ready_interrupt_enabled{false};
 

--- a/src/drivers/imu/invensense/icm40609d/ICM40609D.hpp
+++ b/src/drivers/imu/invensense/icm40609d/ICM40609D.hpp
@@ -48,7 +48,7 @@
 #include <lib/drivers/gyroscope/PX4Gyroscope.hpp>
 #include <lib/geo/geo.h>
 #include <lib/perf/perf_counter.h>
-#include <px4_platform_common/atomic.h>
+#include <px4_platform_common/atomic_from_isr.h>
 #include <px4_platform_common/i2c_spi_buses.h>
 
 using namespace InvenSense_ICM40609D;
@@ -146,7 +146,7 @@ private:
 
 	enum REG_BANK_SEL_BIT _last_register_bank {REG_BANK_SEL_BIT::USER_BANK_0};
 
-	px4::atomic<hrt_abstime> _drdy_timestamp_sample{0};
+	px4::atomic_from_isr<hrt_abstime> _drdy_timestamp_sample{0};
 	bool _data_ready_interrupt_enabled{false};
 
 	enum class STATE : uint8_t {

--- a/src/drivers/imu/invensense/icm42605/ICM42605.hpp
+++ b/src/drivers/imu/invensense/icm42605/ICM42605.hpp
@@ -48,7 +48,7 @@
 #include <lib/drivers/gyroscope/PX4Gyroscope.hpp>
 #include <lib/geo/geo.h>
 #include <lib/perf/perf_counter.h>
-#include <px4_platform_common/atomic.h>
+#include <px4_platform_common/atomic_from_isr.h>
 #include <px4_platform_common/i2c_spi_buses.h>
 
 using namespace InvenSense_ICM42605;
@@ -146,7 +146,7 @@ private:
 
 	enum REG_BANK_SEL_BIT _last_register_bank {REG_BANK_SEL_BIT::USER_BANK_0};
 
-	px4::atomic<hrt_abstime> _drdy_timestamp_sample{0};
+	px4::atomic_from_isr<hrt_abstime> _drdy_timestamp_sample{0};
 	bool _data_ready_interrupt_enabled{false};
 
 	enum class STATE : uint8_t {

--- a/src/drivers/imu/invensense/icm42670p/ICM42670P.hpp
+++ b/src/drivers/imu/invensense/icm42670p/ICM42670P.hpp
@@ -47,7 +47,7 @@
 #include <lib/drivers/device/spi.h>
 #include <lib/drivers/gyroscope/PX4Gyroscope.hpp>
 #include <lib/perf/perf_counter.h>
-#include <px4_platform_common/atomic.h>
+#include <px4_platform_common/atomic_from_isr.h>
 #include <px4_platform_common/i2c_spi_buses.h>
 
 using namespace InvenSense_ICM42670P;
@@ -151,7 +151,7 @@ private:
 
 	enum REG_BANK_SEL_BIT _last_register_bank {REG_BANK_SEL_BIT::USER_BANK_0};
 
-	px4::atomic<uint32_t> _drdy_fifo_read_samples{0};
+	px4::atomic_from_isr<hrt_abstime> _drdy_timestamp_sample{0};
 	bool _data_ready_interrupt_enabled{false};
 
 	enum class STATE : uint8_t {

--- a/src/drivers/imu/invensense/icm42688p/ICM42688P.hpp
+++ b/src/drivers/imu/invensense/icm42688p/ICM42688P.hpp
@@ -48,7 +48,7 @@
 #include <lib/drivers/gyroscope/PX4Gyroscope.hpp>
 #include <lib/geo/geo.h>
 #include <lib/perf/perf_counter.h>
-#include <px4_platform_common/atomic.h>
+#include <px4_platform_common/atomic_from_isr.h>
 #include <px4_platform_common/i2c_spi_buses.h>
 
 using namespace InvenSense_ICM42688P;
@@ -158,7 +158,7 @@ private:
 
 	enum REG_BANK_SEL_BIT _last_register_bank {REG_BANK_SEL_BIT::USER_BANK_0};
 
-	px4::atomic<hrt_abstime> _drdy_timestamp_sample{0};
+	px4::atomic_from_isr<hrt_abstime> _drdy_timestamp_sample{0};
 	bool _data_ready_interrupt_enabled{false};
 
 	enum class STATE : uint8_t {

--- a/src/drivers/imu/invensense/mpu6000/MPU6000.hpp
+++ b/src/drivers/imu/invensense/mpu6000/MPU6000.hpp
@@ -48,7 +48,7 @@
 #include <lib/drivers/gyroscope/PX4Gyroscope.hpp>
 #include <lib/geo/geo.h>
 #include <lib/perf/perf_counter.h>
-#include <px4_platform_common/atomic.h>
+#include <px4_platform_common/atomic_from_isr.h>
 #include <px4_platform_common/i2c_spi_buses.h>
 
 using namespace InvenSense_MPU6000;
@@ -140,7 +140,7 @@ private:
 	FIFO::DATA _fifo_sample_last_new_accel{};
 	uint32_t _fifo_accel_samples_count{0};
 
-	px4::atomic<hrt_abstime> _drdy_timestamp_sample{0};
+	px4::atomic_from_isr<hrt_abstime> _drdy_timestamp_sample{0};
 	int32_t _drdy_count{0};
 	bool _data_ready_interrupt_enabled{false};
 

--- a/src/drivers/imu/invensense/mpu6500/MPU6500.hpp
+++ b/src/drivers/imu/invensense/mpu6500/MPU6500.hpp
@@ -48,7 +48,7 @@
 #include <lib/drivers/gyroscope/PX4Gyroscope.hpp>
 #include <lib/geo/geo.h>
 #include <lib/perf/perf_counter.h>
-#include <px4_platform_common/atomic.h>
+#include <px4_platform_common/atomic_from_isr.h>
 #include <px4_platform_common/i2c_spi_buses.h>
 
 using namespace InvenSense_MPU6500;
@@ -138,7 +138,7 @@ private:
 	hrt_abstime _temperature_update_timestamp{0};
 	int _failure_count{0};
 
-	px4::atomic<hrt_abstime> _drdy_timestamp_sample{0};
+	px4::atomic_from_isr<hrt_abstime> _drdy_timestamp_sample{0};
 	int32_t _drdy_count{0};
 	bool _data_ready_interrupt_enabled{false};
 

--- a/src/drivers/imu/invensense/mpu9250/MPU9250.hpp
+++ b/src/drivers/imu/invensense/mpu9250/MPU9250.hpp
@@ -48,7 +48,7 @@
 #include <lib/drivers/gyroscope/PX4Gyroscope.hpp>
 #include <lib/geo/geo.h>
 #include <lib/perf/perf_counter.h>
-#include <px4_platform_common/atomic.h>
+#include <px4_platform_common/atomic_from_isr.h>
 #include <px4_platform_common/i2c_spi_buses.h>
 
 #include "MPU9250_AK8963.hpp"
@@ -150,7 +150,7 @@ private:
 	hrt_abstime _temperature_update_timestamp{0};
 	int _failure_count{0};
 
-	px4::atomic<hrt_abstime> _drdy_timestamp_sample{0};
+	px4::atomic_from_isr<hrt_abstime> _drdy_timestamp_sample{0};
 	int32_t _drdy_count{0};
 	bool _data_ready_interrupt_enabled{false};
 

--- a/src/drivers/imu/invensense/mpu9250/MPU9250_I2C.hpp
+++ b/src/drivers/imu/invensense/mpu9250/MPU9250_I2C.hpp
@@ -48,7 +48,7 @@
 #include <lib/drivers/gyroscope/PX4Gyroscope.hpp>
 #include <lib/geo/geo.h>
 #include <lib/perf/perf_counter.h>
-#include <px4_platform_common/atomic.h>
+#include <px4_platform_common/atomic_from_isr.h>
 #include <px4_platform_common/i2c_spi_buses.h>
 
 using namespace InvenSense_MPU9250;
@@ -136,7 +136,7 @@ private:
 	hrt_abstime _temperature_update_timestamp{0};
 	int _failure_count{0};
 
-	px4::atomic<hrt_abstime> _drdy_timestamp_sample{0};
+	px4::atomic_from_isr<hrt_abstime> _drdy_timestamp_sample{0};
 	int32_t _drdy_count{0};
 	bool _data_ready_interrupt_enabled{false};
 


### PR DESCRIPTION
Use IRQ locking only when the atomic access is performed from IRQs

(part 2)