### PR TITLE
T-Motor M690B airframe

### DIFF
--- a/ROMFS/px4fmu_common/init.d/airframes/4401_ssrc_fog_x_tmotor
+++ b/ROMFS/px4fmu_common/init.d/airframes/4401_ssrc_fog_x_tmotor
@@ -1,0 +1,67 @@
+#!/bin/sh
+#
+# @name SSRC Quad X on T-Motor M690 series
+#
+# @type Quadrotor x
+# @class Copter
+#
+# @maintainer Jukka Laitinen <jukkax@ssrc.tii.ae>
+#
+# @board px4_fmu-v2 exclude
+# @board bitcraze_crazyflie exclude
+#
+
+. /etc/init.d/rc.mc_defaults
+
+set MIXER quad_x
+set PWM_OUT 1234
+
+# Default rates
+param set-default IMU_GYRO_CUTOFF 60
+param set-default IMU_DGYRO_CUTOFF 30
+param set-default MC_ROLLRATE_P 0.14
+param set-default MC_PITCHRATE_P 0.14
+param set-default MC_ROLLRATE_I 0.3
+param set-default MC_PITCHRATE_I 0.3
+param set-default MC_ROLLRATE_D 0.004
+param set-default MC_PITCHRATE_D 0.004
+
+# Increase velocity controller P gain
+param set-default MPC_XY_VEL_P_ACC 2.4
+
+# Battery parameters
+param set-default BAT1_N_CELLS 4
+param set-default BAT1_V_CHARGED 4.2
+param set-default BAT1_V_EMPTY 3.6
+param set-default BAT1_V_DIV 18.1
+
+# Enable ethernet for PX4<->MC
+param set-default RTPS_MAV_CONFIG 0
+
+# Enable LL40LS in i2c
+param set-default SENS_EN_LL40LS 2
+
+# LEDs on TELEMETRY 1
+param set-default SER_TEL1_BAUD 57600
+param set-default MAV_1_CONFIG 101
+param set-default MAV_1_MODE 7
+param set-default MAV_1_RATE 1000
+
+# Disable MAV_0 and MAV_2
+param set-default MAV_0_CONFIG 0
+param set-default MAV_2_CONFIG 0
+
+# Enable safety switch
+param set-default CBRK_IO_SAFETY 0
+
+# Set default for disarm after land to 4s
+param set-default COM_DISARM_LAND 4.0
+
+# Enable satellite info by default
+param set-default GPS_SAT_INFO 1
+
+# Set sticks movement not to switch to RC, we use mode switch for this
+param set-default COM_RC_OVERRIDE 0
+
+# Change current sense shunt resistor value
+param set-default INA226_SHUNT 0.00025

--- a/ROMFS/px4fmu_common/init.d/airframes/CMakeLists.txt
+++ b/ROMFS/px4fmu_common/init.d/airframes/CMakeLists.txt
@@ -90,6 +90,7 @@ px4_add_romfs_files(
 	4090_nanomind
 	4100_tiltquadrotor
 	4400_ssrc_fog_x
+	4401_ssrc_fog_x_tmotor
 	4500_clover4
 	4900_crazyflie
 	4901_crazyflie21


### PR DESCRIPTION
Create initial T-Motor M690B airframe by cloning the SSRC holybro X500 configuration

The T-Motor power management HW does not provide the I2C output that Pixhawk 5X needs for current sensing. Create a new airframe config that specifies the correct value for the INA226_SHUNT parameter. Add airframe to 'CMakeLists.txt'.
