### PR TITLE
airframe 4400 & 4401: define HIL_ACT_FUNCx params

### DIFF
--- a/ROMFS/px4fmu_common/init.d/airframes/4400_ssrc_fog_x
+++ b/ROMFS/px4fmu_common/init.d/airframes/4400_ssrc_fog_x
@@ -49,6 +49,12 @@ param set-default PWM_MAIN_MIN2 1050
 param set-default PWM_MAIN_MIN3 1050
 param set-default PWM_MAIN_MIN4 1050
 
+# HITL PWM functions
+param set-default HIL_ACT_FUNC1 101
+param set-default HIL_ACT_FUNC2 102
+param set-default HIL_ACT_FUNC3 103
+param set-default HIL_ACT_FUNC4 104
+
 # Increase velocity controller P gain
 param set-default MPC_XY_VEL_P_ACC 2.4
 

--- a/ROMFS/px4fmu_common/init.d/airframes/4401_ssrc_fog_x_tmotor
+++ b/ROMFS/px4fmu_common/init.d/airframes/4401_ssrc_fog_x_tmotor
@@ -42,6 +42,12 @@ param set-default PWM_MAIN_FUNC2 102
 param set-default PWM_MAIN_FUNC3 103
 param set-default PWM_MAIN_FUNC4 104
 
+# HITL PWM functions
+param set-default HIL_ACT_FUNC1 101
+param set-default HIL_ACT_FUNC2 102
+param set-default HIL_ACT_FUNC3 103
+param set-default HIL_ACT_FUNC4 104
+
 # Increase velocity controller P gain
 param set-default MPC_XY_VEL_P_ACC 2.4
 


### PR DESCRIPTION
To make PWM_OUT_SIM & mixer to generate actuator_output messages, the HIL_ACT_FUNCx params need to be set to define which actuator function is used in which HIL actuator.
