### PR TITLE
usr_hrt: Obtain location of MTIME via syscall

### DIFF
--- a/platforms/nuttx/src/px4/common/hrt_ioctl.c
+++ b/platforms/nuttx/src/px4/common/hrt_ioctl.c
@@ -331,6 +331,14 @@ hrt_ioctl(unsigned int cmd, unsigned long arg)
 		}
 		break;
 
+	case HRT_ABSTIME_BASE: {
+#ifdef PX4_USERSPACE_HRT
+		*(uintptr_t *)arg = hrt_absolute_time_usr_base();
+#else
+		*(uintptr_t *)arg = NULL;
+#endif
+		}
+		break;
 	default:
 		return -EINVAL;
 	}

--- a/platforms/nuttx/src/px4/microchip/mpfs/include/px4_arch/micro_hal.h
+++ b/platforms/nuttx/src/px4/microchip/mpfs/include/px4_arch/micro_hal.h
@@ -115,7 +115,10 @@ __BEGIN_DECLS
  */
 
 #define PX4_USERSPACE_HRT
-#define usr_hrt_absolute_time() getreg64(USRIO_START + (MPFS_CLINT_MTIME & RV_MMU_PAGE_MASK))
+static inline uintptr_t hrt_absolute_time_usr_base(void)
+{
+	return USRIO_START + (MPFS_CLINT_MTIME & RV_MMU_PAGE_MASK);
+}
 
 // TODO!
 #  define px4_cache_aligned_data()

--- a/src/drivers/drv_hrt.h
+++ b/src/drivers/drv_hrt.h
@@ -127,6 +127,7 @@ typedef struct latency_boardctl {
 #define HRT_RESET_LATENCY	_HRTIOC(8)
 #define HRT_REGISTER	_HRTIOC(9)
 #define HRT_UNREGISTER	_HRTIOC(10)
+#define HRT_ABSTIME_BASE	_HRTIOC(11)
 
 #endif
 


### PR DESCRIPTION
Instead of using a const value for USRIO_START, which fails when dynamic linking is used (i.e. CONFIG_BUILD_KERNEL), obtain the location of MTIME via syscall to the kernel side HRT.

Overload HRT_ABSOLUTE_TIME ioctl to do this, as the old way becomes unnecessary. There is a compatibility break here but should not matter.

