### PR TITLE
nuttx/load_mon: Fix call to user-space mallinfo()

### DIFF
--- a/src/modules/load_mon/LoadMon.cpp
+++ b/src/modules/load_mon/LoadMon.cpp
@@ -226,7 +226,7 @@ void LoadMon::cpuload()
 	cpuload.load = interval_spent_time / interval;
 #elif defined(__PX4_NUTTX)
 	// get ram usage
-	struct mallinfo mem = mallinfo();
+	struct mallinfo mem = kmm_mallinfo();
 	cpuload.ram_usage = (float)mem.uordblks / mem.arena;
 	cpuload.load = 1.f - interval_idletime / interval;
 #endif

--- a/src/modules/load_mon/LoadMon.hpp
+++ b/src/modules/load_mon/LoadMon.hpp
@@ -34,7 +34,7 @@
 #pragma once
 
 #if defined(__PX4_NUTTX)
-#include <malloc.h>
+#include <kmalloc.h>
 #endif
 #include <drivers/drv_hrt.h>
 #include <lib/perf/perf_counter.h>


### PR DESCRIPTION
Use kmm_mallinfo() instead, querying for user space memory usage does not work in BUILD_KERNEL.