### PR TITLE
PX4 NuttX kernel mode build

### DIFF
--- a/ROMFS/CMakeLists.txt
+++ b/ROMFS/CMakeLists.txt
@@ -145,6 +145,18 @@ endif()
 # copy extras into ROMFS
 set(extras_dependencies)
 
+# sysinit script for kernel mode
+if(CONFIG_BUILD_KERNEL)
+	add_custom_command(OUTPUT ${romfs_gen_root_dir}/init.d/rc.sysinit
+	COMMAND ${CMAKE_COMMAND} -E copy_if_different ${PX4_BINARY_DIR}/NuttX/rc.sysinit ${romfs_gen_root_dir}/init.d/rc.sysinit
+		DEPENDS
+			${PX4_BINARY_DIR}/NuttX/rc.sysinit
+	)
+	list(APPEND extras_dependencies
+		${romfs_gen_root_dir}/init.d/rc.sysinit
+	)
+endif()
+
 # optional board architecture defaults
 set(board_arch_rc_file "rc.board_arch_defaults")
 if(EXISTS "${PX4_SOURCE_DIR}/platforms/${PX4_PLATFORM}/init/${CONFIG_ARCH_CHIP}/${board_arch_rc_file}")

--- a/platforms/common/uORB/CMakeLists.txt
+++ b/platforms/common/uORB/CMakeLists.txt
@@ -57,9 +57,12 @@ px4_add_library(uORB
 
 if ("${PX4_PLATFORM}" MATCHES "posix")
 	target_link_libraries(uORB PRIVATE rt)
+elseif ("${PX4_PLATFORM}" MATCHES "nuttx")
+	target_link_libraries(uORB PRIVATE nuttx_fs)
 endif()
 
 target_compile_options(uORB PRIVATE ${MAX_CUSTOM_OPT_LEVEL})
+target_link_libraries(uORB PRIVATE uorb_msgs)
 
 if(PX4_TESTING)
 	add_subdirectory(uORB_tests)

--- a/platforms/nuttx/CMakeLists.txt
+++ b/platforms/nuttx/CMakeLists.txt
@@ -234,6 +234,8 @@ if (NOT CONFIG_BUILD_FLAT)
 		)
 
 	target_link_libraries(nuttx_c INTERFACE nuttx_proxies)
+	target_link_libraries(nuttx_c INTERFACE nuttx_mm)
+	target_link_libraries(nuttx_c INTERFACE gcc)
 
 if (CONFIG_BUILD_KERNEL)
 
@@ -292,6 +294,70 @@ if (CONFIG_BUILD_KERNEL)
 		DEPS boot_bins
 	)
 
+	# TODO: The dependencies here are a big mess, figure out if they can be
+	# demangled / handled properly
+	target_link_libraries(perf nuttx_c)
+	target_link_libraries(px4_platform board_bus_info)
+
+	# Build and install the px4 processes
+	foreach(module ${module_libraries})
+		get_target_property(MAIN ${module} MAIN)
+
+		# Don't handle modules that don't have a main (entry) function
+		if (NOT MAIN)
+			continue()
+		endif()
+
+		# Build module.a into module.elf
+		set(BIN px4-${MAIN}.elf)
+		add_executable(${BIN} ${PX4_SOURCE_DIR}/platforms/nuttx/src/px4/common/main.cpp)
+		set_target_properties(${BIN} PROPERTIES OUTPUT_NAME ${BIN})
+		add_dependencies(${BIN} nuttx_crt0 ${module})
+		target_compile_options(${BIN} PRIVATE -Dentry=${MAIN}_main)
+
+		target_link_libraries(${BIN} PRIVATE
+
+			-nostartfiles
+			-nodefaultlibs
+			-nostdlib
+			-nostdinc++
+
+			-fno-exceptions
+			-fno-rtti
+
+			-Wl,--script=${LDSCRIPT}
+			-Wl,--entry=_start
+			-Wl,-r
+			-Wl,-Bstatic
+			-Wl,-Map=${PX4_CONFIG}.map
+			-Wl,--warn-common
+			-Wl,--gc-sections
+
+			-Wl,--start-group
+			nuttx_crt0
+			px4_layer
+			px4_platform
+			px4_work_queue
+			uORB
+			${nuttx_userspace}
+			${module_libraries}
+			-Wl,--end-group
+
+			m
+			gcc
+		)
+
+		# Install the executable to /bin
+		add_custom_target(${BIN}_install
+			COMMAND mkdir -p ${PX4_BINARY_DIR}/bin
+			COMMAND install -D ${PX4_BINARY_DIR}/${BIN} -t ${PX4_BINARY_DIR}/bin
+			COMMAND mv ${PX4_BINARY_DIR}/bin/${BIN} ${PX4_BINARY_DIR}/bin/${MAIN}
+			COMMAND rm -f ${PX4_BINARY_DIR}/${BIN}
+			DEPENDS ${BIN}
+		)
+
+		list(APPEND px4_bins ${BIN}_install)
+	endforeach()
 
 	# Create the /bin ROMFS
 	make_bin_romfs(
@@ -300,7 +366,7 @@ if (CONFIG_BUILD_KERNEL)
 		OUTPREFIX bin
 		LABEL Px4BinVol
 		STRIPPED "y"
-		DEPS nuttx_app_bins
+		DEPS nuttx_app_bins ${px4_bins}
 	)
 
 	add_custom_command(OUTPUT ${PX4_BINARY_OUTPUT}

--- a/platforms/nuttx/CMakeLists.txt
+++ b/platforms/nuttx/CMakeLists.txt
@@ -36,6 +36,7 @@ if(POLICY CMP0079)
 endif()
 
 include(cygwin_cygpath)
+include(bin_romfs)
 
 add_executable(px4 ${PX4_SOURCE_DIR}/platforms/common/empty.c)
 if (CONFIG_OPENSBI AND "${PX4_BOARD_LABEL}" STREQUAL "bootloader")
@@ -113,6 +114,9 @@ elseif (CONFIG_BUILD_PROTECTED)
 	set(LDMEMORY ${NUTTX_CONFIG_DIR}/scripts/${SCRIPT_PREFIX}memory.ld)
 	set(LDSCRIPT ${LDMEMORY},--script=${NUTTX_CONFIG_DIR}/scripts/${SCRIPT_PREFIX}user-space.ld)
 	set(LDKERNEL ${LDMEMORY},--script=${NUTTX_CONFIG_DIR}/scripts/${SCRIPT_PREFIX}kernel-space.ld)
+elseif (CONFIG_BUILD_KERNEL)
+	set(LDKERNEL ${NUTTX_CONFIG_DIR}/scripts/${SCRIPT_PREFIX}kernel.ld)
+	set(LDSCRIPT ${NUTTX_CONFIG_DIR}/scripts/${SCRIPT_PREFIX}gnu-elf.ld)
 else()
 	message(FATAL_ERROR "Cannot determine linker script for build type")
 endif()
@@ -231,6 +235,81 @@ if (NOT CONFIG_BUILD_FLAT)
 
 	target_link_libraries(nuttx_c INTERFACE nuttx_proxies)
 
+if (CONFIG_BUILD_KERNEL)
+
+	add_dependencies(px4 nuttx_startup nuttx_nsh)
+
+	list(APPEND px4_initlibs
+		nuttx_nsh
+		nuttx_crt0
+		px4_layer
+		px4_platform
+		px4_work_queue
+		uORB
+	)
+
+	target_link_libraries(px4 PRIVATE
+
+		-nostartfiles
+		-nodefaultlibs
+		-nostdlib
+		-nostdinc++
+
+		-fno-exceptions
+		-fno-rtti
+
+		-Wl,--script=${LDSCRIPT}
+		-Wl,--entry=_start
+		-Wl,-r
+		-Wl,-Bstatic
+		-Wl,-Map=${PX4_CONFIG}.map
+		-Wl,--warn-common
+		-Wl,--gc-sections
+
+		-Wl,--start-group
+		${px4_initlibs}
+		${nuttx_userspace}
+		-Wl,--end-group
+
+		m
+		gcc
+	)
+
+	# Create the initial boot ROMFS
+	add_custom_target(boot_bins
+		COMMAND cp ${PX4_BINARY_DIR_REL}/${FW_NAME} ${PX4_BINARY_DIR}/init
+		COMMAND install -D ${PX4_BINARY_DIR}/init -t ${PX4_BINARY_DIR}/boot
+		COMMAND rm -f ${PX4_BINARY_DIR}/init
+		DEPENDS px4
+	)
+
+	make_bin_romfs(
+		BINDIR ${PX4_BINARY_DIR}/boot
+		OUTDIR ${NUTTX_CONFIG_DIR}/include
+		OUTPREFIX boot
+		LABEL Px4BootVol
+		STRIPPED "y"
+		DEPS boot_bins
+	)
+
+
+	# Create the /bin ROMFS
+	make_bin_romfs(
+		BINDIR ${PX4_BINARY_DIR}/bin
+		OUTDIR ${NUTTX_CONFIG_DIR}/include
+		OUTPREFIX bin
+		LABEL Px4BinVol
+		STRIPPED "y"
+		DEPS nuttx_app_bins
+	)
+
+	add_custom_command(OUTPUT ${PX4_BINARY_OUTPUT}
+		COMMAND ${CMAKE_OBJCOPY} -O binary ${PX4_BINARY_DIR_REL}/${KERNEL_NAME} ${PX4_BINARY_OUTPUT}
+		DEPENDS px4_kernel
+	)
+
+else() # CONFIG_BUILD_PROTECTED
+
 	target_link_libraries(px4 PRIVATE
 
 		-nostartfiles
@@ -269,7 +348,9 @@ if (NOT CONFIG_BUILD_FLAT)
 		DEPENDS px4 px4_kernel
 	)
 
-else()
+endif()
+
+else() # CONFIG_BUILD_FLAT
 
 	target_link_libraries(nuttx_c INTERFACE nuttx_sched)
 

--- a/platforms/nuttx/CMakeLists.txt
+++ b/platforms/nuttx/CMakeLists.txt
@@ -128,7 +128,6 @@ list(APPEND nuttx_libs
 	nuttx_sched
 	nuttx_crypto
 	nuttx_binfmt
-	nuttx_xx
 	)
 
 if (NOT CONFIG_BUILD_FLAT)
@@ -138,6 +137,7 @@ if (NOT CONFIG_BUILD_FLAT)
 		nuttx_kmm
 		nuttx_stubs
 		nuttx_kc
+		nuttx_kxx
 		)
 else()
 	list(APPEND nuttx_libs
@@ -145,6 +145,7 @@ else()
 		nuttx_arch
 		nuttx_mm
 		nuttx_c
+		nuttx_xx
 		)
 endif()
 

--- a/platforms/nuttx/CMakeLists.txt
+++ b/platforms/nuttx/CMakeLists.txt
@@ -132,7 +132,6 @@ list(APPEND nuttx_libs
 
 if (NOT CONFIG_BUILD_FLAT)
 	list(APPEND nuttx_libs
-		px4_board_ctrl
 		nuttx_karch
 		nuttx_kmm
 		nuttx_stubs
@@ -182,13 +181,22 @@ else()
 	set(PX4_BINARY_OUTPUT ${PX4_BINARY_DIR_REL}/${PX4_CONFIG}.bin)
 endif()
 
+if(NOT "${PX4_BOARD_LABEL}" STREQUAL "bootloader")
+	# Bind init to board logic (TODO move to board?)
+	target_link_libraries(drivers_board PRIVATE px4_init)
+endif()
+
 if (NOT CONFIG_BUILD_FLAT)
 
-	target_link_libraries(nuttx_karch
-		INTERFACE
-			drivers_board
-			arch_hrt
-			)
+	# Common set of libraries, for both user and kernel
+	list(APPEND px4_commonlibs
+		px4_platform
+		perf
+		px4_work_queue
+		uORB
+	)
+
+	target_link_libraries(nuttx_karch INTERFACE arch_hrt)
 
 	target_link_libraries(px4_kernel PRIVATE
 
@@ -207,8 +215,10 @@ if (NOT CONFIG_BUILD_FLAT)
 		-Wl,--gc-sections
 
 		-Wl,--start-group
+			drivers_board
+			px4_kernel_layer
+			${px4_commonlibs}
 			${nuttx_libs}
-			${kernel_module_libraries}
 		-Wl,--end-group
 
 		m
@@ -221,6 +231,10 @@ if (NOT CONFIG_BUILD_FLAT)
 	endif()
 
 	target_link_libraries(px4_kernel PRIVATE -Wl,--print-memory-usage)
+	target_link_libraries(px4_kernel PRIVATE ${kernel_module_libraries})
+
+	# In order to fill kernel_builtins table
+	target_link_libraries(px4_board_ctrl PRIVATE ${kernel_module_libraries})
 
 	set(nuttx_userspace)
 
@@ -394,7 +408,9 @@ else() # CONFIG_BUILD_PROTECTED
 		-Wl,--gc-sections
 
 		-Wl,--start-group
-		${nuttx_userspace}
+			px4_layer
+			${px4_commonlibs}
+			${nuttx_userspace}
 		-Wl,--end-group
 
 		m
@@ -402,10 +418,7 @@ else() # CONFIG_BUILD_PROTECTED
 		)
 
 	target_link_libraries(px4 PRIVATE -Wl,--print-memory-usage)
-
-	target_link_libraries(px4 PRIVATE
-		${module_libraries}
-	)
+	target_link_libraries(px4 PRIVATE ${module_libraries})
 
 	add_custom_command(OUTPUT ${PX4_BINARY_OUTPUT}
 		COMMAND ${CMAKE_OBJCOPY} -O binary ${PX4_BINARY_DIR_REL}/${FW_NAME} ${PX4_BINARY_DIR_REL}/${PX4_BOARD}_user.bin

--- a/platforms/nuttx/CMakeLists.txt
+++ b/platforms/nuttx/CMakeLists.txt
@@ -256,14 +256,8 @@ if (CONFIG_BUILD_KERNEL)
 
 	add_dependencies(px4 nuttx_startup nuttx_nsh)
 
-	list(APPEND px4_initlibs
-		nuttx_nsh
-		nuttx_crt0
-		px4_layer
-		px4_platform
-		px4_work_queue
-		uORB
-	)
+	# Every user space app needs crt0
+	list(APPEND nuttx_userspace nuttx_crt0)
 
 	target_link_libraries(px4 PRIVATE
 
@@ -284,8 +278,8 @@ if (CONFIG_BUILD_KERNEL)
 		-Wl,--gc-sections
 
 		-Wl,--start-group
-		${px4_initlibs}
-		${nuttx_userspace}
+			nuttx_nsh
+			${nuttx_userspace}
 		-Wl,--end-group
 
 		m
@@ -308,11 +302,6 @@ if (CONFIG_BUILD_KERNEL)
 		STRIPPED "y"
 		DEPS boot_bins
 	)
-
-	# TODO: The dependencies here are a big mess, figure out if they can be
-	# demangled / handled properly
-	target_link_libraries(perf nuttx_c)
-	target_link_libraries(px4_platform board_bus_info)
 
 	# Build and install the px4 processes
 	foreach(module ${module_libraries})
@@ -349,18 +338,16 @@ if (CONFIG_BUILD_KERNEL)
 			-Wl,--gc-sections
 
 			-Wl,--start-group
-			nuttx_crt0
-			px4_layer
-			px4_platform
-			px4_work_queue
-			uORB
-			${nuttx_userspace}
-			${module_libraries}
+				px4_layer
+				${px4_commonlibs}
+				${nuttx_userspace}
 			-Wl,--end-group
 
 			m
 			gcc
 		)
+
+		target_link_libraries(${BIN} PRIVATE ${module})
 
 		# Install the executable to /bin
 		add_custom_target(${BIN}_install

--- a/platforms/nuttx/NuttX/CMakeLists.txt
+++ b/platforms/nuttx/NuttX/CMakeLists.txt
@@ -93,6 +93,7 @@ if (NOT CONFIG_BUILD_FLAT)
 	set(kernel_builtin_apps_string)
 	set(kernel_builtin_apps_proxy_string)
 	set(kernel_builtin_apps_decl_string)
+	set(kernel_symlinks_string)
 
 	list(SORT kernel_module_libraries)
 	foreach(module ${kernel_module_libraries})
@@ -104,11 +105,13 @@ if (NOT CONFIG_BUILD_FLAT)
 			set(kernel_builtin_apps_string "${kernel_builtin_apps_string}{ \"${MAIN}\", ${PRIORITY}, ${STACK_MAIN}, ${MAIN}_main },\n")
 			set(kernel_builtin_apps_proxy_string "${kernel_builtin_apps_proxy_string}{ \"${MAIN}\", ${PRIORITY}, ${STACK_MAIN}, launch_kmod_main },\n")
 			set(kernel_builtin_apps_decl_string "${kernel_builtin_apps_decl_string}int ${MAIN}_main(int argc, char *argv[]);\n")
+			set(kernel_symlinks_string "${kernel_symlinks_string}ln -s bin/launch_kmod lnk/${MAIN}\n")
 		endif()
 	endforeach()
 
 	configure_file(${CMAKE_CURRENT_SOURCE_DIR}/px4_kernel.bdat.in ${CMAKE_CURRENT_BINARY_DIR}/px4_kernel.bdat)
 	configure_file(${CMAKE_CURRENT_SOURCE_DIR}/px4_kernel.pdat.in ${CMAKE_CURRENT_BINARY_DIR}/px4_kernel.pdat)
+	configure_file(${CMAKE_CURRENT_SOURCE_DIR}/rc.sysinit.in      ${CMAKE_CURRENT_BINARY_DIR}/rc.sysinit)
 
 	add_custom_command(OUTPUT ${KERNEL_BUILTIN_DIR}/kernel_builtin_list.h ${KERNEL_BUILTIN_DIR}/kernel_builtin_proto.h
 		WORKING_DIRECTORY  ${KERNEL_BUILTIN_DIR}

--- a/platforms/nuttx/NuttX/CMakeLists.txt
+++ b/platforms/nuttx/NuttX/CMakeLists.txt
@@ -159,6 +159,15 @@ function(add_nuttx_dir nuttx_lib nuttx_lib_dir kernel extra target)
 		set(nuttx_lib_target lib${target}.a)
 	endif()
 
+	# Facilitate building kxx, as NuttX kernel should not contain CXX code
+	# and thus does not support creating libkxx natively...
+	# # This is a temporary _HACK_ and should be removed ASAP
+	if(${nuttx_lib} STREQUAL "kxx")
+		set(nuttx_libname "xx")
+	else()
+		set(nuttx_libname ${nuttx_lib})
+	endif()
+
 	file(GLOB_RECURSE nuttx_lib_files LIST_DIRECTORIES false
 		${CMAKE_CURRENT_SOURCE_DIR}/nuttx/${nuttx_lib_dir}/*.c
 		${CMAKE_CURRENT_SOURCE_DIR}/nuttx/${nuttx_lib_dir}/*.h
@@ -168,7 +177,7 @@ function(add_nuttx_dir nuttx_lib nuttx_lib_dir kernel extra target)
 		COMMAND ${CMAKE_COMMAND} -E remove -f ${NUTTX_DIR}/${nuttx_lib_dir}/lib${nuttx_lib}.a
 		COMMAND find ${nuttx_lib_dir} -type f -name \*.o -delete
 		COMMAND make -C ${nuttx_lib_dir} --no-print-directory --silent ${nuttx_lib_target} TOPDIR="${NUTTX_DIR}" KERNEL=${kernel} EXTRAFLAGS=${extra}
-		COMMAND ${CMAKE_COMMAND} -E copy_if_different ${NUTTX_DIR}/${nuttx_lib_dir}/lib${nuttx_lib}.a ${CMAKE_CURRENT_BINARY_DIR}/nuttx/${nuttx_lib_dir}/lib${nuttx_lib}.a
+		COMMAND ${CMAKE_COMMAND} -E copy_if_different ${NUTTX_DIR}/${nuttx_lib_dir}/lib${nuttx_libname}.a ${CMAKE_CURRENT_BINARY_DIR}/nuttx/${nuttx_lib_dir}/lib${nuttx_lib}.a
 		DEPENDS
 			${nuttx_lib_files}
 			nuttx_context ${NUTTX_DIR}/include/nuttx/config.h
@@ -198,6 +207,8 @@ if (NOT CONFIG_BUILD_FLAT)
 	add_nuttx_dir(c libs/libc n "" c)
 	add_dependencies(nuttx_c_build nuttx_kc_build) # can't build these in parallel
 	add_nuttx_dir(kc libs/libc y -D__KERNEL__ kc)
+	add_dependencies(nuttx_xx_build nuttx_kxx_build) # can't build these in parallel
+	add_nuttx_dir(kxx libs/libxx y -D__KERNEL__ all xx)
 	add_nuttx_dir(mm mm n "" mm)
 	add_dependencies(nuttx_mm_build nuttx_kmm_build) # can't build these in parallel
 	add_nuttx_dir(kmm mm y -D__KERNEL__ kmm)

--- a/platforms/nuttx/NuttX/CMakeLists.txt
+++ b/platforms/nuttx/NuttX/CMakeLists.txt
@@ -71,7 +71,6 @@ add_custom_command(
 )
 add_custom_target(nuttx_context DEPENDS ${NUTTX_DIR}/include/nuttx/config.h)
 
-
 # builtins
 set(builtin_apps_string)
 set(builtin_apps_decl_string)
@@ -214,6 +213,70 @@ endif()
 
 if(CONFIG_OPENAMP)
 	add_nuttx_dir(openamp openamp y -D__KERNEL__ all)
+endif()
+
+if (CONFIG_BUILD_KERNEL)
+	include(bin_romfs)
+
+	# For modules in kernel mode, we need the startup object files (crt0)
+	add_custom_command(OUTPUT ${PX4_BINARY_DIR}/startup/crt0.o
+		COMMAND mkdir -p ${PX4_BINARY_DIR}/startup
+		COMMAND make -C arch/${CONFIG_ARCH}/src export_startup --no-print-directory --silent
+			TOPDIR="${NUTTX_DIR}"
+			EXPORT_DIR="${PX4_BINARY_DIR}" > ${CMAKE_CURRENT_BINARY_DIR}/nuttx_startup.log
+		DEPENDS nuttx_context nuttx_arch_build nuttx_karch_build
+		WORKING_DIRECTORY ${NUTTX_DIR}
+	)
+	add_custom_target(nuttx_startup DEPENDS ${PX4_BINARY_DIR}/startup/crt0.o)
+	add_library(nuttx_crt0 OBJECT IMPORTED GLOBAL)
+	set_property(TARGET nuttx_crt0 PROPERTY IMPORTED_OBJECTS ${PX4_BINARY_DIR}/startup/crt0.o)
+
+	# We also need to manually compile nsh_main.c, note that must wait for
+	# nuttx_apps_build because it wipes ALL OBJECT FILES without thinking
+	configure_file(${CMAKE_CURRENT_SOURCE_DIR}/Make.nsh.in ${CMAKE_CURRENT_BINARY_DIR}/apps/Make.nsh)
+
+	add_custom_command(OUTPUT ${PX4_BINARY_DIR}/nsh/nsh_main.o
+		COMMAND ${CMAKE_COMMAND} -E copy_if_different ${CMAKE_CURRENT_BINARY_DIR}/apps/Make.nsh ${APPS_DIR}/Make.nsh
+		COMMAND mkdir -p ${PX4_BINARY_DIR}/nsh
+		COMMAND make -f Make.nsh --no-print-directory --silent
+			TOPDIR="${NUTTX_DIR}"
+			NSH_TOPDIR="${APPS_DIR}"
+			NHS_OBJDIR="${PX4_BINARY_DIR}/nsh" > ${CMAKE_CURRENT_BINARY_DIR}/nsh_build.log
+		DEPENDS nuttx_context nuttx_apps_build
+		WORKING_DIRECTORY ${APPS_DIR}
+	)
+	add_custom_target(nuttx_nsh_build DEPENDS ${PX4_BINARY_DIR}/nsh/nsh_main.o)
+	add_library(nuttx_nsh OBJECT IMPORTED GLOBAL)
+	set_property(TARGET nuttx_nsh PROPERTY IMPORTED_OBJECTS ${PX4_BINARY_DIR}/nsh/nsh_main.o)
+
+	# Build and install the NuttX applications into build/xx/bin
+	set(LDSCRIPT ${NUTTX_CONFIG_DIR}/scripts/${SCRIPT_PREFIX}gnu-elf.ld)
+
+	list(APPEND nuttx_userlibs
+		nuttx_apps
+		nuttx_mm
+		nuttx_proxies
+		nuttx_c
+		nuttx_xx
+	)
+
+	foreach(lib ${nuttx_userlibs})
+		get_property(lib_location TARGET ${lib} PROPERTY IMPORTED_LOCATION)
+		list(APPEND userlibs ${lib_location})
+	endforeach(lib)
+
+	get_property(CRT0_OBJ TARGET nuttx_crt0 PROPERTY IMPORTED_OBJECTS)
+
+	add_custom_target(nuttx_app_bins
+		COMMAND mkdir -p ${PX4_BINARY_DIR}/bin
+		COMMAND make -C ${NUTTX_SRC_DIR}/apps install --no-print-directory --silent
+			ARCHCRT0OBJ="${CRT0_OBJ}"
+			BINDIR="${PX4_BINARY_DIR}/bin"
+			TOPDIR="${NUTTX_DIR}"
+			ELFLDNAME="${LDSCRIPT}"
+			USERLIBS="${userlibs}" > ${CMAKE_CURRENT_BINARY_DIR}/nuttx_apps_install.log
+		DEPENDS ${nuttx_userlibs} nuttx_startup
+	)
 endif()
 
 ###############################################################################

--- a/platforms/nuttx/NuttX/Make.defs.in
+++ b/platforms/nuttx/NuttX/Make.defs.in
@@ -93,15 +93,18 @@ else
    MAXOPTIMIZATION = -Os
 endif
 
-FLAGS = $(MAXOPTIMIZATION) -g2 \
+ARCHOPTIMIZATION = $(MAXOPTIMIZATION) \
+	-g2 \
 	-fdata-sections \
 	-ffunction-sections \
 	-fno-builtin-printf \
 	-fno-common \
 	-fno-strength-reduce \
 	-fno-strict-aliasing \
-	-fomit-frame-pointer \
-	-Wall \
+	-fomit-frame-pointer
+
+FLAGS = -Wall \
+	-Werror \
 	-Wextra \
 	-Wlogical-op \
 	-Wno-cpp \
@@ -126,9 +129,7 @@ ifeq ($(CONFIG_ARMV7M_STACKCHECK),y)
 	FLAGS += -finstrument-functions -ffixed-r10
 endif
 
-CFLAGS = $(ARCHINCLUDES) \
-	-std=gnu11 \
-	${CMAKE_C_FLAGS} \
+ARCHCFLAGS = -std=gnu11 \
 	$(FLAGS) \
 	-Wno-bad-function-cast \
 	-Wno-float-equal \
@@ -145,10 +146,10 @@ CFLAGS = $(ARCHINCLUDES) \
 	-Wno-type-limits \
 	${CMAKE_C_COMP_DEP_FLAGS}
 
-CXXFLAGS = $(ARCHXXINCLUDES) \
-	-std=c++14 \
+ARCHCPUFLAGS = ${CMAKE_C_FLAGS}
+
+ARCHCXXFLAGS = 	-std=c++14 \
 	-nostdinc++ \
-	${CMAKE_CXX_FLAGS} \
 	$(FLAGS) \
 	-fcheck-new \
 	-fno-builtin \
@@ -159,6 +160,8 @@ CXXFLAGS = $(ARCHXXINCLUDES) \
 	-Wno-double-promotion \
 	-Wno-missing-declarations
 
+CFLAGS = $(ARCHINCLUDES) $(ARCHCFLAGS) $(ARCHCPUFLAGS) $(ARCHOPTIMIZATION)
+CXXFLAGS = $(ARCHXXINCLUDES) $(ARCHCXXFLAGS) $(ARCHCPUFLAGS) $(ARCHOPTIMIZATION)
 CPPFLAGS = $(ARCHINCLUDES) $(ARCHDEFINES) $(EXTRAFLAGS)
 AFLAGS = $(CFLAGS) -D__ASSEMBLY__
 
@@ -182,3 +185,18 @@ endef
 define ARCHIVE
     $(AR) $1 $(2)
 endef
+
+# ELF module definitions
+
+CELFFLAGS = $(CFLAGS)
+CXXELFFLAGS = $(CXXFLAGS)
+
+# ELF linkage
+
+LDSTARTGROUP = --start-group
+LDENDGROUP   = --end-group
+LDLIBPATH = $(foreach PATH, $(USERLIBS), $(addprefix -L, $(dir $(PATH))))
+LDLIBFILES = $(foreach PATH, $(USERLIBS), $(notdir $(PATH)))
+LDLIBS = $(patsubst %.a,%,$(patsubst lib%,-l%,$(LDLIBFILES)))
+LDELFFLAGS = -r -e _start -Bstatic
+LDELFFLAGS += $(addprefix -T, $(ELFLDNAME))

--- a/platforms/nuttx/NuttX/Make.nsh.in
+++ b/platforms/nuttx/NuttX/Make.nsh.in
@@ -1,0 +1,56 @@
+############################################################################
+#
+#   Copyright (c) 2022 Technology Innovation Institute. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+# 1. Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in
+#    the documentation and/or other materials provided with the
+#    distribution.
+# 3. Neither the name PX4 nor the names of its contributors may be
+#    used to endorse or promote products derived from this software
+#    without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+# OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+# AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+# ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+#
+############################################################################
+
+# Rule to make nsh_main
+
+export APPDIR = $(CURDIR)
+include $(APPDIR)/Make.defs
+
+all:: system_nsh
+
+NSH_SRCS := $(shell find $(APPDIR)/ -name "nsh_main.c" -type f)
+NSH_OBJS := $(NSH_SRCS:.c=$(OBJEXT))
+
+system_nsh: $(NSH_OBJS)
+ifneq ($(NSH_OBJS),)
+	$(Q) if [ -d "$(NHS_OBJDIR)" ]; then \
+		cp -f $(NSH_OBJS) "$(NHS_OBJDIR)/."; \
+	 else \
+		echo "$(NHS_OBJDIR) does not exist"; \
+		exit 1; \
+	fi
+endif
+
+$(NSH_OBJS): %$(OBJEXT): %.c
+	$(eval $<_CFLAGS += $(shell $(DEFINE) "$(CC)" main=nsh_main))
+	$(call COMPILE, $<, $@)

--- a/platforms/nuttx/NuttX/include/kmalloc.h
+++ b/platforms/nuttx/NuttX/include/kmalloc.h
@@ -1,0 +1,55 @@
+/****************************************************************************
+ *
+ *   Copyright (c) 2023 Technology Innovation Institute. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+#pragma once
+
+/* This file forwards the user space memory API to the kernel versions */
+
+#if !defined(CONFIG_BUILD_FLAT) && defined(__KERNEL__)
+
+#include <nuttx/kmalloc.h>
+
+#undef malloc
+#undef realloc
+#undef free
+#undef mallinfo
+
+#define malloc kmm_malloc
+#define realloc kmm_realloc
+#define free kmm_free
+
+/* struct mallinfo has the same name as the function */
+
+#define mallinfo() kmm_mallinfo()
+
+#endif

--- a/platforms/nuttx/NuttX/rc.sysinit.in
+++ b/platforms/nuttx/NuttX/rc.sysinit.in
@@ -1,0 +1,5 @@
+# Create folder for the links
+mkdir -p lnk
+
+# The link strings, these are generated
+@kernel_symlinks_string@

--- a/platforms/nuttx/cmake/bin_romfs.cmake
+++ b/platforms/nuttx/cmake/bin_romfs.cmake
@@ -1,0 +1,135 @@
+############################################################################
+#
+#   Copyright (c) 2022 Technology Innovation Institute. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+# 1. Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in
+#    the documentation and/or other materials provided with the
+#    distribution.
+# 3. Neither the name PX4 nor the names of its contributors may be
+#    used to endorse or promote products derived from this software
+#    without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+# OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+# AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+# ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+#
+############################################################################
+
+#=============================================================================
+#
+#	make_bin_romfs
+#
+#	This function creates a ROMFS from the input binary directory and places
+#	the generated C-style header into the specified output directory. To
+#	reduce the ROMFS size, an option is given to strip the input files, which
+#	reduces their size considerably
+#
+#	Usage:
+#		make_bin_romfs(
+#			BINDIR <string>
+#			OUTDIR <string>
+#			OUTPREFIX <string>
+#			LABEL <string>
+#			STRIPPED <string>
+#			DEPS <list>
+#		)
+#
+#	Input:
+#		BINDIR		: Input binary directory (source for ROMFS)
+#		OUTDIR  	: Output directory (${OUTPREFIX}_romfs.h is placed here)
+#		OUTPREFIX	: Prefix for the output file
+#		LABEL		: Volume label
+#		STRIPPED	: Set to 'y' to strip the input binaries
+#		DEPS		: Dependencies for the ROMFS
+#
+#	Output:
+#		${OUTPREFIX}_romfs.h file, that can be added to any C-source file.
+#		Mounting as a ROM-disk will be trivial once this is done.
+#
+function(make_bin_romfs)
+
+	px4_parse_function_args(
+		NAME make_bin_romfs
+		ONE_VALUE BINDIR OUTDIR OUTPREFIX LABEL STRIPPED
+		MULTI_VALUE DEPS
+		REQUIRED BINDIR OUTDIR OUTPREFIX DEPS
+		ARGN ${ARGN}
+	)
+
+	if (NOT STRIPPED)
+		set(STRIPPED "n")
+	endif()
+
+	if (NOT LABEL)
+		set(LABEL "NuttXRomfsVol")
+	endif()
+
+	# Strip the elf files to reduce romfs image size
+
+	if (${STRIPPED} STREQUAL "y")
+		# Preserve the files with debug symbols
+
+		add_custom_target(debug_${OUTPREFIX}
+			COMMAND cp -r ${BINDIR} ${BINDIR}_debug
+			DEPENDS ${DEPS}
+		)
+
+		# Then strip the binaries in place
+
+		add_custom_command(OUTPUT ${OUTPREFIX}_stripped_bins
+			COMMAND for f in * \; do if [ -f "$$f" ]; then ${CMAKE_STRIP} $$f --strip-unneeded \; fi \; done
+			DEPENDS ${DEPS} debug_${OUTPREFIX}
+			WORKING_DIRECTORY ${BINDIR}
+		)
+	else()
+		add_custom_command(OUTPUT ${OUTPREFIX}_stripped_bins
+			COMMAND touch ${BINDIR}
+		)
+	endif()
+
+	# Make sure we have what we need
+
+	find_program(GENROMFS genromfs)
+	if(NOT GENROMFS)
+		message(FATAL_ERROR "genromfs not found")
+	endif()
+
+	find_program(XXD xxd)
+	if(NOT XXD)
+		message(FATAL_ERROR "xxd not found")
+	endif()
+
+	find_program(SED sed)
+	if(NOT SED)
+		message(FATAL_ERROR "sed not found")
+	endif()
+
+	# Generate the ROM file system
+
+	add_custom_command(OUTPUT ${OUTDIR}/${OUTPREFIX}_romfsimg.h
+		COMMAND ${GENROMFS} -f ${OUTPREFIX}_romfs.img -d ${BINDIR} -V "${LABEL}"
+		COMMAND ${XXD} -i ${OUTPREFIX}_romfs.img |
+				${SED} 's/^unsigned char/const unsigned char/g' >${OUTPREFIX}_romfsimg.h
+		COMMAND mv ${OUTPREFIX}_romfsimg.h ${OUTDIR}/${OUTPREFIX}_romfsimg.h
+		COMMAND rm -f ${OUTPREFIX}_romfs.img
+		DEPENDS ${OUTDIR} ${DEPS} ${OUTPREFIX}_stripped_bins
+	)
+	add_custom_target(${OUTPREFIX}_romfsimg DEPENDS ${OUTDIR}/${OUTPREFIX}_romfsimg.h)
+
+endfunction()

--- a/platforms/nuttx/src/px4/common/CMakeLists.txt
+++ b/platforms/nuttx/src/px4/common/CMakeLists.txt
@@ -45,20 +45,22 @@ if(NOT PX4_BOARD MATCHES "io-v2")
 		tasks.cpp
 		px4_atomic.cpp
 		px4_nuttx_impl.cpp
-		px4_init.cpp
 		px4_manifest.cpp
 		px4_mtd.cpp
 		px4_24xxxx_mtd.c
 		px4_crypto.cpp
 	)
 
-	# Kernel side & nuttx flat build common libraries
+	# Kernel side & nuttx flat build common (private) libraries
 	set(KERNEL_LIBS
 		arch_board_reset
 		arch_board_critmon
 		arch_version
 		nuttx_sched
 	)
+
+	# Add the init library
+	include(${CMAKE_CURRENT_SOURCE_DIR}/px4_init.cmake)
 
 if (NOT DEFINED CONFIG_BUILD_FLAT AND "${PX4_PLATFORM}" MATCHES "nuttx")
 	# Build the NuttX user and kernel space px4 layers
@@ -67,6 +69,7 @@ if (NOT DEFINED CONFIG_BUILD_FLAT AND "${PX4_PLATFORM}" MATCHES "nuttx")
 else()
 	# Build the flat build px4_layer
 	include(${CMAKE_CURRENT_SOURCE_DIR}/px4_layer.cmake)
+
 endif()
 
 else()

--- a/platforms/nuttx/src/px4/common/include/px4_platform/task.h
+++ b/platforms/nuttx/src/px4/common/include/px4_platform/task.h
@@ -1,0 +1,33 @@
+/****************************************************************************
+ * /px4-firmware/platforms/nuttx/src/px4/common/include/px4_platform/task.h
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+#pragma once
+
+#include <nuttx/config.h>
+
+__BEGIN_DECLS
+
+#ifdef CONFIG_BUILD_KERNEL
+int task_create(FAR const char *name, int priority,
+                int stack_size, main_t entry, FAR char * const argv[]);
+int task_delete(int pid);
+#endif
+
+__END_DECLS

--- a/platforms/nuttx/src/px4/common/main.cpp
+++ b/platforms/nuttx/src/px4/common/main.cpp
@@ -1,0 +1,44 @@
+/****************************************************************************
+ *
+ *   Copyright (c) 2022 Technology Innovation Institute. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+extern "C"
+{
+	void px4_userspace_init(void);
+	int entry(int argc, char *argv[]);
+}
+
+int main(int argc, char *argv[])
+{
+	px4_userspace_init();
+	return entry(argc, argv);
+}

--- a/platforms/nuttx/src/px4/common/px4_init.cmake
+++ b/platforms/nuttx/src/px4/common/px4_init.cmake
@@ -1,0 +1,20 @@
+
+# Build the px4_init object library, part of the entry point logic
+
+add_library(px4_init OBJECT
+	px4_init.cpp
+)
+add_dependencies(px4_init prebuild_targets)
+
+if (CONFIG_BUILD_FLAT)
+	target_link_libraries(px4_init INTERFACE px4_layer)
+else()
+	target_link_libraries(px4_init INTERFACE px4_kernel_layer)
+	target_compile_options(px4_init INTERFACE -D__KERNEL__)
+endif()
+
+target_link_libraries(px4_init INTERFACE px4_platform px4_work_queue perf uORB)
+
+if (DEFINED PX4_CRYPTO)
+	target_link_libraries(px4_init PRIVATE crypto_backend_interface)
+endif()

--- a/platforms/nuttx/src/px4/common/px4_init.cpp
+++ b/platforms/nuttx/src/px4/common/px4_init.cpp
@@ -131,7 +131,9 @@ int px4_platform_init()
 	hrt_ioctl_init();
 #endif
 
+#ifdef CONFIG_SYSTEMCMDS_PARAM
 	param_init();
+#endif
 
 	/* configure CPU load estimation */
 #ifdef CONFIG_SCHED_INSTRUMENTATION

--- a/platforms/nuttx/src/px4/common/px4_layer.cmake
+++ b/platforms/nuttx/src/px4/common/px4_layer.cmake
@@ -10,6 +10,7 @@ target_link_libraries(px4_layer
 		${KERNEL_LIBS}
 		nuttx_c
 		nuttx_arch
+		nuttx_xx
 		nuttx_mm
 	)
 
@@ -20,5 +21,3 @@ if (DEFINED PX4_CRYPTO)
 			crypto_backend
 	)
 endif()
-
-target_link_libraries(px4_layer PRIVATE px4_platform)

--- a/platforms/nuttx/src/px4/common/px4_protected_layers.cmake
+++ b/platforms/nuttx/src/px4/common/px4_protected_layers.cmake
@@ -50,6 +50,7 @@ target_link_libraries(px4_kernel_layer
 	PRIVATE
 		${KERNEL_LIBS}
 		nuttx_kc
+		nuttx_kxx
 		nuttx_karch
 		nuttx_kmm
 )

--- a/platforms/nuttx/src/px4/common/px4_protected_layers.cmake
+++ b/platforms/nuttx/src/px4/common/px4_protected_layers.cmake
@@ -5,6 +5,7 @@ add_library(px4_layer
 	board_dma_alloc.c
 	board_fat_dma_alloc.c
 	tasks.cpp
+	task.c
 	console_buffer_usr.cpp
 	cdc_acm_check.cpp
 	${PX4_SOURCE_DIR}/platforms/posix/src/px4/common/print_load.cpp

--- a/platforms/nuttx/src/px4/common/px4_protected_layers.cmake
+++ b/platforms/nuttx/src/px4/common/px4_protected_layers.cmake
@@ -19,6 +19,8 @@ add_library(px4_layer
 )
 
 target_link_libraries(px4_layer
+	PUBLIC
+		board_bus_info
 	PRIVATE
 		nuttx_c
 		nuttx_xx
@@ -35,11 +37,6 @@ add_library(px4_board_ctrl
 add_dependencies(px4_board_ctrl nuttx_context px4_kernel_builtin_list_target)
 target_compile_options(px4_board_ctrl PRIVATE -D__KERNEL__)
 
-target_link_libraries(px4_layer
-	PUBLIC
-		board_bus_info
-)
-
 # Build the kernel side px4_kernel_layer
 
 add_library(px4_kernel_layer
@@ -47,17 +44,15 @@ add_library(px4_kernel_layer
 )
 
 target_link_libraries(px4_kernel_layer
+	PUBLIC
+		px4_board_ctrl
+		board_bus_info
 	PRIVATE
 		${KERNEL_LIBS}
 		nuttx_kc
 		nuttx_kxx
 		nuttx_karch
 		nuttx_kmm
-)
-
-target_link_libraries(px4_kernel_layer
-	PUBLIC
-		board_bus_info
 )
 
 if (DEFINED PX4_CRYPTO)
@@ -67,7 +62,6 @@ endif()
 
 add_dependencies(px4_kernel_layer prebuild_targets)
 target_compile_options(px4_kernel_layer PRIVATE -D__KERNEL__)
-target_link_libraries(px4_kernel_layer PUBLIC px4_board_ctrl)
 
 if (CONFIG_BUILD_KERNEL)
 	target_sources(px4_layer PRIVATE usr_mmap.c)

--- a/platforms/nuttx/src/px4/common/task.c
+++ b/platforms/nuttx/src/px4/common/task.c
@@ -1,0 +1,234 @@
+/****************************************************************************
+ *
+ *   Copyright (c) 2023 Technology Innovation Institute. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+
+#include <errno.h>
+#include <malloc.h>
+#include <pthread.h>
+#include <spawn.h>
+#include <stddef.h>
+#include <stdio.h>
+#include <string.h>
+
+#include <nuttx/compiler.h>
+
+#ifdef CONFIG_BUILD_KERNEL
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+#define MAX_EXEC_ARGS 256
+
+/****************************************************************************
+ * Private Types
+ ****************************************************************************/
+
+struct main_args_s
+{
+  main_t     entry;
+  int        prio;
+  int        argc;
+  FAR char  *argv[];
+};
+
+/****************************************************************************
+ * Private Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: main_trampoline
+ *
+ * Description:
+ *   Trampoline function for pthread to pass argv among other things
+ *
+ ****************************************************************************/
+
+static void *main_trampoline(void *ptr)
+{
+  struct main_args_s *args = (struct main_args_s *) ptr;
+  pthread_setschedprio(pthread_self(), args->prio);
+  pthread_setname_np(pthread_self(), args->argv[0]);
+  args->entry(args->argc, args->argv);
+  free(ptr);
+  return NULL;
+}
+
+/****************************************************************************
+ * Name: task_create
+ *
+ * Description:
+ *   Adaptation for CONFIG_BUILD_KERNEL to compile task_create using pthreads
+ *   instead of NuttX tasks.
+ *
+ ****************************************************************************/
+
+int task_create(FAR const char *name, int priority,
+                int stack_size, main_t entry, FAR char * const argv[])
+{
+  FAR struct main_args_s *args;
+  FAR char *ptr;
+  pthread_t pid;
+  pthread_attr_t attr;
+  size_t argvsize = 0;
+  size_t argssize;
+  int argc = 0;
+  int ret;
+  int i;
+
+  /* Get the number of arguments and the size of the argument list */
+
+  if (argv)
+    {
+      while (argv[argc])
+        {
+          argvsize += strlen(argv[argc]) + 1;
+          if (argc >= MAX_EXEC_ARGS)
+            {
+              ret = E2BIG;
+              goto update_errno;
+            }
+
+          argc++;
+        }
+    }
+
+  /* Name is a part of argv */
+
+  argvsize += strlen(name) + 1;
+
+  /* Allocate the struct + memory for argv + name */
+
+  argssize = sizeof(struct main_args_s) + (argc + 2) * sizeof(FAR char *);
+
+  args = (struct main_args_s *)malloc(argssize + argvsize);
+  if (!args)
+    {
+      ret = ENOMEM;
+      goto update_errno;
+    }
+
+  /* Initialize the struct */
+
+  args->entry = entry;
+  args->prio = priority;
+  args->argc = argc + 1; /* +1 for name */
+
+  /* Copy the name */
+
+  ptr = (char *)args + argssize;
+  args->argv[0] = ptr;
+  strcpy(ptr, name);
+  ptr += strlen(name) + 1;
+
+  /* Copy the argv list */
+
+  for (i = 0; i < argc; i++)
+    {
+      args->argv[i + 1] = ptr;
+      strcpy(ptr, argv[i]);
+      ptr += strlen(argv[i]) + 1;
+    }
+
+  /* Terminate the argv[] list */
+
+  args->argv[args->argc] = NULL;
+
+  /* Set the worker parameters */
+
+  pthread_attr_init(&attr);
+  pthread_attr_setschedpolicy(&attr, SCHED_RR);
+  pthread_attr_setdetachstate(&attr, PTHREAD_CREATE_JOINABLE);
+  pthread_attr_setinheritsched(&attr, PTHREAD_EXPLICIT_SCHED);
+  pthread_attr_setstacksize(&attr, stack_size);
+
+  /* Start the worker */
+
+  ret = pthread_create(&pid, &attr, &main_trampoline, args);
+  if (ret != 0)
+    {
+      printf("ERROR: pthread_create:%d, errno:%s\n", ret, strerror(ret));
+      free(args);
+      pid = ERROR;
+    }
+
+  pthread_attr_destroy(&attr);
+
+update_errno:
+  if (ret != 0)
+    {
+      set_errno(-ret);
+      pid = ERROR;
+    }
+
+  return (int)pid;
+}
+
+/****************************************************************************
+ * Name: task_delete
+ *
+ * Description:
+ *   Adaptation for CONFIG_BUILD_KERNEL to compile task_create using pthreads
+ *   instead of NuttX tasks.
+ *
+ ****************************************************************************/
+
+int task_delete(int pid)
+{
+  int ret;
+
+  if (pid == pthread_self())
+    {
+      ret = pthread_join(pid, NULL);
+      pthread_exit(NULL);
+    }
+  else
+    {
+      ret = pthread_cancel(pid);
+    }
+
+  if (ret < 0)
+    {
+      set_errno(-ret);
+      ret = ERROR;
+    }
+
+  return ret;
+}
+
+#endif /* CONFIG_BUILD_KERNEL */

--- a/platforms/nuttx/src/px4/common/tasks.cpp
+++ b/platforms/nuttx/src/px4/common/tasks.cpp
@@ -41,6 +41,8 @@
 #include <px4_platform_common/log.h>
 #include <px4_platform_common/tasks.h>
 
+#include <px4_platform/task.h>
+
 #include <nuttx/board.h>
 #include <nuttx/kthread.h>
 
@@ -88,18 +90,11 @@ int px4_task_spawn_cmd(const char *name, int scheduler, int priority, int stack_
 
 int px4_task_delete(int pid)
 {
-	int ret = OK;
-
-	if (pid == getpid()) {
-		// Commit suicide
-		exit(EXIT_SUCCESS);
-
-	} else {
-		// Politely ask someone else to kill themselves
-		ret = kill(pid, SIGKILL);
-	}
-
-	return ret;
+#if !defined(__KERNEL__)
+	return task_delete(pid);
+#else
+	return kthread_delete(pid);
+#endif
 }
 
 const char *px4_get_taskname(void)

--- a/platforms/nuttx/src/px4/common/tasks.cpp
+++ b/platforms/nuttx/src/px4/common/tasks.cpp
@@ -61,7 +61,7 @@ int px4_task_spawn_cmd(const char *name, int scheduler, int priority, int stack_
 {
 	sched_lock();
 
-#if !defined(CONFIG_DISABLE_ENVIRON)
+#if !defined(CONFIG_DISABLE_ENVIRON) && !defined(__KERNEL__)
 	/* None of the modules access the environment variables (via getenv() for instance), so delete them
 	 * all. They are only used within the startup script, and NuttX automatically exports them to the children
 	 * tasks.

--- a/src/lib/parameters/parameters.cpp
+++ b/src/lib/parameters/parameters.cpp
@@ -81,6 +81,10 @@ using namespace time_literals;
 #include "parameters_ioctl.h"
 #endif
 
+#if defined(__PX4_NUTTX)
+#include <kmalloc.h>
+#endif
+
 #if defined(FLASH_BASED_PARAMS)
 #include "flashparams/flashparams.h"
 #else

--- a/src/modules/load_mon/LoadMon.hpp
+++ b/src/modules/load_mon/LoadMon.hpp
@@ -34,7 +34,7 @@
 #pragma once
 
 #if defined(__PX4_NUTTX)
-#include <malloc.h>
+#include <kmalloc.h>
 #endif
 #include <drivers/drv_hrt.h>
 #include <lib/perf/perf_counter.h>

--- a/src/systemcmds/reboot/CMakeLists.txt
+++ b/src/systemcmds/reboot/CMakeLists.txt
@@ -36,7 +36,5 @@ px4_add_module(
 	COMPILE_FLAGS
 	SRCS
 		reboot.cpp
-	DEPENDS
-		px4_platform
 	)
 


### PR DESCRIPTION
Enable building PX4 as a set of processes on NuttX with CONFIG_BUILD_KERNEL=y

The result is two ROMFS's which are placed into the kernel binary and mounted into /bin and /sbin by the board initialization logic. - The kernel knows the mount point and starts the user space from /sbin/init, which is the nsh shell.
- Kernel processes are launched via symbolic links, created into /lnk
- User processes are launched via $PATH which points to /bin
- Note: the symbolic links cannot be placed into /bin or /sbin as the drivers do not support creating symlinks, only the pseudofs knows how to do this -> must create a folder in the pseudofs (/lnk)

The current configuration boots into nsh and starts every module:
- The kernel modules actually work and stay running
- User modules start and exit at once, they need a daemon server to work properly

Requirements:
- Saluki-v1 needs to be updated
- Bootloader needs a build with SBI enabled
- NuttX must be updated (pending upstreaming, not all patches are even available yet)
- uORB which uses shmem is needed (pending merge)