### PR TITLE
Enabled bmm150 driver for the other half of v5x models

### DIFF
--- a/boards/px4/fmu-v5x/init/rc.board_sensors
+++ b/boards/px4/fmu-v5x/init/rc.board_sensors
@@ -70,7 +70,7 @@ then
 	icm20602 -R 10 -s start
 
 	# Internal magnetometer on I2c
-	#bmm150 -I start
+	bmm150 -I start
 
 else
 	#SKYNODE base fmu board orientation


### PR DESCRIPTION
Fix for internal magnetometer (bmm150) driver not being loaded on the 02 variant of the fmu-v5x board