### PR TITLE
DP-4485: Git commit info is printed out in the bootloader

### DIFF
--- a/platforms/nuttx/src/bootloader/microchip/mpfs/CMakeLists.txt
+++ b/platforms/nuttx/src/bootloader/microchip/mpfs/CMakeLists.txt
@@ -36,6 +36,15 @@ px4_add_library(arch_bootloader
 	systick.c
 )
 
+execute_process(
+	COMMAND  git show --summary --pretty="%h %d, %as"
+	WORKING_DIRECTORY ${CMAKE_CURRENT_LIST_DIR}
+	OUTPUT_VARIABLE GIT_COMMIT
+	OUTPUT_STRIP_TRAILING_WHITESPACE
+	)
+
+add_definitions(-DGIT_COMMIT=${GIT_COMMIT})
+
 target_link_libraries(arch_bootloader
 	PRIVATE
 		bootloader_lib

--- a/platforms/nuttx/src/bootloader/microchip/mpfs/CMakeLists.txt
+++ b/platforms/nuttx/src/bootloader/microchip/mpfs/CMakeLists.txt
@@ -37,13 +37,13 @@ px4_add_library(arch_bootloader
 )
 
 execute_process(
-	COMMAND  git show --summary --pretty="%h %d, %as"
+	COMMAND  git describe --dirty --all --long
 	WORKING_DIRECTORY ${CMAKE_CURRENT_LIST_DIR}
-	OUTPUT_VARIABLE GIT_COMMIT
+	OUTPUT_VARIABLE VERSION
 	OUTPUT_STRIP_TRAILING_WHITESPACE
 	)
 
-add_definitions(-DGIT_COMMIT=${GIT_COMMIT})
+add_definitions(-DVERSION=\"${VERSION}\")
 
 target_link_libraries(arch_bootloader
 	PRIVATE

--- a/platforms/nuttx/src/bootloader/microchip/mpfs/main.c
+++ b/platforms/nuttx/src/bootloader/microchip/mpfs/main.c
@@ -917,7 +917,7 @@ bootloader_main(int argc, char *argv[])
 {
 	unsigned timeout = BOOTLOADER_DELAY;	 /* if nonzero, drop out of the bootloader after this time */
 	bool try_boot;
-	_alert("Git commit: %s\n", GIT_COMMIT);
+	_alert("Version: %s\n", VERSION);
 
 	/* do board-specific initialisation */
 	board_init();

--- a/platforms/nuttx/src/bootloader/microchip/mpfs/main.c
+++ b/platforms/nuttx/src/bootloader/microchip/mpfs/main.c
@@ -917,6 +917,7 @@ bootloader_main(int argc, char *argv[])
 {
 	unsigned timeout = BOOTLOADER_DELAY;	 /* if nonzero, drop out of the bootloader after this time */
 	bool try_boot;
+	_alert("Git commit: %s\n", GIT_COMMIT);
 
 	/* do board-specific initialisation */
 	board_init();


### PR DESCRIPTION
<!--

Thank you for your contribution!

Get early feedback through
- Dronecode Discord: https://discord.gg/dronecode
- PX4 Discuss: http://discuss.px4.io/
- opening a draft pr and sharing the link

-->

### Solved Problem
Fix for bug "DP-4485:  Saluki bootloader does not show a version identifier"

### Solution
Git commit information added

### Alternatives
-

### Test coverage
-

### Context
-
