### PR TITLE
nuttx/protected_build: Fix protected build linkage

### DIFF
--- a/platforms/nuttx/src/px4/common/px4_protected_layers.cmake
+++ b/platforms/nuttx/src/px4/common/px4_protected_layers.cmake
@@ -19,7 +19,6 @@ add_library(px4_layer
 
 target_link_libraries(px4_layer
 	PRIVATE
-		m
 		nuttx_c
 		nuttx_xx
 		nuttx_mm


### PR DESCRIPTION
Do not link the soft float math library, it is not needed for anything and it confuses the linker which does relocations to the FP instructions