### PR TITLE
Fix HRT for protected/kernel builds

### DIFF
--- a/platforms/nuttx/src/px4/common/hrt_ioctl.c
+++ b/platforms/nuttx/src/px4/common/hrt_ioctl.c
@@ -128,6 +128,11 @@ static struct usr_hrt_call *dup_entry(const px4_hrt_handle_t handle, struct hrt_
 	}
 
 	if (e) {
+
+		/* Store the user side callout function and argument to the user's handle */
+		entry->callout = callout;
+		entry->arg = arg;
+
 		/* Store reference to the kernel side entry to the user side struct and
 		 * references to the semaphore and user side entry to the kernel side item
 		 */


### PR DESCRIPTION
The HRT driver was not storing the callback function or argument

Signed-off-by: Jukka Laitinen <jukkax@ssrc.tii.ae>


