### PR TITLE
Set IPv4 address for RPMSG network interface

### DIFF
--- a/ROMFS/px4fmu_common/init.d/rcS
+++ b/ROMFS/px4fmu_common/init.d/rcS
@@ -552,6 +552,8 @@ if [ -d "/dev/rptun" ]
 then
 	echo "Starting RPTUN"
 	rptun start /dev/rptun/mpfs-ihc
+	ifconfig rpnet 192.168.200.101
+	ifup rpnet
 else
 	echo "No RPTUN device available"
 fi


### PR DESCRIPTION
This is done in init.d/rcS because interface does not exist before rptun is up.

Signed-off-by: Jani Paalijarvi <jani.paalijarvi@unikie.com>
