### PR TITLE
launch_kmod: Small adjustments to code in preparation for CONFIG_BUILD_KERNEL

### DIFF
--- a/platforms/nuttx/src/px4/common/board_ioctl.c
+++ b/platforms/nuttx/src/px4/common/board_ioctl.c
@@ -42,6 +42,8 @@
 #include <px4_platform/board_ctrl.h>
 #include "board_config.h"
 
+#include <libgen.h>
+
 #include <NuttX/kernel_builtin/kernel_builtin_proto.h>
 
 struct kernel_builtin_s {
@@ -114,9 +116,10 @@ static int launch_kernel_builtin(int argc, char **argv)
 {
 	int i;
 	const struct kernel_builtin_s *builtin = NULL;
+	char *name = basename(argv[0]);
 
 	for (i = 0; i < g_n_kernel_builtins; i++) {
-		if (!strcmp(g_kernel_builtins[i].name, argv[0])) {
+		if (!strcmp(g_kernel_builtins[i].name, name)) {
 			builtin = &g_kernel_builtins[i];
 			break;
 		}

--- a/platforms/nuttx/src/px4/common/board_ioctl.c
+++ b/platforms/nuttx/src/px4/common/board_ioctl.c
@@ -42,14 +42,20 @@
 #include <px4_platform/board_ctrl.h>
 #include "board_config.h"
 
-#include <nuttx/lib/builtin.h>
 #include <NuttX/kernel_builtin/kernel_builtin_proto.h>
 
-FAR const struct builtin_s g_kernel_builtins[] = {
+struct kernel_builtin_s {
+	const char *name;         /* Invocation name and as seen under /sbin/ */
+	int         priority;     /* Use: SCHED_PRIORITY_DEFAULT */
+	int         stacksize;    /* Desired stack size */
+	main_t      main;         /* Entry point: main(int argc, char *argv[]) */
+};
+
+const struct kernel_builtin_s g_kernel_builtins[] = {
 #include <NuttX/kernel_builtin/kernel_builtin_list.h>
 };
 
-const int g_n_kernel_builtins = sizeof(g_kernel_builtins) / sizeof(struct builtin_s);
+const int g_n_kernel_builtins = sizeof(g_kernel_builtins) / sizeof(g_kernel_builtins[0]);
 
 static struct {
 	ioctl_ptr_t ioctl_func;
@@ -107,7 +113,7 @@ int board_ioctl(unsigned int cmd, uintptr_t arg)
 static int launch_kernel_builtin(int argc, char **argv)
 {
 	int i;
-	FAR const struct builtin_s *builtin = NULL;
+	const struct kernel_builtin_s *builtin = NULL;
 
 	for (i = 0; i < g_n_kernel_builtins; i++) {
 		if (!strcmp(g_kernel_builtins[i].name, argv[0])) {


### PR DESCRIPTION
lib/builtin is not available if CONFIG_BUILD_KERNEL=y (the K-configurator disables the CONFIG_BUILTIN flag)

argv[0] passes the full path to the process to be launched, but the builtins list only contains the name, thus, use the base name
to launch kernel modules