### PR TITLE
Fix print_load to be compatible with upstream NuttX

### DIFF
--- a/platforms/nuttx/src/px4/common/print_load.cpp
+++ b/platforms/nuttx/src/px4/common/print_load.cpp
@@ -202,14 +202,14 @@ void print_load_buffer(char *buffer, int buffer_length, print_load_callback_f cb
 
 		if (system_load.tasks[i].tcb->pid == 0) {
 			stack_size = (CONFIG_ARCH_INTERRUPTSTACK & ~3);
-			stack_free = up_check_intstack_remain();
+			stack_free = (CONFIG_ARCH_INTERRUPTSTACK & ~3) - up_check_intstack();
 
 		} else {
-			stack_free = up_check_tcbstack_remain(system_load.tasks[i].tcb);
+			stack_free = system_load.tasks[i].tcb->adj_stack_size - up_check_tcbstack(system_load.tasks[i].tcb);
 		}
 
 #else
-		stack_free = up_check_tcbstack_remain(system_load.tasks[i].tcb);
+		stack_free = system_load.tasks[i].tcb->adj_stack_size - up_check_tcbstack(system_load.tasks[i].tcb);
 #endif
 
 #if CONFIG_ARCH_BOARD_SIM || !defined(CONFIG_PRIORITY_INHERITANCE)

--- a/src/modules/load_mon/LoadMon.cpp
+++ b/src/modules/load_mon/LoadMon.cpp
@@ -259,7 +259,8 @@ void LoadMon::stack_usage()
 
 	if (system_load.tasks[_stack_task_index].valid && (system_load.tasks[_stack_task_index].tcb->pid > 0)) {
 
-		stack_free = up_check_tcbstack_remain(system_load.tasks[_stack_task_index].tcb);
+		stack_free = system_load.tasks[_stack_task_index].tcb->adj_stack_size - up_check_tcbstack(
+				     system_load.tasks[_stack_task_index].tcb);
 
 		strncpy((char *)task_stack_info.task_name, system_load.tasks[_stack_task_index].tcb->name, CONFIG_TASK_NAME_SIZE - 1);
 		task_stack_info.task_name[CONFIG_TASK_NAME_SIZE - 1] = '\0';


### PR DESCRIPTION
This solves a problem with further nuttx update, where some nuttx internal functions have been removed.
