### PR TITLE
GitHub refined token

### DIFF
--- a/.github/workflows/tiiuae-pixhawk-and-saluki-builder.yaml
+++ b/.github/workflows/tiiuae-pixhawk-and-saluki-builder.yaml
@@ -19,7 +19,7 @@ jobs:
       - name: Checkout px4-firmware
         uses: actions/checkout@v3
         with:
-          token: ${{ secrets.GH_REPO_TOKEN }}
+          token: ${{ secrets.GHFG_TOKEN }}
           # if we clone_public, then do not clone submodules, otherwise 'recursive'
           submodules: ${{ inputs.clone_public == true && 'false' || 'recursive' }}
           path: px4-firmware

--- a/.github/workflows/tiiuae-pixhawk-and-saluki.yaml
+++ b/.github/workflows/tiiuae-pixhawk-and-saluki.yaml
@@ -13,6 +13,7 @@ jobs:
     strategy:
       matrix:
         product: [pixhawk, saluki-v1_default, saluki-v1_bootloader, saluki-v1_amp, saluki-v1_protected, saluki-v2_default, saluki-v2_bootloader, saluki-v2_amp, saluki-v2_protected, saluki-pi_default, saluki-pi_bootloader, saluki-pi_amp, saluki-pi_protected]
+      fail-fast: false
     uses: ./.github/workflows/tiiuae-pixhawk-and-saluki-builder.yaml
     with:
       product: ${{ matrix.product }}


### PR DESCRIPTION
- use github fine-grained PAT to access private repos
- disable fail-fast from build strategy so all targets are built even if one fails