### PR TITLE
px4/userspace: Minor fixes for the px4 userspace

### DIFF
--- a/platforms/nuttx/src/px4/common/px4_protected_layers.cmake
+++ b/platforms/nuttx/src/px4/common/px4_protected_layers.cmake
@@ -11,7 +11,6 @@ add_library(px4_layer
 	${PX4_SOURCE_DIR}/platforms/posix/src/px4/common/cpuload.cpp
 	px4_userspace_init.cpp
 	px4_usr_crypto.cpp
-	px4_mtd.cpp
 	usr_atomic.cpp
 	usr_board_ctrl.c
 	usr_hrt.cpp

--- a/platforms/nuttx/src/px4/common/px4_userspace_init.cpp
+++ b/platforms/nuttx/src/px4/common/px4_userspace_init.cpp
@@ -41,6 +41,7 @@
 #include <lib/parameters/param.h>
 #include <px4_platform_common/px4_work_queue/WorkQueueManager.hpp>
 #include <px4_platform_common/spi.h>
+#include <px4_platform_common/log.h>
 #include <uORB/uORB.h>
 #include <sys/boardctl.h>
 
@@ -55,6 +56,8 @@ extern "C" void px4_userspace_init(void)
 	px4::WorkQueueManagerStart();
 
 	uorb_start();
+
+	px4_log_initialize();
 
 #if defined(CONFIG_SYSTEM_CDCACM)
 	cdcacm_init();

--- a/src/systemcmds/mtd/Kconfig
+++ b/src/systemcmds/mtd/Kconfig
@@ -6,7 +6,7 @@ menuconfig SYSTEMCMDS_MTD
 
 menuconfig USER_MTD
 	bool "mtd running as userspace module"
-	default y
+	default n
 	depends on BOARD_PROTECTED && SYSTEMCMDS_MTD
 	---help---
 		Put mtd in userspace memory


### PR DESCRIPTION
- Remove mtd, it can't be used from userspace anyway
- Initialize logger, no idea why this was not done before