### PR TITLE
cdc_acm_check: Remove it from KERNEL_SRCS

### DIFF
--- a/platforms/nuttx/src/px4/common/CMakeLists.txt
+++ b/platforms/nuttx/src/px4/common/CMakeLists.txt
@@ -38,7 +38,6 @@ if(NOT PX4_BOARD MATCHES "io-v2")
 		board_crashdump.c
 		board_dma_alloc.c
 		board_fat_dma_alloc.c
-		cdc_acm_check.cpp
 		console_buffer.cpp
 		cpuload.cpp
 		gpio.c


### PR DESCRIPTION
This clearly belongs to user space, only