### PR TITLE
nuttx/build: nxsched_get_streams no longer exists in NuttX

### DIFF
--- a/platforms/nuttx/CMakeLists.txt
+++ b/platforms/nuttx/CMakeLists.txt
@@ -260,7 +260,7 @@ if (NOT CONFIG_BUILD_FLAT)
 
 else()
 
-	target_link_libraries(nuttx_c INTERFACE nuttx_sched) # nxsched_get_streams
+	target_link_libraries(nuttx_c INTERFACE nuttx_sched)
 
 	target_link_libraries(nuttx_arch
 		INTERFACE


### PR DESCRIPTION
Streams have been moved to user space, so do not need to link nuttx_sched into nuttx_c any longer.
