### PR TITLE
Add mavlink ip address params

### DIFF
--- a/src/modules/mavlink/mavlink_main.cpp
+++ b/src/modules/mavlink/mavlink_main.cpp
@@ -1854,7 +1854,7 @@ Mavlink::task_main(int argc, char *argv[])
 	int temp_int_arg;
 #endif
 
-	while ((ch = px4_getopt(argc, argv, "b:r:d:n:u:o:m:t:c:fswxzZp", &myoptind, &myoptarg)) != EOF) {
+	while ((ch = px4_getopt(argc, argv, "b:r:d:n:u:o:m:t:i:c:fswxzZp", &myoptind, &myoptarg)) != EOF) {
 		switch (ch) {
 		case 'b':
 			if (px4_get_parameter_value(myoptarg, _baudrate) != 0) {
@@ -1955,6 +1955,31 @@ Mavlink::task_main(int argc, char *argv[])
 
 			break;
 
+		case 'i': {
+				_src_addr.sin_family = AF_INET;
+				int mav_id = atoi(myoptarg);
+				char tmp_str[32];
+				uint8_t digits[4] = {0,0,0,0};
+				for (int i=0; i<4; i++) {
+					snprintf(tmp_str, 32, "p:MAV_%d_REMOTE_IP%d", mav_id, i);
+					int ret = px4_get_parameter_value(tmp_str, temp_int_arg);
+					if (!ret) {
+						digits[i] = (uint8_t)(temp_int_arg & 0xff);
+					} else {
+						PX4_ERR("parse_ip: cant parse %s -> %d", tmp_str, ret);
+					}
+				}
+
+				snprintf(tmp_str, 32, "%d.%d.%d.%d", digits[0], digits[1], digits[2], digits[3]);
+				if (inet_aton(tmp_str, &_src_addr.sin_addr)) {
+					PX4_INFO("UDP mavlink remote address: %s", tmp_str);
+					_src_addr_initialized = true;
+				} else {
+					PX4_ERR("invalid partner ip '%s'", tmp_str);
+					err_flag = true;
+				}
+			}
+			break;
 #else
 
 		case 'p':
@@ -3265,6 +3290,7 @@ $ mavlink stream -u 14556 -s HIGHRES_IMU -r 50
 	PRINT_MODULE_USAGE_PARAM_FLAG('p', "Enable Broadcast", true);
 	PRINT_MODULE_USAGE_PARAM_INT('u', 14556, 0, 65536, "Select UDP Network Port (local)", true);
 	PRINT_MODULE_USAGE_PARAM_INT('o', 14550, 0, 65536, "Select UDP Network Port (remote)", true);
+	PRINT_MODULE_USAGE_PARAM_INT('i', 0, 0, 3, "Partner IP from MAV_<x>_REMOTE_IPn params, where <x> is the argument value", true);
 	PRINT_MODULE_USAGE_PARAM_STRING('t', "127.0.0.1", nullptr, "Partner IP (broadcasting can be enabled via -p flag)", true);
 #endif
 	PRINT_MODULE_USAGE_PARAM_STRING('m', "normal", "custom|camera|onboard|osd|magic|config|iridium|minimal|extvision|extvisionmin|gimbal",

--- a/src/modules/mavlink/module.yaml
+++ b/src/modules/mavlink/module.yaml
@@ -15,6 +15,26 @@ serial_config:
             then
                 set MAV_ARGS "${MAV_ARGS} -c"
             fi
+            set USE_REMOTE_IP 0
+            if param greater MAV_${i}_REMOTE_IP0 0
+            then
+                set USE_REMOTE_IP 1
+            fi
+            if param greater MAV_${i}_REMOTE_IP1 0
+            then
+                set USE_REMOTE_IP 1
+            fi
+            if param greater MAV_${i}_REMOTE_IP2 0
+            then
+                set USE_REMOTE_IP 1
+            fi
+            if param greater MAV_${i}_REMOTE_IP3 0
+            then
+                set USE_REMOTE_IP 1
+            fi
+            if [ ${USE_REMOTE_IP} != 0 ]; then
+                set MAV_ARGS "${MAV_ARGS} -i ${i}"
+            fi
         fi
         if param compare MAV_${i}_FORWARD 1
         then
@@ -176,3 +196,63 @@ parameters:
                 2: Auto-detected
             num_instances: *max_num_config_instances
             default: [2, 2, 2]
+
+        MAV_${i}_REMOTE_IP0:
+            description:
+                short: MAVLink 1st digit of Remote IP Address for instance ${i}
+                long: |
+                    If ethernet enabled and selected as configuration for MAVLink instance ${i},
+                    selected 1st digit of remote ip address will be set and used in MAVLink instance ${i}.
+
+            type: int32
+            min: 0
+            max: 255
+            reboot_required: true
+            num_instances: *max_num_config_instances
+            default: [0, 0, 0]
+            requires_ethernet: true
+
+        MAV_${i}_REMOTE_IP1:
+            description:
+                short: MAVLink 2nd digit of Remote IP Address for instance ${i}
+                long: |
+                    If ethernet enabled and selected as configuration for MAVLink instance ${i},
+                    selected 2nd digit of remote ip address will be set and used in MAVLink instance ${i}.
+
+            type: int32
+            min: 0
+            max: 255
+            reboot_required: true
+            num_instances: *max_num_config_instances
+            default: [0, 0, 0]
+            requires_ethernet: true
+
+        MAV_${i}_REMOTE_IP2:
+            description:
+                short: MAVLink 3rd digit of Remote IP Address for instance ${i}
+                long: |
+                    If ethernet enabled and selected as configuration for MAVLink instance ${i},
+                    selected 3rd digit of remote ip address will be set and used in MAVLink instance ${i}.
+
+            type: int32
+            min: 0
+            max: 255
+            reboot_required: true
+            num_instances: *max_num_config_instances
+            default: [0, 0, 0]
+            requires_ethernet: true
+
+        MAV_${i}_REMOTE_IP3:
+            description:
+                short: MAVLink 4th digit of Remote IP Address for instance ${i}
+                long: |
+                    If ethernet enabled and selected as configuration for MAVLink instance ${i},
+                    selected 4th digit of remote ip address will be set and used in MAVLink instance ${i}.
+
+            type: int32
+            min: 0
+            max: 255
+            reboot_required: true
+            num_instances: *max_num_config_instances
+            default: [0, 0, 0]
+            requires_ethernet: true


### PR DESCRIPTION
Add MAV_x_REMOTE_IPn params to define partner IP for mavlink instance.
param is used when MAV_x_CONFIG is 1000 (UDP mavlink)
Support for '-i <x>' flag added to mavlink start command. It reads IP address from MAV_<x>_REMOTE_IPn params.
e.g. mavlink start -i 2  => read partner ip address from MAV_2_REMOTE_IP0..3
