### PR TITLE
Fix bl logic

### DIFF
--- a/platforms/nuttx/src/bootloader/microchip/mpfs/main.c
+++ b/platforms/nuttx/src/bootloader/microchip/mpfs/main.c
@@ -135,11 +135,12 @@ typedef enum {
 	UNINITIALIZED = -1,
 	IN_PROGRESS,
 	DONE,
+	SW_UPDATED,
 	INTERRUPTED,
 	LOAD_FAIL
 } image_loading_status_t;
 
-static image_loading_status_t loading_status = UNINITIALIZED;
+static image_loading_status_t loading_status;
 static bool u_boot_loaded = false;
 
 /* board definition */
@@ -607,7 +608,11 @@ flash_func_write_word(uintptr_t address, uint32_t word)
 
 	/* After the last word has been written, update the loading_status */
 	if (address == 0 && word != 0xffffffffu) {
-		loading_status = DONE;
+#ifdef CONFIG_MMCSD
+		close(px4_fd);
+		px4_fd = -1;
+#endif
+		loading_status = SW_UPDATED;
 	}
 }
 
@@ -901,8 +906,11 @@ static int loader_main(int argc, char *argv[])
 	return 0;
 }
 
-int start_image_loading(void)
+static void start_image_loading(void)
 {
+	/* Mark that we are waiting for the task to start */
+	loading_status = UNINITIALIZED;
+
 	/* create the task */
 	loader_task = task_create("loader", SCHED_PRIORITY_MAX - 6, 8192, loader_main, (char *const *)0);
 
@@ -910,8 +918,6 @@ int start_image_loading(void)
 	while (loading_status == UNINITIALIZED) {
 		usleep(1000);
 	}
-
-	return 0;
 }
 
 int
@@ -967,6 +973,12 @@ bootloader_main(int argc, char *argv[])
 	while (1) {
 		/* run the bootloader, come back after an app is uploaded or we time out */
 		bootloader(timeout);
+
+		/* if the sw was just re-flashed, load the image again */
+		if (loading_status == SW_UPDATED) {
+			timeout = BOOTLOADER_DELAY;
+			start_image_loading();
+		}
 
 		/* look to see if we can boot the app */
 

--- a/platforms/nuttx/src/bootloader/microchip/mpfs/main.c
+++ b/platforms/nuttx/src/bootloader/microchip/mpfs/main.c
@@ -105,6 +105,8 @@ extern int mpfs_set_entrypt(uint64_t hartid, uintptr_t entry);
    S)*/
 #define RESET_SR_SCB_BUS_RESET_MASK                          (0x01 << 0x7)
 
+/* Indicates that CPU soft reset occured */
+#define RESET_SR_CPU_SOFT_RESET_MASK                         (0x01 << 0x8)
 
 #ifdef CONFIG_MMCSD
 static int px4_fd = -1;
@@ -939,21 +941,15 @@ bootloader_main(int argc, char *argv[])
 	uint32_t reset_reason = board_get_reset_reason();
 
 	/* Is not FABRIC reset and not caused by WDOG? FABRIC reset bit is only
-	 * set in POR, since it is not even connected in FPGA
+	 * set in POR, since it is not even connected in FPGA.
+	 * If also CPU_SOFT_RESET is set, we know that this is soft reset from PX4 (reboot -b)
 	 */
 	if ((reset_reason & RESET_SR_FABRIC_RESET_MASK) == 0 &&
-	    (reset_reason & RESET_SR_WDOG_RESET_MASK) == 0) {
-		/* This is not a power-on (cold boot) or WDOG reset. Check if the reset
-		 *  reason is soft reset (periph reset is not set) or RISC-V debugger
-		 *  (debugger reset is not set)
-		 */
-		if ((reset_reason & RESET_SR_SCB_PERIPH_RESET_MASK) == 0 ||
-		    (reset_reason & RESET_SR_DEBUGGER_RESET_MASK) == 0) {
-			/*
-			 * Don't drop out of the bootloader until something has been uploaded.
-			 */
-			timeout = 0;
-		}
+	    (reset_reason & RESET_SR_WDOG_RESET_MASK) == 0 &&
+	    (reset_reason & RESET_SR_CPU_SOFT_RESET_MASK) == RESET_SR_CPU_SOFT_RESET_MASK) {
+
+		/* Don't drop out of the bootloader until something has been uploaded */
+		timeout = 0;
 	}
 
 	/* Clear the reset reason */


### PR DESCRIPTION
This fixes 2 issues:
- Resetting the board with debugger doesn't get stuck any more
- After flashing the old info from TOC is not used in attempt to boot the image right away

I tried just resetting the board after successful flashing. This has the problem that you'd need to store the information about reset after flashing somewhere, otherwise it is indistinguishable from the sw reset from px4 (reboot -b), which needs to stay in bl.

STM boards have some freely usable registers in RTC block (which is separately powered and keep the contents over power cuts as well), which are used to store the information about the last known state. We don't have that atm. l2lim is not usable for that because it seems to loose content at reset.

After flashing it must boot right away, otherwise the flashing script will try to re-flash indefinitely
