### PR TITLE
microdds_client: cleanup pub&sub instances after connection lost

### DIFF
--- a/src/modules/microdds_client/microdds_client.cpp
+++ b/src/modules/microdds_client/microdds_client.cpp
@@ -172,6 +172,7 @@ void MicroddsClient::run()
 
 	while (!should_exit()) {
 		bool got_response = false;
+		PX4_INFO("Waiting for ping response...");
 
 		while (!should_exit() && !got_response) {
 			// Sending ping without initing a XRCE session
@@ -332,6 +333,21 @@ void MicroddsClient::run()
 		uxr_delete_session_retries(&session, _connected ? 1 : 0);
 		_last_payload_tx_rate = 0;
 		_last_payload_tx_rate = 0;
+
+		if (_subs) {
+			delete _subs;
+		}
+		_subs = new SendTopicsSubs();
+
+		if (_pubs) {
+			delete _pubs;
+		}
+		_pubs = new RcvTopicsPubs();
+
+		if (!_subs || !_pubs) {
+			PX4_ERR("alloc failed");
+			return;
+		}
 	}
 }
 


### PR DESCRIPTION
datawriters were not recreated in case of reconnection to agent. Pub&Sub instances are cleared after connection lost is detected, so they are forced to be recreated when connection is regained.
