### PR TITLE
[DO NOT MERGE] Test locking pf crypto version

### DIFF
--- a/.github/workflows/tiiuae-pixhawk-and-saluki.yaml
+++ b/.github/workflows/tiiuae-pixhawk-and-saluki.yaml
@@ -155,6 +155,7 @@ jobs:
         with:
           token: ${{ secrets.GH_REPO_TOKEN }}
           repository: tiiuae/pf_crypto
+          ref: 4eed24d99ef7bb020f3156f4cba9ea9369e2c6d1
           path: px4-firmware/platforms/nuttx/NuttX/nuttx/arch/risc-v/src/mpfs/crypto
       - name: Run px4-firmware saluki-v2_default build
         run: |
@@ -187,6 +188,7 @@ jobs:
         with:
           token: ${{ secrets.GH_REPO_TOKEN }}
           repository: tiiuae/pf_crypto
+          ref: 4eed24d99ef7bb020f3156f4cba9ea9369e2c6d1
           path: px4-firmware/platforms/nuttx/NuttX/nuttx/arch/risc-v/src/mpfs/crypto
       - name: Run px4-firmware saluki-v2_bootloader build
         run: |
@@ -219,6 +221,7 @@ jobs:
         with:
           token: ${{ secrets.GH_REPO_TOKEN }}
           repository: tiiuae/pf_crypto
+          ref: 4eed24d99ef7bb020f3156f4cba9ea9369e2c6d1
           path: px4-firmware/platforms/nuttx/NuttX/nuttx/arch/risc-v/src/mpfs/crypto
       - name: Run px4-firmware saluki-v2_amp build
         run: |
@@ -251,6 +254,7 @@ jobs:
         with:
           token: ${{ secrets.GH_REPO_TOKEN }}
           repository: tiiuae/pf_crypto
+          ref: 4eed24d99ef7bb020f3156f4cba9ea9369e2c6d1
           path: px4-firmware/platforms/nuttx/NuttX/nuttx/arch/risc-v/src/mpfs/crypto
       - name: Run px4-firmware saluki-v2_protected build
         run: |


### PR DESCRIPTION
This patch locks the pf_crypto to commit 4eed24d. This is just for testing and not the proper solution as there is still no easy way to change the commit. Better solution is needed for final implementation.