### PR TITLE
PX4 NuttX kernel mode build part 0.1

### DIFF
--- a/platforms/nuttx/CMakeLists.txt
+++ b/platforms/nuttx/CMakeLists.txt
@@ -96,6 +96,19 @@ else()
 	endif()
 endif()
 
+# Select the correct linker script(s) for build type
+if (CONFIG_BUILD_FLAT)
+	set(LDSCRIPT ${NUTTX_CONFIG_DIR}/scripts/${SCRIPT_PREFIX}script.ld)
+elseif (CONFIG_BUILD_PROTECTED)
+	set(LDMEMORY ${NUTTX_CONFIG_DIR}/scripts/${SCRIPT_PREFIX}memory.ld)
+	set(LDSCRIPT ${LDMEMORY},--script=${NUTTX_CONFIG_DIR}/scripts/${SCRIPT_PREFIX}user-space.ld)
+	set(LDKERNEL ${LDMEMORY},--script=${NUTTX_CONFIG_DIR}/scripts/${SCRIPT_PREFIX}kernel-space.ld)
+elseif (CONFIG_BUILD_KERNEL)
+	set(LDKERNEL ${NUTTX_CONFIG_DIR}/scripts/${SCRIPT_PREFIX}kernel.ld)
+else()
+	message(FATAL_ERROR "Cannot determine linker script for build type")
+endif()
+
 list(APPEND nuttx_libs
 	nuttx_boards
 	nuttx_drivers
@@ -168,7 +181,7 @@ if (NOT CONFIG_BUILD_FLAT)
 		-fno-exceptions
 		-fno-rtti
 
-		-Wl,--script=${NUTTX_CONFIG_DIR}/scripts/${SCRIPT_PREFIX}memory.ld,--script=${NUTTX_CONFIG_DIR}/scripts/${SCRIPT_PREFIX}kernel-space.ld
+		-Wl,--script=${LDKERNEL}
 
 		-Wl,-Map=${PX4_CONFIG}_kernel.map
 		-Wl,--warn-common
@@ -214,7 +227,7 @@ if (NOT CONFIG_BUILD_FLAT)
 		-fno-exceptions
 		-fno-rtti
 
-		-Wl,--script=${NUTTX_CONFIG_DIR}/scripts/${SCRIPT_PREFIX}memory.ld,--script=${NUTTX_CONFIG_DIR}/scripts/${SCRIPT_PREFIX}user-space.ld
+		-Wl,--script=${LDSCRIPT}
 
 		-Wl,-Map=${PX4_CONFIG}.map
 		-Wl,--warn-common
@@ -268,7 +281,7 @@ else()
 		-fno-exceptions
 		-fno-rtti
 		${RISCV_RELAXATIONS}
-		-Wl,--script=${NUTTX_CONFIG_DIR_CYG}/scripts/${SCRIPT_PREFIX}script.ld
+		-Wl,--script=${LDSCRIPT}
 		-Wl,-Map=${PX4_CONFIG}.map
 		-Wl,--warn-common
 		-Wl,--gc-sections

--- a/platforms/nuttx/CMakeLists.txt
+++ b/platforms/nuttx/CMakeLists.txt
@@ -36,6 +36,7 @@ if(POLICY CMP0079)
 endif()
 
 include(cygwin_cygpath)
+include(bin_romfs)
 
 add_executable(px4 ${PX4_SOURCE_DIR}/platforms/common/empty.c)
 if (CONFIG_OPENSBI AND "${PX4_BOARD_LABEL}" STREQUAL "bootloader")
@@ -105,6 +106,7 @@ elseif (CONFIG_BUILD_PROTECTED)
 	set(LDKERNEL ${LDMEMORY},--script=${NUTTX_CONFIG_DIR}/scripts/${SCRIPT_PREFIX}kernel-space.ld)
 elseif (CONFIG_BUILD_KERNEL)
 	set(LDKERNEL ${NUTTX_CONFIG_DIR}/scripts/${SCRIPT_PREFIX}kernel.ld)
+	set(LDSCRIPT ${NUTTX_CONFIG_DIR}/scripts/${SCRIPT_PREFIX}gnu-elf.ld)
 else()
 	message(FATAL_ERROR "Cannot determine linker script for build type")
 endif()
@@ -217,6 +219,81 @@ if (NOT CONFIG_BUILD_FLAT)
 
 	target_link_libraries(nuttx_c INTERFACE nuttx_proxies)
 
+if (CONFIG_BUILD_KERNEL)
+
+	add_dependencies(px4 nuttx_startup nuttx_nsh)
+
+	list(APPEND px4_initlibs
+		nuttx_nsh
+		nuttx_crt0
+		px4_layer
+		px4_platform
+		px4_work_queue
+		uORB
+	)
+
+	target_link_libraries(px4 PRIVATE
+
+		-nostartfiles
+		-nodefaultlibs
+		-nostdlib
+		-nostdinc++
+
+		-fno-exceptions
+		-fno-rtti
+
+		-Wl,--script=${LDSCRIPT}
+		-Wl,--entry=_start
+		-Wl,-r
+		-Wl,-Bstatic
+		-Wl,-Map=${PX4_CONFIG}.map
+		-Wl,--warn-common
+		-Wl,--gc-sections
+
+		-Wl,--start-group
+		${px4_initlibs}
+		${nuttx_userspace}
+		-Wl,--end-group
+
+		m
+		gcc
+	)
+
+	# Create the initial boot ROMFS
+	add_custom_target(boot_bins
+		COMMAND cp ${PX4_BINARY_DIR_REL}/${FW_NAME} ${PX4_BINARY_DIR}/init
+		COMMAND install -D ${PX4_BINARY_DIR}/init -t ${PX4_BINARY_DIR}/boot
+		COMMAND rm -f ${PX4_BINARY_DIR}/init
+		DEPENDS px4
+	)
+
+	make_bin_romfs(
+		BINDIR ${PX4_BINARY_DIR}/boot
+		OUTDIR ${NUTTX_CONFIG_DIR}/include
+		OUTPREFIX boot
+		LABEL Px4BootVol
+		STRIPPED "y"
+		DEPS boot_bins
+	)
+
+
+	# Create the /bin ROMFS
+	make_bin_romfs(
+		BINDIR ${PX4_BINARY_DIR}/bin
+		OUTDIR ${NUTTX_CONFIG_DIR}/include
+		OUTPREFIX bin
+		LABEL Px4BinVol
+		STRIPPED "y"
+		DEPS nuttx_app_bins
+	)
+
+	add_custom_command(OUTPUT ${PX4_BINARY_OUTPUT}
+		COMMAND ${CMAKE_OBJCOPY} -O binary ${PX4_BINARY_DIR_REL}/${KERNEL_NAME} ${PX4_BINARY_OUTPUT}
+		DEPENDS px4_kernel
+	)
+
+else() # CONFIG_BUILD_PROTECTED
+
 	target_link_libraries(px4 PRIVATE
 
 		-nostartfiles
@@ -255,7 +332,9 @@ if (NOT CONFIG_BUILD_FLAT)
 		DEPENDS px4 px4_kernel
 	)
 
-else()
+endif()
+
+else() # CONFIG_BUILD_FLAT
 
 	target_link_libraries(nuttx_c INTERFACE nuttx_sched) # nxsched_get_streams
 

--- a/platforms/nuttx/NuttX/CMakeLists.txt
+++ b/platforms/nuttx/NuttX/CMakeLists.txt
@@ -71,7 +71,6 @@ add_custom_command(
 )
 add_custom_target(nuttx_context DEPENDS ${NUTTX_DIR}/include/nuttx/config.h)
 
-
 # builtins
 set(builtin_apps_string)
 set(builtin_apps_decl_string)
@@ -210,6 +209,70 @@ endif()
 
 if(CONFIG_NET)
 	add_nuttx_dir(net net y -D__KERNEL__ all)
+endif()
+
+if (CONFIG_BUILD_KERNEL)
+	include(bin_romfs)
+
+	# For modules in kernel mode, we need the startup object files (crt0)
+	add_custom_command(OUTPUT ${PX4_BINARY_DIR}/startup/crt0.o
+		COMMAND mkdir -p ${PX4_BINARY_DIR}/startup
+		COMMAND make -C arch/${CONFIG_ARCH}/src export_startup --no-print-directory --silent
+			TOPDIR="${NUTTX_DIR}"
+			EXPORT_DIR="${PX4_BINARY_DIR}" > ${CMAKE_CURRENT_BINARY_DIR}/nuttx_startup.log
+		DEPENDS nuttx_context
+		WORKING_DIRECTORY ${NUTTX_DIR}
+	)
+	add_custom_target(nuttx_startup DEPENDS ${PX4_BINARY_DIR}/startup/crt0.o)
+	add_library(nuttx_crt0 OBJECT IMPORTED GLOBAL)
+	set_property(TARGET nuttx_crt0 PROPERTY IMPORTED_OBJECTS ${PX4_BINARY_DIR}/startup/crt0.o)
+
+	# We also need to manually compile nsh_main.c, note that must wait for
+	# nuttx_apps_build because it wipes ALL OBJECT FILES without thinking
+	configure_file(${CMAKE_CURRENT_SOURCE_DIR}/Make.nsh.in ${CMAKE_CURRENT_BINARY_DIR}/apps/Make.nsh)
+
+	add_custom_command(OUTPUT ${PX4_BINARY_DIR}/nsh/nsh_main.o
+		COMMAND ${CMAKE_COMMAND} -E copy_if_different ${CMAKE_CURRENT_BINARY_DIR}/apps/Make.nsh ${APPS_DIR}/Make.nsh
+		COMMAND mkdir -p ${PX4_BINARY_DIR}/nsh
+		COMMAND make -f Make.nsh --no-print-directory --silent
+			TOPDIR="${NUTTX_DIR}"
+			NSH_TOPDIR="${APPS_DIR}"
+			NHS_OBJDIR="${PX4_BINARY_DIR}/nsh" > ${CMAKE_CURRENT_BINARY_DIR}/nsh_build.log
+		DEPENDS nuttx_context nuttx_apps_build
+		WORKING_DIRECTORY ${APPS_DIR}
+	)
+	add_custom_target(nuttx_nsh_build DEPENDS ${PX4_BINARY_DIR}/nsh/nsh_main.o)
+	add_library(nuttx_nsh OBJECT IMPORTED GLOBAL)
+	set_property(TARGET nuttx_nsh PROPERTY IMPORTED_OBJECTS ${PX4_BINARY_DIR}/nsh/nsh_main.o)
+
+	# Build and install the NuttX applications into build/xx/bin
+	set(LDSCRIPT ${NUTTX_CONFIG_DIR}/scripts/${SCRIPT_PREFIX}gnu-elf.ld)
+
+	list(APPEND nuttx_userlibs
+		nuttx_apps
+		nuttx_mm
+		nuttx_proxies
+		nuttx_c
+		nuttx_xx
+	)
+
+	foreach(lib ${nuttx_userlibs})
+		get_property(lib_location TARGET ${lib} PROPERTY IMPORTED_LOCATION)
+		list(APPEND userlibs ${lib_location})
+	endforeach(lib)
+
+	get_property(CRT0_OBJ TARGET nuttx_crt0 PROPERTY IMPORTED_OBJECTS)
+
+	add_custom_target(nuttx_app_bins
+		COMMAND mkdir -p ${PX4_BINARY_DIR}/bin
+		COMMAND make -C ${NUTTX_SRC_DIR}/apps install --no-print-directory --silent
+			ARCHCRT0OBJ="${CRT0_OBJ}"
+			BINDIR="${PX4_BINARY_DIR}/bin"
+			TOPDIR="${NUTTX_DIR}"
+			ELFLDNAME="${LDSCRIPT}"
+			USERLIBS="${userlibs}" > ${CMAKE_CURRENT_BINARY_DIR}/nuttx_apps_install.log
+		DEPENDS ${nuttx_userlibs} nuttx_startup
+	)
 endif()
 
 ###############################################################################

--- a/platforms/nuttx/NuttX/Make.defs.in
+++ b/platforms/nuttx/NuttX/Make.defs.in
@@ -93,15 +93,17 @@ else
    MAXOPTIMIZATION = -Os
 endif
 
-FLAGS = $(MAXOPTIMIZATION) -g2 \
+ARCHOPTIMIZATION = $(MAXOPTIMIZATION) \
+	-g2 \
 	-fdata-sections \
 	-ffunction-sections \
 	-fno-builtin-printf \
 	-fno-common \
 	-fno-strength-reduce \
 	-fno-strict-aliasing \
-	-fomit-frame-pointer \
-	-Wall \
+	-fomit-frame-pointer
+
+FLAGS = -Wall \
 	-Werror \
 	-Wextra \
 	-Wlogical-op \
@@ -127,9 +129,7 @@ ifeq ($(CONFIG_ARMV7M_STACKCHECK),y)
 	FLAGS += -finstrument-functions -ffixed-r10
 endif
 
-CFLAGS = $(ARCHINCLUDES) \
-	-std=gnu11 \
-	${CMAKE_C_FLAGS} \
+ARCHCFLAGS = -std=gnu11 \
 	$(FLAGS) \
 	-Wno-bad-function-cast \
 	-Wno-float-equal \
@@ -146,10 +146,10 @@ CFLAGS = $(ARCHINCLUDES) \
 	-Wno-type-limits \
 	${CMAKE_C_COMP_DEP_FLAGS}
 
-CXXFLAGS = $(ARCHXXINCLUDES) \
-	-std=c++14 \
+ARCHCPUFLAGS = ${CMAKE_C_FLAGS}
+
+ARCHCXXFLAGS = 	-std=c++14 \
 	-nostdinc++ \
-	${CMAKE_CXX_FLAGS} \
 	$(FLAGS) \
 	-fcheck-new \
 	-fno-builtin \
@@ -160,6 +160,8 @@ CXXFLAGS = $(ARCHXXINCLUDES) \
 	-Wno-double-promotion \
 	-Wno-missing-declarations
 
+CFLAGS = $(ARCHINCLUDES) $(ARCHCFLAGS) $(ARCHCPUFLAGS) $(ARCHOPTIMIZATION)
+CXXFLAGS = $(ARCHXXINCLUDES) $(ARCHCXXFLAGS) $(ARCHCPUFLAGS) $(ARCHOPTIMIZATION)
 CPPFLAGS = $(ARCHINCLUDES) $(ARCHDEFINES) $(EXTRAFLAGS)
 AFLAGS = $(CFLAGS) -D__ASSEMBLY__
 
@@ -183,3 +185,18 @@ endef
 define ARCHIVE
     $(AR) $1 $(2)
 endef
+
+# ELF module definitions
+
+CELFFLAGS = $(CFLAGS)
+CXXELFFLAGS = $(CXXFLAGS)
+
+# ELF linkage
+
+LDSTARTGROUP = --start-group
+LDENDGROUP   = --end-group
+LDLIBPATH = $(foreach PATH, $(USERLIBS), $(addprefix -L, $(dir $(PATH))))
+LDLIBFILES = $(foreach PATH, $(USERLIBS), $(notdir $(PATH)))
+LDLIBS = $(patsubst %.a,%,$(patsubst lib%,-l%,$(LDLIBFILES)))
+LDELFFLAGS = -r -e _start -Bstatic
+LDELFFLAGS += $(addprefix -T, $(ELFLDNAME))

--- a/platforms/nuttx/NuttX/Make.nsh.in
+++ b/platforms/nuttx/NuttX/Make.nsh.in
@@ -1,0 +1,56 @@
+############################################################################
+#
+#   Copyright (c) 2022 Technology Innovation Institute. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+# 1. Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in
+#    the documentation and/or other materials provided with the
+#    distribution.
+# 3. Neither the name PX4 nor the names of its contributors may be
+#    used to endorse or promote products derived from this software
+#    without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+# OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+# AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+# ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+#
+############################################################################
+
+# Rule to make nsh_main
+
+export APPDIR = $(CURDIR)
+include $(APPDIR)/Make.defs
+
+all:: system_nsh
+
+NSH_SRCS := $(shell find $(APPDIR)/ -name "nsh_main.c" -type f)
+NSH_OBJS := $(NSH_SRCS:.c=$(OBJEXT))
+
+system_nsh: $(NSH_OBJS)
+ifneq ($(NSH_OBJS),)
+	$(Q) if [ -d "$(NHS_OBJDIR)" ]; then \
+		cp -f $(NSH_OBJS) "$(NHS_OBJDIR)/."; \
+	 else \
+		echo "$(NHS_OBJDIR) does not exist"; \
+		exit 1; \
+	fi
+endif
+
+$(NSH_OBJS): %$(OBJEXT): %.c
+	$(eval $<_CFLAGS += $(shell $(DEFINE) "$(CC)" main=nsh_main))
+	$(call COMPILE, $<, $@)

--- a/platforms/nuttx/cmake/bin_romfs.cmake
+++ b/platforms/nuttx/cmake/bin_romfs.cmake
@@ -1,0 +1,126 @@
+############################################################################
+#
+#   Copyright (c) 2022 Technology Innovation Institute. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+# 1. Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in
+#    the documentation and/or other materials provided with the
+#    distribution.
+# 3. Neither the name PX4 nor the names of its contributors may be
+#    used to endorse or promote products derived from this software
+#    without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+# OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+# AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+# ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+#
+############################################################################
+
+#=============================================================================
+#
+#	make_bin_romfs
+#
+#	This function creates a ROMFS from the input binary directory and places
+#	the generated C-style header into the specified output directory. To
+#	reduce the ROMFS size, an option is given to strip the input files, which
+#	reduces their size considerably
+#
+#	Usage:
+#		make_bin_romfs(
+#			BINDIR <string>
+#			OUTDIR <string>
+#			OUTPREFIX <string>
+#			LABEL <string>
+#			STRIPPED <string>
+#			DEPS <list>
+#		)
+#
+#	Input:
+#		BINDIR		: Input binary directory (source for ROMFS)
+#		OUTDIR  	: Output directory (${OUTPREFIX}_romfs.h is placed here)
+#		OUTPREFIX	: Prefix for the output file
+#		LABEL		: Volume label
+#		STRIPPED	: Set to 'y' to strip the input binaries
+#		DEPS		: Dependencies for the ROMFS
+#
+#	Output:
+#		${OUTPREFIX}_romfs.h file, that can be added to any C-source file.
+#		Mounting as a ROM-disk will be trivial once this is done.
+#
+function(make_bin_romfs)
+
+	px4_parse_function_args(
+		NAME make_bin_romfs
+		ONE_VALUE BINDIR OUTDIR OUTPREFIX LABEL STRIPPED
+		MULTI_VALUE DEPS
+		REQUIRED BINDIR OUTDIR OUTPREFIX DEPS
+		ARGN ${ARGN}
+	)
+
+	if (NOT STRIPPED)
+		set(STRIPPED "n")
+	endif()
+
+	if (NOT LABEL)
+		set(LABEL "NuttXRomfsVol")
+	endif()
+
+	# Strip the elf files to reduce romfs image size
+
+	if (${STRIPPED} STREQUAL "y")
+		add_custom_command(OUTPUT ${OUTPREFIX}_stripped_bins
+			COMMAND for f in * \; do if [ -f "$$f" ]; then ${CMAKE_STRIP} $$f --strip-unneeded \; fi \; done
+			DEPENDS ${DEPS}
+			WORKING_DIRECTORY ${BINDIR}
+		)
+	else()
+		add_custom_command(OUTPUT ${OUTPREFIX}_stripped_bins
+			COMMAND touch ${BINDIR}
+		)
+	endif()
+
+	# Make sure we have what we need
+
+	find_program(GENROMFS genromfs)
+	if(NOT GENROMFS)
+		message(FATAL_ERROR "genromfs not found")
+	endif()
+
+	find_program(XXD xxd)
+	if(NOT XXD)
+		message(FATAL_ERROR "xxd not found")
+	endif()
+
+	find_program(SED sed)
+	if(NOT SED)
+		message(FATAL_ERROR "sed not found")
+	endif()
+
+	# Generate the ROM file system
+
+	add_custom_command(OUTPUT ${OUTDIR}/${OUTPREFIX}_romfsimg.h
+		COMMAND ${GENROMFS} -f ${OUTPREFIX}_romfs.img -d ${BINDIR} -V "${LABEL}"
+		COMMAND ${XXD} -i ${OUTPREFIX}_romfs.img |
+				${SED} 's/^unsigned char/const unsigned char/g' >${OUTPREFIX}_romfsimg.h
+		COMMAND mv ${OUTPREFIX}_romfsimg.h ${OUTDIR}/${OUTPREFIX}_romfsimg.h
+		COMMAND rm -f ${OUTPREFIX}_romfs.img
+		DEPENDS ${OUTDIR} ${DEPS} ${OUTPREFIX}_stripped_bins
+	)
+	add_custom_target(${OUTPREFIX}_rofmsimg DEPENDS ${OUTDIR}/${OUTPREFIX}_romfsimg.h)
+
+endfunction()

--- a/platforms/nuttx/src/px4/common/board_ioctl.c
+++ b/platforms/nuttx/src/px4/common/board_ioctl.c
@@ -42,14 +42,20 @@
 #include <px4_platform/board_ctrl.h>
 #include "board_config.h"
 
-#include <nuttx/lib/builtin.h>
 #include <NuttX/kernel_builtin/kernel_builtin_proto.h>
 
-FAR const struct builtin_s g_kernel_builtins[] = {
+struct kernel_builtin_s {
+	const char *name;         /* Invocation name and as seen under /sbin/ */
+	int         priority;     /* Use: SCHED_PRIORITY_DEFAULT */
+	int         stacksize;    /* Desired stack size */
+	main_t      main;         /* Entry point: main(int argc, char *argv[]) */
+};
+
+const struct kernel_builtin_s g_kernel_builtins[] = {
 #include <NuttX/kernel_builtin/kernel_builtin_list.h>
 };
 
-const int g_n_kernel_builtins = sizeof(g_kernel_builtins) / sizeof(struct builtin_s);
+const int g_n_kernel_builtins = sizeof(g_kernel_builtins) / sizeof(g_kernel_builtins[0]);
 
 static struct {
 	ioctl_ptr_t ioctl_func;
@@ -107,7 +113,7 @@ int board_ioctl(unsigned int cmd, uintptr_t arg)
 static int launch_kernel_builtin(int argc, char **argv)
 {
 	int i;
-	FAR const struct builtin_s *builtin = NULL;
+	const struct kernel_builtin_s *builtin = NULL;
 
 	for (i = 0; i < g_n_kernel_builtins; i++) {
 		if (!strcmp(g_kernel_builtins[i].name, argv[0])) {


### PR DESCRIPTION
Add a skeleton to enable building PX4 as a set of processes on NuttX with CONFIG_BUILD_KERNEL=y

The result is a bootable ROMFS which is placed into the kernel binary and mounted into /sbin by the board initialization logic. The kernel knows the mount point and starts the user space from /sbin/init, which is the nsh shell.
