### PR TITLE
Fix mavlink_log after uORB changes. TODO: squash to 0ee351b46270b69ba…

### DIFF
--- a/src/lib/systemlib/mavlink_log.cpp
+++ b/src/lib/systemlib/mavlink_log.cpp
@@ -56,7 +56,7 @@ __EXPORT void mavlink_vasprintf(int severity, orb_advert_t *mavlink_log_pub, con
 		return;
 	}
 
-	if (mavlink_log_pub == nullptr || !orb_advert_valid(*mavlink_log_pub)) {
+	if (mavlink_log_pub == nullptr) {
 		return;
 	}
 


### PR DESCRIPTION
…ddf0ad1cb952cf0da9822ab

There is a bug introduced in:

commit 0ee351b46270b69baddf0ad1cb952cf0da9822ab
Author: Jukka Laitinen <jukkax@ssrc.tii.ae>
Date:   Wed Apr 27 10:55:23 2022 +0400

    Change orb_publish interface and intialization of advertiser handles

This reverts one erroneus change in that patch


