### PR TITLE
Changed filter config to work with saluki single soc x500 frame

### DIFF
--- a/ROMFS/px4fmu_common/init.d/airframes/4400_ssrc_fog_x
+++ b/ROMFS/px4fmu_common/init.d/airframes/4400_ssrc_fog_x
@@ -14,7 +14,8 @@
 . /etc/init.d/rc.mc_defaults
 
 # Default rates
-param set-default IMU_GYRO_CUTOFF 60
+param set-default IMU_GYRO_CUTOFF 30
+param set-default IMU_GYRO_NF0 75
 param set-default IMU_DGYRO_CUTOFF 30
 param set-default MC_ROLLRATE_P 0.14
 param set-default MC_PITCHRATE_P 0.14
@@ -41,6 +42,12 @@ param set-default PWM_MAIN_FUNC1 101
 param set-default PWM_MAIN_FUNC2 102
 param set-default PWM_MAIN_FUNC3 103
 param set-default PWM_MAIN_FUNC4 104
+
+# Set minimum PWM control values
+param set-default PWM_MAIN_MIN1 1050
+param set-default PWM_MAIN_MIN2 1050
+param set-default PWM_MAIN_MIN3 1050
+param set-default PWM_MAIN_MIN4 1050
 
 # Increase velocity controller P gain
 param set-default MPC_XY_VEL_P_ACC 2.4

--- a/ROMFS/px4fmu_common/init.d/airframes/4400_ssrc_fog_x
+++ b/ROMFS/px4fmu_common/init.d/airframes/4400_ssrc_fog_x
@@ -15,7 +15,7 @@
 
 # Default rates
 param set-default IMU_GYRO_CUTOFF 30
-param set-default IMU_GYRO_NF0 75
+param set-default IMU_GYRO_NF0_FRQ 75
 param set-default IMU_DGYRO_CUTOFF 30
 param set-default MC_ROLLRATE_P 0.14
 param set-default MC_PITCHRATE_P 0.14


### PR DESCRIPTION
1. Changed filter configuration to solve vibration problem when using lighter x500 configuration without MC and rplidar.
2.Added PWM_MAIN_MIN* values of 1050