### PR TITLE
Changed value of parameter MPC_TAKEOFF_RAMP_T to 0 in both outdoor an…

### DIFF
--- a/ROMFS/px4fmu_common/init.d/airframes/4400_ssrc_fog_x
+++ b/ROMFS/px4fmu_common/init.d/airframes/4400_ssrc_fog_x
@@ -62,3 +62,6 @@ param set-default GPS_SAT_INFO 1
 
 # Set sticks movement not to switch to RC, we use mode switch for this
 param set-default COM_RC_OVERRIDE 0
+
+# Set takeoff ramp to disabled for a more decisive takeoff action
+param set-default MPC_TKO_RAMP_T 0

--- a/ssrc_config/config_indoor.txt
+++ b/ssrc_config/config_indoor.txt
@@ -41,9 +41,6 @@ param set MPC_XY_CRUISE 2.0
 # Track trajectory more aggressively (default 0.5)
 param set MPC_XY_TRAJ_P 0.7
 
-# Make it accelerate faster upwards at takeoff
-param set MPC_TKO_RAMP_T 1.0
-
 # Limit upward movement speed for safety
 param set MPC_Z_VEL_MAX_UP 1.0
 


### PR DESCRIPTION
**Describe problem solved by this pull request**
Takeoff parameter change to both indoor and outdoor configuration

**Describe your solution**
Changed airframe config and config_indoor.txt so that the parameter MPC_TKO_RAMP_T is always at value 0
