### PR TITLE
Disabled internal magnetometer in configuration, enabled loading inte…

### DIFF
--- a/ROMFS/px4fmu_common/init.d/airframes/4400_ssrc_fog_x
+++ b/ROMFS/px4fmu_common/init.d/airframes/4400_ssrc_fog_x
@@ -78,6 +78,9 @@ param set-default BAT2_V_EMPTY 3.5000
 # Enable LL40LS in i2c
 param set-default SENS_EN_LL40LS 2
 
+# Disable internal magnetometer
+param set CAL_MAG0_PRIO 0
+
 # LEDs on TELEMETRY 1
 param set-default SER_TEL1_BAUD 57600
 param set-default MAV_1_CONFIG 101
@@ -102,7 +105,3 @@ param set-default COM_RC_OVERRIDE 0
 
 # Set takeoff ramp to disabled for a more decisive takeoff action
 param set-default MPC_TKO_RAMP_T 0
-
-# Set default logfile encryption key indecies
-param set-default SDLOG_EXCH_KEY 2
-param set-default SDLOG_KEY 3

--- a/ROMFS/px4fmu_common/init.d/airframes/4401_ssrc_fog_x_tmotor
+++ b/ROMFS/px4fmu_common/init.d/airframes/4401_ssrc_fog_x_tmotor
@@ -60,6 +60,9 @@ param set-default BAT1_V_DIV 18.1
 # Enable LL40LS in i2c
 param set-default SENS_EN_LL40LS 2
 
+# Disable internal magnetometer
+param set CAL_MAG0_PRIO 0
+
 # LEDs on TELEMETRY 1
 param set-default SER_TEL1_BAUD 57600
 param set-default MAV_1_CONFIG 101

--- a/boards/px4/fmu-v5x/init/rc.board_sensors
+++ b/boards/px4/fmu-v5x/init/rc.board_sensors
@@ -92,7 +92,7 @@ else
 	icm20602 -R 8 -s start
 
 	# Internal magnetometer on I2c
-	#bmm150 -I -R 6 start
+	bmm150 -I -R 6 start
 
 fi
 


### PR DESCRIPTION
Disable internal magnetometer in SSRC airframe configurations
Enable internal magnetometer for fmu-v5x (to have the same magnetometer numbering)