### PR TITLE
Rover interface CAN driver

### DIFF
--- a/ROMFS/px4fmu_common/init.d/50005_ssrc_scout_mini_rover
+++ b/ROMFS/px4fmu_common/init.d/50005_ssrc_scout_mini_rover
@@ -1,0 +1,83 @@
+#!/bin/sh
+#
+# @name SSRC SCOUT MINI UGV
+#
+# @url https://global.agilex.ai/products/scout-mini
+#
+# @type Rover
+# @class Rover
+#
+# @board px4_fmu-v2 exclude
+# @board bitcraze_crazyflie exclude
+#
+
+. ${R}etc/init.d/rc.rover_defaults
+
+param set-default RI_ENABLE 1
+param set-default RI_ROVER_TYPE 0
+
+param set-default BAT1_N_CELLS 4
+
+param set-default EKF2_GBIAS_INIT 0.01
+param set-default EKF2_ANGERR_INIT 0.01
+param set-default EKF2_MAG_TYPE 1
+
+param set-default FW_AIRSPD_MIN 0
+param set-default FW_AIRSPD_TRIM 1
+param set-default FW_AIRSPD_MAX 3
+
+param set-default GND_SP_CTRL_MODE 1
+param set-default GND_L1_DIST 5       #todo
+param set-default GND_L1_PERIOD 3
+param set-default GND_THR_CRUISE 0.1
+param set-default GND_THR_MAX 0.3
+
+# Because this is differential drive, it can make a turn with radius 0.
+# This corresponds to a turn angle of pi radians.
+# If a special case is made for differential-drive, this will need to change.
+param set-default GND_MAX_ANG 3.142
+param set-default GND_WHEEL_BASE 0.3      #todo
+
+# TODO: Set to -1.0, to allow reversing. This will require many changes in the codebase
+# to support negative throttle.
+param set-default GND_THR_MIN 0
+param set-default GND_SPEED_P 0.25
+param set-default GND_SPEED_I 3
+param set-default GND_SPEED_D 0.001
+param set-default GND_SPEED_IMAX 0.125
+param set-default GND_SPEED_THR_SC 1
+
+param set-default MIS_TAKEOFF_ALT 0.01
+
+param set-default NAV_ACC_RAD 0.5     # reached when within 0.5m of waypoint
+
+# Enable Airspeed check circuit breaker because Rovers will have no airspeed sensor
+param set-default CBRK_AIRSPD_CHK 162128
+
+# Set geometry & output configration. This is just the place holder for rover type. We dont actually use control allocation for scout mini.
+param set-default CA_AIRFRAME 6
+
+
+###### ROVER/DRONE COMMON PARAMS ######
+# LEDs on TELEMETRY 1
+param set-default SER_TEL1_BAUD 57600
+param set-default MAV_1_CONFIG 101
+param set-default MAV_1_MODE 7
+param set-default MAV_1_RATE 1000
+
+# Disable MAV_0 and MAV_2
+param set-default MAV_0_CONFIG 0
+param set-default MAV_2_CONFIG 0
+
+# Enable safety switch
+param set-default CBRK_IO_SAFETY 0
+
+# Enable satellite info by default
+param set-default GPS_SAT_INFO 1
+
+# Set sticks movement not to switch to RC, we use mode switch for this
+param set-default COM_RC_OVERRIDE 0
+
+# Set default logfile encryption key indecies
+param set-default SDLOG_EXCH_KEY 2
+param set-default SDLOG_KEY 3

--- a/ROMFS/px4fmu_common/init.d/airframes/50005_ssrc_scout_mini_rover
+++ b/ROMFS/px4fmu_common/init.d/airframes/50005_ssrc_scout_mini_rover
@@ -13,7 +13,6 @@
 
 . ${R}etc/init.d/rc.rover_defaults
 
-param set-default RI_ENABLE 1
 param set-default RI_ROVER_TYPE 0
 
 param set-default BAT1_N_CELLS 4
@@ -27,24 +26,24 @@ param set-default FW_AIRSPD_TRIM 1
 param set-default FW_AIRSPD_MAX 3
 
 param set-default GND_SP_CTRL_MODE 1
-param set-default GND_L1_DIST 5       #todo
+param set-default GND_L1_DIST 5
 param set-default GND_L1_PERIOD 3
-param set-default GND_THR_CRUISE 0.1
-param set-default GND_THR_MAX 0.3
+param set-default GND_THR_CRUISE 1
+param set-default GND_THR_MAX 1
 
 # Because this is differential drive, it can make a turn with radius 0.
 # This corresponds to a turn angle of pi radians.
 # If a special case is made for differential-drive, this will need to change.
 param set-default GND_MAX_ANG 3.142
-param set-default GND_WHEEL_BASE 0.3      #todo
+param set-default GND_WHEEL_BASE 0.45
 
 # TODO: Set to -1.0, to allow reversing. This will require many changes in the codebase
 # to support negative throttle.
 param set-default GND_THR_MIN 0
-param set-default GND_SPEED_P 0.25
+param set-default GND_SPEED_P 3
 param set-default GND_SPEED_I 3
 param set-default GND_SPEED_D 0.001
-param set-default GND_SPEED_IMAX 0.125
+param set-default GND_SPEED_IMAX 1
 param set-default GND_SPEED_THR_SC 1
 
 param set-default MIS_TAKEOFF_ALT 0.01

--- a/ROMFS/px4fmu_common/init.d/airframes/CMakeLists.txt
+++ b/ROMFS/px4fmu_common/init.d/airframes/CMakeLists.txt
@@ -121,6 +121,7 @@ px4_add_romfs_files(
 	50000_generic_ground_vehicle
 	50004_nxpcup_car_dfrobot_gpx
 	50003_aion_robotics_r1_rover
+	50005_ssrc_scout_mini_rover
 
 	# [60000, 61000] (Unmanned) Underwater Robots
 	60000_uuv_generic

--- a/ROMFS/px4fmu_common/init.d/rc.rover_apps
+++ b/ROMFS/px4fmu_common/init.d/rc.rover_apps
@@ -6,6 +6,15 @@
 #
 
 #
+# Start the rover interface CAN driver if airframe is one of SSRC supported rover types (50005, ..)
+#
+if param compare SYS_AUTOSTART 50005
+then
+  ifup can0
+  rover_interface start
+fi
+
+#
 # Start the attitude and position estimator.
 #
 ekf2 start &

--- a/msg/CMakeLists.txt
+++ b/msg/CMakeLists.txt
@@ -149,6 +149,7 @@ set(msg_files
 	RateCtrlStatus.msg
 	RcChannels.msg
 	RcParameterMap.msg
+	RoverStatus.msg
 	Rpm.msg
 	RtlTimeEstimate.msg
 	SatelliteInfo.msg

--- a/msg/RoverStatus.msg
+++ b/msg/RoverStatus.msg
@@ -1,0 +1,12 @@
+uint64 timestamp    # time since system start (microseconds)
+float32 linear_velocity
+float32 angular_velocity
+uint8 vehicle_state
+uint8 control_mode
+uint16 error_code
+float32 battery_voltage
+bool light_control_enable
+uint8 front_light_mode
+uint8 front_light_custom_value
+uint8 rear_light_mode
+uint8 rear_light_custom_value

--- a/platforms/common/include/px4_platform_common/px4_work_queue/WorkQueueManager.hpp
+++ b/platforms/common/include/px4_platform_common/px4_work_queue/WorkQueueManager.hpp
@@ -76,6 +76,8 @@ static constexpr wq_config_t hp_default{"wq:hp_default", 1900, -18};
 
 static constexpr wq_config_t uavcan{"wq:uavcan", 3624, -19};
 
+static constexpr wq_config_t rover_interface{"wq:rover_interface", 2000, -19};
+
 static constexpr wq_config_t ttyS0{"wq:ttyS0", 1732, -21};
 static constexpr wq_config_t ttyS1{"wq:ttyS1", 1732, -22};
 static constexpr wq_config_t ttyS2{"wq:ttyS2", 1732, -23};

--- a/src/drivers/rover_interface/CMakeLists.txt
+++ b/src/drivers/rover_interface/CMakeLists.txt
@@ -1,0 +1,16 @@
+# set(SCOUT_SDK_DIR ${CMAKE_CURRENT_SOURCE_DIR}/scout_sdk)
+add_subdirectory(scout_sdk)
+
+px4_add_module(
+	MODULE drivers__rover_interface
+	MAIN rover_interface
+	STACK_MAIN 4096
+	COMPILE_FLAGS
+	INCLUDES
+		${SCOUT_SDK_DIR}/include
+	SRCS
+		RoverInterface.cpp
+		RoverInterface.hpp
+	DEPENDS
+		scout_sdk
+)

--- a/src/drivers/rover_interface/Kconfig
+++ b/src/drivers/rover_interface/Kconfig
@@ -1,0 +1,5 @@
+menuconfig DRIVERS_ROVER_INTERFACE
+        bool "rover_interface"
+        default n
+        ---help---
+                Enable support for rover_interface

--- a/src/drivers/rover_interface/RoverInterface.cpp
+++ b/src/drivers/rover_interface/RoverInterface.cpp
@@ -1,0 +1,378 @@
+#include "RoverInterface.hpp"
+#include <px4_platform_common/log.h>
+
+RoverInterface *RoverInterface::_instance;
+
+RoverInterface::RoverInterface(uint8_t rover_type, const char *can_iface)
+	: ModuleParams(nullptr),
+	ScheduledWorkItem(MODULE_NAME, px4::wq_configurations::rover_interface),
+	_rover_type(rover_type)
+{
+	pthread_mutex_init(&_node_mutex, nullptr);
+	_can_iface = strdup(can_iface);
+}
+
+
+RoverInterface::~RoverInterface()
+{
+	if (_instance) {
+		// Tell the task we want it to go away
+		_task_should_exit.store(true);
+		ScheduleNow();
+
+		unsigned i = 1000;
+
+		do
+		{
+			// Wait for it to exit or timeout
+			usleep(5000);
+
+			if (--i == 0) {
+				PX4_ERR("Failed to Stop Task - reboot needed");
+				break;
+			}
+
+		} while (_instance);
+	}
+
+	perf_free(_cycle_perf);
+	perf_free(_interval_perf);
+}
+
+
+int RoverInterface::start(uint8_t rover_type, const char *can_iface)
+{
+	if (_instance != nullptr)
+	{
+		PX4_ERR("Already started");
+		return -1;
+	}
+
+	_instance = new RoverInterface(rover_type, can_iface);
+
+	if (_instance == nullptr)
+	{
+		PX4_ERR("Failed to allocate RoverInterface object");
+		return -1;
+	}
+
+	_instance->ScheduleOnInterval(ScheduleIntervalMs);
+
+	return PX4_OK;
+}
+
+
+void RoverInterface::Init()
+{
+	_initialized = false;
+
+	// Check rover type
+	if (_rover_type == 0)
+	{
+		// Scout Mini
+		PX4_INFO("Scout Mini (rover type 0) is supported. Initializing...");
+	}
+	else if (_rover_type == 1)
+	{
+		// Scout
+		PX4_INFO("Scout (rover type 1) is not supported. Aborted");
+		return;
+	}
+	else if (_rover_type == 2)
+	{
+		// Scout Pro
+		PX4_INFO("Scout Pro (rover type 0) is not supported. Aborted");
+		return;
+	}
+	else if (_rover_type == 3)
+	{
+		// Scout 2
+		PX4_INFO("Scout 2 (rover type 3) is not supported. Aborted");
+		return;
+	}
+	else if (_rover_type == 4)
+	{
+		// Scout 2 Pro
+		PX4_INFO("Scout 2 Pro (rover type 4) is not supported. Aborted");
+		return;
+	}
+	else
+	{
+		// Unknown Rover type
+		PX4_INFO("Unknown rover type. Aborted");
+		return;
+	}
+
+
+	// Check protocol version and create ScoutRobot object
+	if (_protocol_version == scoutsdk::ProtocolVersion::AGX_V1)
+	{
+		PX4_INFO("AGX V1 protocol version is not supported. Aborted");
+	}
+	else if (_protocol_version == scoutsdk::ProtocolVersion::AGX_V2)
+	{
+		PX4_INFO("Detected AGX V2 protocol");
+		_scout = new scoutsdk::ScoutRobot(scoutsdk::ProtocolVersion::AGX_V2, true);
+	}
+	else
+	{
+		PX4_INFO("Unknown protocol version");
+	}
+	if (_scout == nullptr)
+	{
+		PX4_ERR("Failed to create the ScoutRobot object. Aborted");
+		return;
+	}
+
+	// Finally establish connection to rover
+	_scout->Connect(_can_iface);
+	if(!_scout->GetCANConnected())
+	{
+		PX4_ERR("Failed to connect to the rover CAN bus");
+		return;
+	}
+
+	// Use CAN command mode
+	_scout->EnableCommandMode();
+
+	// Retrieve system version (blocking)
+	_scout->QuerySystemVersion(SystemVersionQueryLimitMs);
+
+	// Setup rover state publisher
+	if (!orb_advert_valid(_rover_status_pub))
+	{
+		_rover_status_pub = orb_advertise(ORB_ID(rover_status), &_rover_status_msg);
+	}
+
+	// Breathing mode light by default when not armed
+	_scout->SetLightCommand(LightMode::BREATH, 0);
+
+	_initialized = true;
+}
+
+
+void RoverInterface::Run()
+{
+	pthread_mutex_lock(&_node_mutex);
+
+	if (_instance != nullptr && _task_should_exit.load())
+	{
+		ScheduleClear();
+
+		if (_initialized) { _initialized = false; }
+
+		// Clean up
+		if (_scout != nullptr)
+		{
+			delete _scout;
+			_scout = nullptr;
+		}
+
+		if (_can_iface != nullptr)
+		{
+			free((char *)_can_iface);
+			_can_iface = nullptr;
+		}
+
+		_instance = nullptr;
+		pthread_mutex_unlock(&_node_mutex);
+		return;
+	}
+
+	if (_instance != nullptr && !_initialized)
+	{
+		// Try initializing for the first time
+		if (!_init_try_count)
+		{
+			Init();
+			_init_try_count++;
+		}
+
+		// Return early if still not initialized
+		if (!_initialized)
+		{
+			pthread_mutex_unlock(&_node_mutex);
+			return;
+		}
+	}
+
+	perf_begin(_cycle_perf);
+	perf_count(_interval_perf);
+
+	// Check for actuator controls command to rover
+	ActuatorControlsUpdate();
+
+	// Check for actuator armed command to rover
+	ActuatorArmedUpdate();
+
+	// Check for receive msgs from the rover
+	_scout->CheckUpdateFromRover();
+
+	// Update from rover and publish the rover state
+	if (hrt_elapsed_time(&_last_rover_status_publish_time) > RoverStatusPublishIntervalMs)
+	{
+		PublishRoverState();
+	}
+
+	perf_end(_cycle_perf);
+
+	pthread_mutex_unlock(&_node_mutex);
+}
+
+
+void RoverInterface::ActuatorControlsUpdate()
+{
+	if (_actuator_controls_sub.updated())
+	{
+		actuator_controls_s actuator_controls_msg;
+		if (_actuator_controls_sub.copy(&actuator_controls_msg))
+		{
+			auto throttle = actuator_controls_msg.control[actuator_controls_s::INDEX_THROTTLE];
+			auto steering = actuator_controls_msg.control[actuator_controls_s::INDEX_YAW];
+			_scout->SetMotionCommand(throttle, steering);
+		}
+	}
+}
+
+
+void RoverInterface::ActuatorArmedUpdate()
+{
+	if (_actuator_armed_sub.updated())
+	{
+		actuator_armed_s actuator_armed_msg;
+		if (_actuator_armed_sub.copy(&actuator_armed_msg))
+		{
+			if (!_armed && actuator_armed_msg.armed)
+			{
+				_scout->SetLightCommand(LightMode::CONST_ON, 0);
+				_armed = true;
+			}
+		}
+	}
+}
+
+
+void RoverInterface::PublishRoverState()
+{
+	// Get rover state
+	auto& robot_state = _scout->GetRobotState();
+
+	// Assign the values to the PX4 side ORB msg
+	_rover_status_msg.timestamp = hrt_absolute_time();
+	_rover_status_msg.linear_velocity = robot_state.motion_state.linear_velocity;
+	_rover_status_msg.angular_velocity = robot_state.motion_state.angular_velocity;
+	_rover_status_msg.vehicle_state = robot_state.system_state.vehicle_state;
+	_rover_status_msg.control_mode = robot_state.system_state.control_mode;
+	_rover_status_msg.error_code = robot_state.system_state.error_code;
+	_rover_status_msg.battery_voltage = robot_state.system_state.battery_voltage;
+	_rover_status_msg.light_control_enable = robot_state.light_state.enable_cmd_ctrl;
+	_rover_status_msg.front_light_mode = robot_state.light_state.front_light.mode;
+	_rover_status_msg.front_light_custom_value = robot_state.light_state.front_light.custom_value;
+	_rover_status_msg.rear_light_mode = robot_state.light_state.rear_light.mode;
+	_rover_status_msg.rear_light_custom_value = robot_state.light_state.rear_light.custom_value;
+
+	if (orb_advert_valid(_rover_status_pub))
+	{
+		orb_publish(ORB_ID(rover_status), &_rover_status_pub, &_rover_status_msg);
+		_last_rover_status_publish_time = _rover_status_msg.timestamp;
+	}
+}
+
+
+void RoverInterface::print_status()
+{
+	pthread_mutex_lock(&_node_mutex);
+
+	if (_scout == nullptr)
+	{
+		PX4_ERR("Scout Robot object not initialized");
+		pthread_mutex_unlock(&_node_mutex);
+		return;
+	}
+
+	// CAN connection info
+	PX4_INFO("CAN interface: %s. Status: %s",
+					 _can_iface, _scout->GetCANConnected() ? "connected" : "disconnected");
+
+	// Rover info
+	if (_scout->GetCANConnected())
+	{
+		PX4_INFO("Rover Type: %s. Protocol Version: %s",
+						 _rover_type == 0 ? "Scout Mini" : "Unknown",
+						 _protocol_version == scoutsdk::ProtocolVersion::AGX_V2 ? "AGX_V2" : "Unknown");
+		PX4_INFO("Rover system version: %s", _scout->GetSystemVersion());
+	}
+
+	// Subscription info
+	PX4_INFO("Subscribed to topics: %s, %s",
+					 _actuator_controls_sub.get_topic()->o_name,
+					 _actuator_armed_sub.get_topic()->o_name);
+
+	// Publication info
+	if (orb_advert_valid(_rover_status_pub)) { PX4_INFO("Publishing rover_status topic"); }
+
+	// Performance counters
+	perf_print_counter(_cycle_perf);
+	perf_print_counter(_interval_perf);
+
+	pthread_mutex_unlock(&_node_mutex);
+}
+
+
+static void print_usage()
+{
+	PX4_INFO("Usage: \n\trover_interface {start|status|stop}");
+}
+
+
+extern "C" __EXPORT int rover_interface_main(int argc, char *argv[])
+{
+	if (argc < 2) {
+		print_usage();
+		return 1;
+	}
+
+	if (!strcmp(argv[1], "start"))
+	{
+		if (RoverInterface::instance())
+		{
+			PX4_ERR("Already started");
+			return 1;
+		}
+
+		// Rover type | default is Scout Mini
+		int32_t rover_type = 0;
+		param_get(param_find("RI_ROVER_TYPE"), &rover_type);
+
+		// CAN interface | default is can0
+		const char *const can_iface = "can0";
+
+		// Start
+		PX4_INFO("Start Rover Interface to rover type %d at CAN iface %s" , rover_type, can_iface);
+		return RoverInterface::start(static_cast<uint8_t>(rover_type), can_iface);
+	}
+
+	/* commands below assume that the app has been already started */
+	RoverInterface *const inst = RoverInterface::instance();
+
+	if (!inst)
+	{
+		PX4_ERR("Application not running");
+		return 1;
+	}
+
+	if (!strcmp(argv[1], "status") || !strcmp(argv[1], "info"))
+	{
+		inst->print_status();
+		return 0;
+	}
+
+	if (!strcmp(argv[1], "stop"))
+	{
+		delete inst;
+		return 0;
+	}
+
+	print_usage();
+	return 1;
+}

--- a/src/drivers/rover_interface/RoverInterface.hpp
+++ b/src/drivers/rover_interface/RoverInterface.hpp
@@ -25,7 +25,7 @@ class RoverInterface : public ModuleParams, public px4::ScheduledWorkItem
 	 * Base interval, has to be compliant with the rate of the actuator_controls
 	 * topic subscription and CAN bus update rate
 	 */
-	static constexpr uint64_t ScheduleIntervalMs{1_ms};
+	static constexpr uint64_t ScheduleIntervalMs{500_us};
 
 	static constexpr uint64_t RoverStatusPublishIntervalMs{1000_ms};
 
@@ -36,10 +36,12 @@ class RoverInterface : public ModuleParams, public px4::ScheduledWorkItem
 	static constexpr uint64_t ActuatorArmedSubIntervalMs{1000_ms};
 
 public:
-	RoverInterface(uint8_t rover_type, const char *can_iface);
+	static const char *const CAN_IFACE;
+
+	RoverInterface(uint8_t rover_type);
 	~RoverInterface() override;
 
-	static int start(uint8_t rover_type, const char *can_iface);
+	static int start(uint8_t rover_type);
 
 	void print_status();
 
@@ -57,6 +59,8 @@ private:
 	px4::atomic_bool _task_should_exit{false};
 
 	bool _armed{false};
+
+	bool _manual_lockdown{false};
 
 	bool _initialized{false};
 

--- a/src/drivers/rover_interface/RoverInterface.hpp
+++ b/src/drivers/rover_interface/RoverInterface.hpp
@@ -1,0 +1,89 @@
+#pragma once
+
+#include <px4_platform_common/px4_config.h>
+#include <px4_platform_common/atomic.h>
+#include <px4_platform_common/defines.h>
+#include <px4_platform_common/module.h>
+#include <px4_platform_common/module_params.h>
+#include <px4_platform_common/px4_work_queue/ScheduledWorkItem.hpp>
+
+#include <lib/perf/perf_counter.h>
+#include <uORB/Subscription.hpp>
+#include <uORB/SubscriptionInterval.hpp>
+#include <uORB/Publication.hpp>
+#include <uORB/topics/actuator_controls.h>
+#include <uORB/topics/actuator_armed.h>
+#include <uORB/topics/rover_status.h>
+
+#include "scout_sdk/ScoutRobot.hpp"
+
+using namespace time_literals;
+
+class RoverInterface : public ModuleParams, public px4::ScheduledWorkItem
+{
+	/*
+	 * Base interval, has to be compliant with the rate of the actuator_controls
+	 * topic subscription and CAN bus update rate
+	 */
+	static constexpr uint64_t ScheduleIntervalMs{1_ms};
+
+	static constexpr uint64_t RoverStatusPublishIntervalMs{1000_ms};
+
+	static constexpr uint64_t SystemVersionQueryLimitMs{10_ms};
+
+	static constexpr uint64_t ActuatorControlSubIntervalMs{20_ms};
+
+	static constexpr uint64_t ActuatorArmedSubIntervalMs{1000_ms};
+
+public:
+	RoverInterface(uint8_t rover_type, const char *can_iface);
+	~RoverInterface() override;
+
+	static int start(uint8_t rover_type, const char *can_iface);
+
+	void print_status();
+
+	static RoverInterface *instance() { return _instance; }
+
+private:
+	void Init();
+	void Run() override;
+
+	void ActuatorControlsUpdate();
+	void ActuatorArmedUpdate();
+	void PublishRoverState();
+
+	// Flag to indicate to tear down the rover interface
+	px4::atomic_bool _task_should_exit{false};
+
+	bool _armed{false};
+
+	bool _initialized{false};
+
+	uint8_t _init_try_count{0};
+
+	static RoverInterface *_instance;
+
+	pthread_mutex_t _node_mutex;
+
+	uint8_t _rover_type;
+
+	scoutsdk::ProtocolVersion _protocol_version{scoutsdk::ProtocolVersion::AGX_V2};
+
+	const char* _can_iface{nullptr};
+
+	scoutsdk::ScoutRobot *_scout{nullptr};
+
+	// Subscription
+	uORB::SubscriptionInterval _actuator_controls_sub{ORB_ID(actuator_controls_0), ActuatorControlSubIntervalMs};
+	uORB::SubscriptionInterval _actuator_armed_sub{ORB_ID(actuator_armed), ActuatorArmedSubIntervalMs};
+
+	// Publication
+	orb_advert_t _rover_status_pub{ORB_ADVERT_INVALID};
+	rover_status_s _rover_status_msg{};
+	hrt_abstime _last_rover_status_publish_time{0};
+
+	// Performance counters
+	perf_counter_t _cycle_perf{perf_alloc(PC_ELAPSED, MODULE_NAME": cycle time")};
+	perf_counter_t _interval_perf{perf_alloc(PC_INTERVAL, MODULE_NAME": cycle interval")};
+};

--- a/src/drivers/rover_interface/rover_interface_params.c
+++ b/src/drivers/rover_interface/rover_interface_params.c
@@ -32,18 +32,6 @@
  ****************************************************************************/
 
 /**
- * RoverInterface mode
- *
- *  0 - Rover Interface disabled.
- *  1 - Rover Interface enabled.
- * @value 0 Disabled
- * @value 1 Enabled
- * @reboot_required true
- * @group RoverInterface
- */
-PARAM_DEFINE_INT32(RI_ENABLE, 0);
-
-/**
  * Rover type.
  *
  * @value 0 Scout Mini

--- a/src/drivers/rover_interface/rover_interface_params.c
+++ b/src/drivers/rover_interface/rover_interface_params.c
@@ -1,0 +1,56 @@
+/****************************************************************************
+ *
+ *   Copyright (c) 2023 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+/**
+ * RoverInterface mode
+ *
+ *  0 - Rover Interface disabled.
+ *  1 - Rover Interface enabled.
+ * @value 0 Disabled
+ * @value 1 Enabled
+ * @reboot_required true
+ * @group RoverInterface
+ */
+PARAM_DEFINE_INT32(RI_ENABLE, 0);
+
+/**
+ * Rover type.
+ *
+ * @value 0 Scout Mini
+ * @value 1 Scout
+ * @value 2 Scout Pro
+ * @value 3 Scout 2
+ * @value 4 Scout 2 Pro
+ * @group RoverInterface
+ */
+PARAM_DEFINE_INT32(RI_ROVER_TYPE, 0);

--- a/src/drivers/rover_interface/scout_sdk/CMakeLists.txt
+++ b/src/drivers/rover_interface/scout_sdk/CMakeLists.txt
@@ -1,0 +1,20 @@
+# Include directories
+include_directories(
+  include/scout_sdk/
+  include/scout_sdk/agilex_protocol
+  include/scout_sdk/CAN
+)
+
+# Source files
+set(SOURCES
+  src/agilex_protocol/agilex_msg_parser_v2.c
+  src/agilex_protocol/agilex_protocol_v2_parser.cpp
+  src/CAN/SocketCAN.cpp
+  src/Utilities.cpp
+  src/ScoutRobot.cpp
+)
+
+# Build library
+add_library(scout_sdk STATIC ${SOURCES})
+target_include_directories(scout_sdk PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/include)
+target_link_libraries(scout_sdk PRIVATE nuttx_arch)

--- a/src/drivers/rover_interface/scout_sdk/include/scout_sdk/CAN/SocketCAN.hpp
+++ b/src/drivers/rover_interface/scout_sdk/include/scout_sdk/CAN/SocketCAN.hpp
@@ -1,0 +1,83 @@
+#pragma once
+
+#include <px4_platform_common/px4_config.h>
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <unistd.h>
+#include <string.h>
+
+#include <sys/time.h>
+#include <sys/socket.h>
+
+#include <nuttx/can.h>
+#include <netpacket/can.h>
+
+#include "can_frame.h"
+
+namespace scoutsdk
+{
+/// RX Frame with its reception timestamp.
+struct RxFrame {
+	uint64_t timestamp_usec;
+
+	/// The actual CAN frame data.
+	CANFrame frame;
+};
+
+/// TX Frame with its transmission deadline.
+struct TxFrame {
+	uint64_t tx_deadline_usec;
+
+	/// The actual CAN frame data.
+	CANFrame frame;
+};
+
+
+class SocketCAN
+{
+public:
+	/// Creates a SocketCAN socket for corresponding iface can_iface_name
+	/// Also sets up the message structures required for socketcanTransmit & socketcanReceive
+	/// can_fd determines to use CAN FD frame when is 1, and classical CAN frame when is 0
+	/// The return value is 0 on success and -1 on error
+	int Init(const char* const can_iface_name);
+
+	/// Close socket connection
+	int Close()
+	{
+		return ::close(_fd);
+	}
+
+	/// Send a Frame to the SocketInstance socket
+	/// This function is blocking
+	/// The return value is number of bytes transferred, negative value on error.
+	int16_t SendFrame(const TxFrame &txframe, int timeout_ms = 0);
+
+	/// Receive a Frame from the SocketInstance socket
+	/// This function is blocking
+	/// The return value is number of bytes received, negative value on error.
+	int16_t ReceiveFrame(RxFrame *rxf);
+
+private:
+
+	int               _fd{-1};
+	bool              _can_fd{false};
+
+	//// Send msg structure
+	struct iovec       _send_iov {};
+	struct canfd_frame _send_frame {};
+	struct msghdr      _send_msg {};
+	struct cmsghdr     *_send_cmsg {};
+	struct timeval     *_send_tv {};  /* TX deadline timestamp */
+	uint8_t            _send_control[sizeof(struct cmsghdr) + sizeof(struct timeval)] {};
+
+	//// Receive msg structure
+	struct iovec       _recv_iov {};
+	struct canfd_frame _recv_frame {};
+	struct msghdr      _recv_msg {};
+	struct cmsghdr     *_recv_cmsg {};
+	uint8_t            _recv_control[sizeof(struct cmsghdr) + sizeof(struct timeval)] {};
+};
+} // namespace scoutsdk

--- a/src/drivers/rover_interface/scout_sdk/include/scout_sdk/CAN/can_frame.h
+++ b/src/drivers/rover_interface/scout_sdk/include/scout_sdk/CAN/can_frame.h
@@ -1,0 +1,24 @@
+#ifndef CAN_FRAME_H
+#define CAN_FRAME_H
+
+#include <stdint.h>
+#include <unistd.h>
+
+/// CAN data frame with support for 11-bit ID and extended 29-bit ID.
+typedef struct
+{
+		/// 11-bit or 29-bit extended ID. The bits above 29-th shall be zero.
+		uint32_t can_id;
+
+		/// The useful data in the frame. The length value is not to be confused with DLC!
+		/// If the payload is empty (payload_size = 0), the payload pointer may be NULL.
+		/// For RX frames: the library does not expect the lifetime of the pointee to extend beyond the point of return
+		/// from the API function. That is, the pointee can be invalidated immediately after the frame has been processed.
+		/// For TX frames: the frame and the payload are allocated within the same dynamic memory fragment, so their
+		/// lifetimes are identical; when the frame is freed, the payload is invalidated.
+		/// A more detailed overview of the dataflow and related resource management issues is provided in the API docs.
+		size_t      payload_size;
+		void* payload;
+} CANFrame;
+
+#endif /* CAN_FRAME_H */

--- a/src/drivers/rover_interface/scout_sdk/include/scout_sdk/ScoutRobot.hpp
+++ b/src/drivers/rover_interface/scout_sdk/include/scout_sdk/ScoutRobot.hpp
@@ -1,5 +1,4 @@
-#ifndef SCOUT_ROBOT_HPP
-#define SCOUT_ROBOT_HPP
+#pragma once
 
 #include <cstdint>
 #include <time.h>
@@ -72,7 +71,7 @@ private:
 	void UpdateRobotCoreState(const AgxMessage &status_msg);
 	void UpdateActuatorState(const AgxMessage &status_msg);
 	void UpdateMotorState(const AgxMessage &status_msg);
-	void UpdateVersionResponse(const AgxMessage &status_msg);
+	int UpdateVersionResponse(const AgxMessage &status_msg);
 
 	AgileXProtocolV2Parser _parser;
 
@@ -85,6 +84,8 @@ private:
 	ScoutMotorState _motor_state_msgs;
 
 	VersionResponse _version_response_msgs;
+
+	char _version_response_string[9]{};
 
 	// TX buffer
 	uint8_t _tx_data[8]{};
@@ -99,5 +100,3 @@ private:
 	SocketCAN *_can{nullptr};
 };
 } // namespace scoutsdk
-
-#endif /* SCOUT_ROBOT_HPP */

--- a/src/drivers/rover_interface/scout_sdk/include/scout_sdk/ScoutRobot.hpp
+++ b/src/drivers/rover_interface/scout_sdk/include/scout_sdk/ScoutRobot.hpp
@@ -1,0 +1,103 @@
+#ifndef SCOUT_ROBOT_HPP
+#define SCOUT_ROBOT_HPP
+
+#include <cstdint>
+#include <time.h>
+#include <drivers/drv_hrt.h>
+#include <px4_platform_common/defines.h>
+
+#include "agilex_protocol/agilex_message.h"
+#include "agilex_protocol/agilex_protocol_v2_parser.hpp"
+
+namespace scoutsdk
+{
+struct ScoutCoreState {
+	SystemStateMessage system_state;
+	MotionStateMessage motion_state;
+	LightStateMessage light_state;
+	RcStateMessage rc_state;
+};
+
+struct ScoutActuatorState {
+	ActuatorHSStateMessage actuator_hs_state[4];
+	ActuatorLSStateMessage actuator_ls_state[4];
+};
+
+struct ScoutMotorState {
+	MotorAngleMessage MotorAngle;
+	MotorSpeedMessage MotorSpeed;
+};
+
+struct VersionResponse {
+	const char* str_version_response;
+	VersionResponseMessage version_response;
+};
+
+
+class ScoutRobot {
+public:
+	ScoutRobot(ProtocolVersion protocol = ProtocolVersion::AGX_V2,
+						 bool is_mini_model = false);
+	~ScoutRobot();
+
+	// do not allow copy or assignment
+	ScoutRobot(const ScoutRobot &robot) = delete;
+	ScoutRobot &operator=(const ScoutRobot &robot) = delete;
+
+	// CAN connection
+	void Connect(const char *const can_dev);
+	void Disconnect();
+
+	// Send commands
+	void EnableCommandMode();
+	void QuerySystemVersion(const uint64_t timeout_msec);
+	void SetMotionCommand(float linear_vel, float angular_vel);
+	void SetLightCommand(LightMode f_mode, uint8_t f_value,
+											 LightMode r_mode = LightMode::CONST_ON, uint8_t r_value = 0);
+	void DisableLightControl();
+
+	// Receive status from rover
+	void CheckUpdateFromRover();
+
+	// Get connection and rover general info
+	bool GetCANConnected() const { return _can_connected; }
+	const char* GetSystemVersion() const { return _version_response_msgs.str_version_response; }
+
+	// Return rover states
+	const ScoutCoreState& GetRobotState() const { return _core_state_msgs; }
+	const ScoutActuatorState& GetActuatorState() const { return _actuator_state_msgs; }
+	const ScoutMotorState& GetMotorState() const { return _motor_state_msgs; }
+
+private:
+	void UpdateRobotCoreState(const AgxMessage &status_msg);
+	void UpdateActuatorState(const AgxMessage &status_msg);
+	void UpdateMotorState(const AgxMessage &status_msg);
+	void UpdateVersionResponse(const AgxMessage &status_msg);
+
+	AgileXProtocolV2Parser _parser;
+
+	// Feedback group 1: core state
+	ScoutCoreState _core_state_msgs;
+
+	// Feedback group 2: actuator state
+	ScoutActuatorState _actuator_state_msgs;
+
+	ScoutMotorState _motor_state_msgs;
+
+	VersionResponse _version_response_msgs;
+
+	// TX buffer
+	uint8_t _tx_data[8]{};
+	TxFrame _tx_frame{};
+
+	// RX buffer
+	uint8_t _rx_data[8]{};
+	RxFrame _rx_frame{};
+
+	// Communication interface
+	bool _can_connected = false;
+	SocketCAN *_can{nullptr};
+};
+} // namespace scoutsdk
+
+#endif /* SCOUT_ROBOT_HPP */

--- a/src/drivers/rover_interface/scout_sdk/include/scout_sdk/Utilities.hpp
+++ b/src/drivers/rover_interface/scout_sdk/include/scout_sdk/Utilities.hpp
@@ -1,0 +1,31 @@
+#ifndef UTILITIES_HPP
+#define UTILITIES_HPP
+
+#include <drivers/drv_hrt.h>
+
+#include "CAN/SocketCAN.hpp"
+#include "agilex_protocol/agilex_protocol_v2_parser.hpp"
+
+namespace scoutsdk
+{
+class ProtocolDetector
+{
+public:
+	ProtocolDetector();
+	~ProtocolDetector();
+
+	bool Connect(const char* const can_name);
+
+	ProtocolVersion DetectProtocolVersion(const uint64_t timeout_sec);
+
+ private:
+	SocketCAN *_can;
+	void ParseCANFrame();
+	AgileXProtocolV2Parser _parser;
+
+	bool _msg_v1_detected;
+	bool _msg_v2_detected;
+};
+}  // namespace scoutsdk
+
+#endif /* UTILITIES_HPP */

--- a/src/drivers/rover_interface/scout_sdk/include/scout_sdk/Utilities.hpp
+++ b/src/drivers/rover_interface/scout_sdk/include/scout_sdk/Utilities.hpp
@@ -1,5 +1,4 @@
-#ifndef UTILITIES_HPP
-#define UTILITIES_HPP
+#pragma once
 
 #include <drivers/drv_hrt.h>
 
@@ -27,5 +26,3 @@ public:
 	bool _msg_v2_detected;
 };
 }  // namespace scoutsdk
-
-#endif /* UTILITIES_HPP */

--- a/src/drivers/rover_interface/scout_sdk/include/scout_sdk/agilex_protocol/agilex_message.h
+++ b/src/drivers/rover_interface/scout_sdk/include/scout_sdk/agilex_protocol/agilex_message.h
@@ -1,0 +1,345 @@
+/*
+ * agilex_message.h
+ *
+ * Created on: Dec 10, 2020 11:47
+ * Description:
+ *  all values are using SI units (e.g. meter/second/radian)
+ *
+ * Copyright (c) 2020 Ruixiang Du (rdu)
+ */
+
+#ifndef AGILEX_MESSAGE_H
+#define AGILEX_MESSAGE_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <stdbool.h>
+#include <stdint.h>
+#include <string.h>
+
+#include "agilex_types.h"
+
+/***************** Control messages *****************/
+
+typedef struct {
+	float linear_velocity;
+	float angular_velocity;
+	float lateral_velocity;
+	float steering_angle;
+} MotionCommandMessage;
+
+typedef struct {
+	bool enable_cmd_ctrl;
+	LightOperation front_light;
+	LightOperation rear_light;
+} LightCommandMessage;
+
+typedef struct {
+	bool enable_braking;
+} BrakingCommandMessage;
+
+typedef struct {
+	uint8_t motion_mode;
+} MotionModeCommandMessage;
+
+/**************** Feedback messages *****************/
+
+#define SYSTEM_ERROR_MOTOR_DRIVER_MASK ((uint16_t)0x0100)
+#define SYSTEM_ERROR_HL_COMM_MASK ((uint16_t)0x0200)
+#define SYSTEM_ERROR_BATTERY_FAULT_MASK ((uint16_t)0x0001)
+#define SYSTEM_ERROR_BATTERY_WARNING_MASK ((uint16_t)0x0002)
+#define SYSTEM_ERROR_RC_SIGNAL_LOSS_MASK ((uint16_t)0x0004)
+#define SYSTEM_ERROR_MOTOR1_COMM_MASK ((uint16_t)0x0008)
+#define SYSTEM_ERROR_MOTOR2_COMM_MASK ((uint16_t)0x0010)
+#define SYSTEM_ERROR_MOTOR3_COMM_MASK ((uint16_t)0x0020)
+#define SYSTEM_ERROR_MOTOR4_COMM_MASK ((uint16_t)0x0040)
+#define SYSTEM_ERROR_STEER_ENCODER_MASK ((uint16_t)0x0080)
+
+typedef struct {
+	VehicleState vehicle_state;
+	ControlMode control_mode;
+	float battery_voltage;
+	uint16_t error_code;
+} SystemStateMessage;
+
+typedef struct {
+	float linear_velocity;
+	float angular_velocity;  // only valid for differential drivering
+	float lateral_velocity;
+	float steering_angle;  // only valid for ackermann steering
+} MotionStateMessage;
+
+typedef LightCommandMessage LightStateMessage;
+
+typedef struct {
+	RcSwitchState swa;
+	RcSwitchState swb;
+	RcSwitchState swc;
+	RcSwitchState swd;
+	int8_t stick_right_v;
+	int8_t stick_right_h;
+	int8_t stick_left_v;
+	int8_t stick_left_h;
+	int8_t var_a;
+} RcStateMessage;
+
+typedef struct {
+	uint8_t motor_id;
+	int16_t rpm;
+	float current;
+	int32_t pulse_count;
+} ActuatorHSStateMessage;
+
+#define DRIVER_STATE_INPUT_VOLTAGE_LOW_MASK ((uint8_t)0x01)
+#define DRIVER_STATE_MOTOR_OVERHEAT_MASK ((uint8_t)0x02)
+#define DRIVER_STATE_DRIVER_OVERLOAD_MASK ((uint8_t)0x04)
+#define DRIVER_STATE_DRIVER_OVERHEAT_MASK ((uint8_t)0x08)
+#define DRIVER_STATE_SENSOR_FAULT_MASK ((uint8_t)0x10)
+#define DRIVER_STATE_DRIVER_FAULT_MASK ((uint8_t)0x20)
+#define DRIVER_STATE_DRIVER_ENABLED_MASK ((uint8_t)0x40)
+#define DRIVER_STATE_DRIVER_RESET_MASK ((uint8_t)0x80)
+
+typedef struct {
+	uint8_t motor_id;
+	float driver_voltage;
+	float driver_temp;
+	float motor_temp;
+	uint8_t driver_state;
+} ActuatorLSStateMessage;
+
+typedef struct {
+	uint8_t motion_mode;
+	uint8_t mode_changing;
+} MotionModeStateMessage;
+
+/***************** Sensor messages ******************/
+
+typedef struct {
+	float left_wheel;
+	float right_wheel;
+} OdometryMessage;
+
+typedef struct {
+	float accel_x;
+	float accel_y;
+	float accel_z;
+} ImuAccelMessage;
+
+typedef struct {
+	float gyro_x;
+	float gyro_y;
+	float gyro_z;
+} ImuGyroMessage;
+
+typedef struct {
+	float yaw;
+	float pitch;
+	float roll;
+} ImuEulerMessage;
+
+typedef struct {
+	uint8_t trigger_state;
+} SafetyBumperMessage;
+
+typedef struct {
+	uint8_t sensor_id;
+	uint8_t distance[8];
+} UltrasonicMessage;
+
+typedef struct {
+	uint8_t sensor_id;
+	float relative_distance;
+	float relative_angle;
+	bool is_normal;
+	int8_t channels[3];
+} UwbMessage;
+
+typedef struct {
+	uint8_t battery_soc;
+	uint8_t battery_soh;
+	float voltage;
+	float current;
+	float temperature;
+} BmsBasicMessage;
+
+typedef struct {
+	float angle_5;
+	float angle_6;
+	float angle_7;
+	float angle_8;
+} MotorAngleMessage;
+
+typedef struct {
+	float speed_1;
+	float speed_2;
+	float speed_3;
+	float speed_4;
+} MotorSpeedMessage;
+
+#define BMS_PROT1_CHARGING_CURRENT_NONZERO_MASK ((uint8_t)0x01)
+#define BMS_PROT1_CHARGING_OVERCURRENT_SET_MASK ((uint8_t)0x02)
+#define BMS_PROT1_DISCHARGING_CURRENT_NONZERO_MASK ((uint8_t)0x10)
+#define BMS_PROT1_DISCHARGING_OVERCURRENT_SET_MASK ((uint8_t)0x20)
+#define BMS_PROT1_DISCHARGING_SHORTCIRCUIT_SET_MASK ((uint8_t)0x40)
+
+#define BMS_PROT2_CORE_OPENCIRCUIT_SET_MASK ((uint8_t)0x01)
+#define BMS_PROT2_TEMP_SENSOR_OPENCIRCUIT_SET_MASK ((uint8_t)0x02)
+#define BMS_PROT2_CORE_OVERVOLTAGE_SET_MASK ((uint8_t)0x10)
+#define BMS_PROT2_CORE_UNDERVOLTAGE_SET_MASK ((uint8_t)0x20)
+#define BMS_PROT2_TOTAL_OVERVOLTAGE_SET_MASK ((uint8_t)0x40)
+#define BMS_PROT2_TOTAL_UNDERVOLTAGE_SET_MASK ((uint8_t)0x80)
+
+#define BMS_PROT3_CHARGING_OVERTEMP_SET_MASK ((uint8_t)0x04)
+#define BMS_PROT3_DISCHARGING_OVERTEMP_SET_MASK ((uint8_t)0x08)
+#define BMS_PROT3_CHARGING_UNDERTEMP_SET_MASK ((uint8_t)0x10)
+#define BMS_PROT3_DISCHARGING_UNDERTEMP_SET_MASK ((uint8_t)0x20)
+#define BMS_PROT3_CHARGING_TEMPDIFF_SET_MASK ((uint8_t)0x40)
+#define BMS_PROT3_DISCHARGING_TEMPDIFF_SET_MASK ((uint8_t)0x80)
+
+#define BMS_PROT4_CHARGING_MOS_STATE_SET_MASK ((uint8_t)0x01)
+#define BMS_PROT4_DISCHARGING_MOS_STATE_SET_MASK ((uint8_t)0x02)
+#define BMS_PROT4_CHARGING_MOS_FAILURE_SET_MASK ((uint8_t)0x04)
+#define BMS_PROT4_DISCHARGING_MOS_FAILURE_SET_MASK ((uint8_t)0x08)
+#define BMS_PROT4_WEAK_SIGNAL_SWITCH_OPEN_SET_MASK ((uint8_t)0x10)
+
+typedef struct {
+	uint8_t protection_code1;
+	uint8_t protection_code2;
+	uint8_t protection_code3;
+	uint8_t protection_code4;
+	uint8_t battery_max_teperature;
+	uint8_t battery_min_teperature;
+} BmsExtendedMessage;
+
+/************  Query/config messages ****************/
+
+typedef struct {
+	bool request;
+} VersionRequestMessage;
+
+typedef struct {
+	uint16_t controller_hw_version;
+	uint16_t motor_driver_hw_version;
+	uint16_t controller_sw_version;
+	uint16_t motor_driver_sw_version;
+} VersionResponseMessage;
+
+typedef struct {
+	ControlMode mode;
+} ControlModeConfigMessage;
+
+typedef struct {
+	BrakeMode mode;
+} BrakeModeConfigMessage;
+
+typedef struct {
+	bool set_as_neutral;
+} SteerNeutralRequestMessage;
+
+typedef struct {
+	bool neutral_set_successful;
+} SteerNeutralResponseMessage;
+
+typedef enum {
+	CLEAR_ALL_FAULT = 0x00,
+	CLEAR_MOTOR1_FAULT = 0x01,
+	CLEAR_MOTOR2_FAULT = 0x02,
+	CLEAR_MOTOR3_FAULT = 0x03,
+	CLEAR__MOTOR4_FAULT = 0x04
+} FaultClearCode;
+
+typedef struct {
+	uint8_t error_clear_byte;
+} StateResetConfigMessage;
+
+//////////////////////////////////////////////////////
+
+typedef enum {
+	AgxMsgUnknown = 0x00,
+	// command
+	AgxMsgMotionCommand,
+	AgxMsgLightCommand,
+	AgxMsgBrakingCommand,
+	AgxMsgSetMotionModeCommand,
+	// state feedback
+	AgxMsgSystemState,
+	AgxMsgMotionState,
+	AgxMsgLightState,
+	AgxMsgMotionModeState,
+	AgxMsgRcState,
+	// actuator feedback
+	AgxMsgActuatorHSState,
+	AgxMsgActuatorLSState,
+	AgxMsgMotorAngle,
+	AgxMsgMotorSpeed,
+	// sensor
+	AgxMsgOdometry,
+	AgxMsgImuAccel,
+	AgxMsgImuGyro,
+	AgxMsgImuEuler,
+	AgxMsgSafetyBumper,
+	AgxMsgUltrasonic,
+	AgxMsgUwb,
+	AgxMsgBmsBasic,
+	AgxMsgBmsExtended,
+	// query/config
+	AgxMsgVersionRequest,
+	AgxMsgVersionResponse,
+	AgxMsgControlModeConfig,
+	AgxMsgSteerNeutralRequest,
+	AgxMsgSteerNeutralResponse,
+	AgxMsgStateResetConfig,
+	AgxMsgBrakeModeConfig
+} MsgType;
+
+typedef struct {
+	MsgType type;
+	union {
+		// command
+		MotionCommandMessage motion_command_msg;
+		LightCommandMessage light_command_msg;
+		BrakingCommandMessage braking_command_msg;
+		MotionModeCommandMessage motion_mode_msg;
+		// core state feedback
+		SystemStateMessage system_state_msg;
+		MotionStateMessage motion_state_msg;
+		LightStateMessage light_state_msg;
+		MotionModeStateMessage motion_mode_state_msg;
+		RcStateMessage rc_state_msg;
+		// actuator feedback
+		ActuatorHSStateMessage actuator_hs_state_msg;
+		ActuatorLSStateMessage actuator_ls_state_msg;
+		// sensor
+		OdometryMessage odometry_msg;
+		ImuAccelMessage imu_accel_msg;
+		ImuGyroMessage imu_gyro_msg;
+		ImuEulerMessage imu_euler_msg;
+		SafetyBumperMessage safety_bumper_msg;
+		UltrasonicMessage ultrasonic_msg;
+		UwbMessage uwb_msg;
+		BmsBasicMessage bms_basic_msg;
+		BmsExtendedMessage bms_extended_msg;
+		// query/config
+		VersionRequestMessage version_request_msg;
+		VersionResponseMessage version_response_msg;
+//    uint8_t version_str[10][8];
+		uint8_t version_str[8];
+		ControlModeConfigMessage control_mode_config_msg;
+		BrakeModeConfigMessage brake_mode_config_msg;
+		SteerNeutralRequestMessage steer_neutral_request_msg;
+		SteerNeutralResponseMessage steer_neutral_response_msg;
+		StateResetConfigMessage state_reset_config_msg;
+
+		MotorAngleMessage motor_angle_msg;
+		MotorSpeedMessage motor_speed_msg;
+
+	} body;
+} AgxMessage;
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* AGILEX_MESSAGE_H */

--- a/src/drivers/rover_interface/scout_sdk/include/scout_sdk/agilex_protocol/agilex_msg_parser_v2.h
+++ b/src/drivers/rover_interface/scout_sdk/include/scout_sdk/agilex_protocol/agilex_msg_parser_v2.h
@@ -1,0 +1,23 @@
+#ifndef AGILEX_MSG_PARSER_H
+#define AGILEX_MSG_PARSER_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <stdint.h>
+#include <stdbool.h>
+#include <string.h>
+
+#include "agilex_message.h"
+#include "../CAN/can_frame.h"
+
+bool DecodeCanFrameV2(const CANFrame *can_frame, AgxMessage *msg);
+bool EncodeCanFrameV2(const AgxMessage *msg, CANFrame *can_frame);
+uint8_t CalcCanFrameChecksumV2(uint16_t id, uint8_t *data, uint8_t dlc);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* AGILEX_MSG_PARSER_H */

--- a/src/drivers/rover_interface/scout_sdk/include/scout_sdk/agilex_protocol/agilex_protocol_v2.h
+++ b/src/drivers/rover_interface/scout_sdk/include/scout_sdk/agilex_protocol/agilex_protocol_v2.h
@@ -1,0 +1,439 @@
+/*
+ * agilex_protocol_v2.h
+ *
+ * Created on: Nov 04, 2020 13:54
+ * Description:
+ *
+ * Copyright (c) 2020 Weston Robot Pte. Ltd.
+ */
+
+#ifndef AGILEX_PROTOCOL_V2_H
+#define AGILEX_PROTOCOL_V2_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <stdint.h>
+
+// define endianess of the platform
+#if (!defined(USE_LITTLE_ENDIAN) && !defined(USE_BIG_ENDIAN))
+#define USE_LITTLE_ENDIAN
+#endif
+
+#ifdef USE_BIG_ENDIAN
+#error "BIG ENDIAN IS CURRENTLY NOT SUPPORTED"
+#endif
+
+/*---------------------------- Motor IDs -------------------------------*/
+
+#define ACTUATOR1_ID ((uint8_t)0x00)
+#define ACTUATOR2_ID ((uint8_t)0x01)
+#define ACTUATOR3_ID ((uint8_t)0x02)
+#define ACTUATOR4_ID ((uint8_t)0x03)
+#define ACTUATOR5_ID ((uint8_t)0x04)
+#define ACTUATOR6_ID ((uint8_t)0x05)
+#define ACTUATOR7_ID ((uint8_t)0x06)
+#define ACTUATOR8_ID ((uint8_t)0x07)
+
+/*--------------------------- Message IDs ------------------------------*/
+
+// control group: 0x1
+#define CAN_MSG_MOTION_COMMAND_ID ((uint32_t)0x111)
+#define CAN_MSG_LIGHT_COMMAND_ID ((uint32_t)0x121)
+#define CAN_MSG_BRAKING_COMMAND_ID ((uint32_t)0x131)
+#define CAN_MSG_SET_MOTION_MODE_ID ((uint32_t)0x141)
+
+// state feedback group: 0x2
+#define CAN_MSG_SYSTEM_STATE_ID ((uint32_t)0x211)
+#define CAN_MSG_MOTION_STATE_ID ((uint32_t)0x221)
+#define CAN_MSG_LIGHT_STATE_ID ((uint32_t)0x231)
+#define CAN_MSG_RC_STATE_ID ((uint32_t)0x241)
+
+#define CAN_MSG_ACTUATOR1_HS_STATE_ID ((uint32_t)0x251)
+#define CAN_MSG_ACTUATOR2_HS_STATE_ID ((uint32_t)0x252)
+#define CAN_MSG_ACTUATOR3_HS_STATE_ID ((uint32_t)0x253)
+#define CAN_MSG_ACTUATOR4_HS_STATE_ID ((uint32_t)0x254)
+#define CAN_MSG_ACTUATOR5_HS_STATE_ID ((uint32_t)0x255)
+#define CAN_MSG_ACTUATOR6_HS_STATE_ID ((uint32_t)0x256)
+#define CAN_MSG_ACTUATOR7_HS_STATE_ID ((uint32_t)0x257)
+#define CAN_MSG_ACTUATOR8_HS_STATE_ID ((uint32_t)0x258)
+
+#define CAN_MSG_ACTUATOR1_LS_STATE_ID ((uint32_t)0x261)
+#define CAN_MSG_ACTUATOR2_LS_STATE_ID ((uint32_t)0x262)
+#define CAN_MSG_ACTUATOR3_LS_STATE_ID ((uint32_t)0x263)
+#define CAN_MSG_ACTUATOR4_LS_STATE_ID ((uint32_t)0x264)
+#define CAN_MSG_ACTUATOR5_LS_STATE_ID ((uint32_t)0x265)
+#define CAN_MSG_ACTUATOR6_LS_STATE_ID ((uint32_t)0x266)
+#define CAN_MSG_ACTUATOR7_LS_STATE_ID ((uint32_t)0x267)
+#define CAN_MSG_ACTUATOR8_LS_STATE_ID ((uint32_t)0x268)
+
+#define CAN_MSG_MOTOR_ANGLE_INFO ((uint32_t)0x271)
+#define CAN_MSG_MOTOR_SPEED_INFO ((uint32_t)0x281)
+#define CAN_MSG_CURRENT_CTRL_MODE ((uint32_t)0x291)
+
+// sensor data group: 0x3
+#define CAN_MSG_ODOMETRY_ID ((uint32_t)0x311)
+
+#define CAN_MSG_IMU_ACCEL_ID ((uint32_t)0x321)
+#define CAN_MSG_IMU_GYRO_ID ((uint32_t)0x322)
+#define CAN_MSG_IMU_EULER_ID ((uint32_t)0x323)
+
+#define CAN_MSG_SAFETY_BUMPER_ID ((uint32_t)0x331)
+
+#define CAN_MSG_ULTRASONIC_1_ID ((uint32_t)0x341)
+#define CAN_MSG_ULTRASONIC_2_ID ((uint32_t)0x342)
+#define CAN_MSG_ULTRASONIC_3_ID ((uint32_t)0x343)
+#define CAN_MSG_ULTRASONIC_4_ID ((uint32_t)0x344)
+#define CAN_MSG_ULTRASONIC_5_ID ((uint32_t)0x345)
+#define CAN_MSG_ULTRASONIC_6_ID ((uint32_t)0x346)
+#define CAN_MSG_ULTRASONIC_7_ID ((uint32_t)0x347)
+#define CAN_MSG_ULTRASONIC_8_ID ((uint32_t)0x348)
+
+#define CAN_MSG_UWB_1_ID ((uint32_t)0x351)
+#define CAN_MSG_UWB_2_ID ((uint32_t)0x352)
+#define CAN_MSG_UWB_3_ID ((uint32_t)0x353)
+#define CAN_MSG_UWB_4_ID ((uint32_t)0x354)
+
+#define CAN_MSG_BMS_BASIC_ID ((uint32_t)0x361)
+#define CAN_MSG_BMS_EXTENDED_ID ((uint32_t)0x362)
+
+// query/config group: 0x4
+#define CAN_MSG_VERSION_REQUEST_ID ((uint32_t)0x411)
+#define CAN_MSG_VERSION_RESPONSE_ID ((uint32_t)0x4a1)
+
+#define CAN_MSG_CTRL_MODE_CONFIG_ID ((uint32_t)0x421)
+
+#define CAN_MSG_STEER_NEUTRAL_REQUEST_ID ((uint32_t)0x431)
+#define CAN_MSG_STEER_NEUTRAL_RESPONSE_ID ((uint32_t)0x43a)
+
+#define CAN_MSG_STATE_RESET_CONFIG_ID ((uint32_t)0x441)
+
+/*------------------------ Frame Memory Layout -------------------------*/
+
+/* No padding in the struct */
+// reference: https://stackoverflow.com/questions/3318410/pragma-pack-effect
+#pragma pack(push, 1)
+
+#ifdef USE_LITTLE_ENDIAN
+typedef struct {
+  uint8_t high_byte;
+  uint8_t low_byte;
+} struct16_t;
+typedef struct {
+  uint8_t msb;
+  uint8_t high_byte;
+  uint8_t low_byte;
+  uint8_t lsb;
+} struct32_t;
+#elif defined(USE_BIG_ENDIAN)
+typedef struct {
+  uint8_t low_byte;
+  uint8_t high_byte;
+} struct16_t;
+typedef struct {
+  uint8_t lsb;
+  uint8_t low_byte;
+  uint8_t high_byte;
+  uint8_t msb;
+} struct32_t;
+#endif
+
+// Control messages
+typedef struct {
+  struct16_t linear_velocity;
+  struct16_t angular_velocity;
+  struct16_t lateral_velocity;
+  struct16_t steering_angle;
+} MotionCommandFrame;
+
+#define LIGHT_ENABLE_CMD_CTRL ((uint8_t)0x01)
+#define LIGHT_DISABLE_CMD_CTRL ((uint8_t)0x00)
+
+typedef struct {
+  uint8_t enable_cmd_ctrl;
+  uint8_t front_mode;
+  uint8_t front_custom;
+  uint8_t rear_mode;
+  uint8_t rear_custom;
+  uint8_t reserved0;
+  uint8_t reserved1;
+  uint8_t count;
+} LightCommandFrame;
+
+typedef struct {
+  uint8_t enable_brake;
+  uint8_t count;
+} BrakingCommandFrame;
+
+typedef struct {
+  uint8_t motion_mode;
+  uint8_t reserved0;
+  uint8_t reserved1;
+  uint8_t reserved2;
+  uint8_t reserved3;
+  uint8_t reserved4;
+  uint8_t reserved5;
+  uint8_t reserved6;
+} SetMotionModeFrame;
+
+// State feedback messages
+typedef struct {
+  uint8_t vehicle_state;
+  uint8_t control_mode;
+  struct16_t battery_voltage;
+  struct16_t error_code;
+  uint8_t reserved0;
+  uint8_t count;
+} SystemStateFrame;
+
+typedef struct {
+  struct16_t linear_velocity;
+  struct16_t angular_velocity;
+  struct16_t lateral_velocity;
+  struct16_t steering_angle;
+} MotionStateFrame;
+
+typedef struct {
+  uint8_t enable_cmd_ctrl;
+  uint8_t front_mode;
+  uint8_t front_custom;
+  uint8_t rear_mode;
+  uint8_t rear_custom;
+  uint8_t reserved0;
+  uint8_t reserved1;
+  uint8_t count;
+} LightStateFrame;
+
+#define RC_SWA_MASK ((uint8_t)0b00000011)
+#define RC_SWA_UP_MASK ((uint8_t)0b00000010)
+#define RC_SWA_DOWN_MASK ((uint8_t)0b00000011)
+
+#define RC_SWB_MASK ((uint8_t)0b00001100)
+#define RC_SWB_UP_MASK ((uint8_t)0b00001000)
+#define RC_SWB_MIDDLE_MASK ((uint8_t)0b00000100)
+#define RC_SWB_DOWN_MASK ((uint8_t)0b00001100)
+
+#define RC_SWC_MASK ((uint8_t)0b00110000)
+#define RC_SWC_UP_MASK ((uint8_t)0b00100000)
+#define RC_SWC_MIDDLE_MASK ((uint8_t)0b00010000)
+#define RC_SWC_DOWN_MASK ((uint8_t)0b00110000)
+
+#define RC_SWD_MASK ((uint8_t)0b11000000)
+#define RC_SWD_UP_MASK ((uint8_t)0b10000000)
+#define RC_SWD_DOWN_MASK ((uint8_t)0b11000000)
+
+typedef struct {
+  uint8_t sws;
+  int8_t stick_right_h;
+  int8_t stick_right_v;
+  int8_t stick_left_v;
+  int8_t stick_left_h;
+  int8_t var_a;
+  uint8_t reserved0;
+  uint8_t count;
+} RcStateFrame;
+
+typedef struct {
+  struct16_t rpm;
+  struct16_t current;
+  struct32_t pulse_count;
+} ActuatorHSStateFrame;
+
+typedef struct {
+  struct16_t driver_voltage;
+  struct16_t driver_temp;
+  int8_t motor_temp;
+  uint8_t driver_state;
+  uint8_t reserved0;
+  uint8_t reserved1;
+} ActuatorLSStateFrame;
+
+// 0x291
+typedef struct {
+  uint8_t motion_mode;
+  uint8_t mode_changing;
+} MotionModeStateFrame;
+
+// sensors
+typedef struct {
+  struct32_t left_wheel;
+  struct32_t right_wheel;
+} OdometryFrame;
+
+typedef struct {
+  struct16_t accel_x;
+  struct16_t accel_y;
+  struct16_t accel_z;
+  uint8_t reserverd0;
+  uint8_t count;
+} ImuAccelFrame;
+
+typedef struct {
+  struct16_t gyro_x;
+  struct16_t gyro_y;
+  struct16_t gyro_z;
+  uint8_t reserverd0;
+  uint8_t count;
+} ImuGyroFrame;
+
+typedef struct {
+  struct16_t yaw;
+  struct16_t pitch;
+  struct16_t roll;
+  uint8_t reserverd0;
+  uint8_t count;
+} ImuEulerFrame;
+
+typedef struct {
+  uint8_t trigger_state;
+  uint8_t reserved0;
+  uint8_t reserved1;
+  uint8_t reserved2;
+  uint8_t reserved3;
+  uint8_t reserved4;
+  uint8_t reserved5;
+  uint8_t reserved6;
+} SafetyBumperFrame;
+
+typedef struct {
+  uint8_t distance[8];
+} UltrasonicFrame;
+
+typedef struct {
+  struct16_t relative_distance;
+  struct16_t relative_angle;
+  uint8_t is_normal;
+  int8_t channels[3];
+} UwbFrame;
+
+typedef struct {
+  uint8_t battery_soc;
+  uint8_t battery_soh;
+  struct16_t voltage;
+  struct16_t current;
+  struct16_t temperature;
+} BmsBasicFrame;
+
+typedef struct {
+  uint8_t protection_code1;
+  uint8_t protection_code2;
+  uint8_t protection_code3;
+  uint8_t protection_code4;
+  uint8_t battery_max_teperature;
+  uint8_t battery_min_teperature;
+  struct16_t count;
+} BmsExtendedFrame;
+
+// query/config
+#define VERSION_REQUEST_VALUE ((uint8_t)0x01)
+#define STEER_NEUTRAL_REQUEST_VALUE ((uint8_t)0xee)
+#define STEER_NEUTRAL_RESPONSE_SUCCESS_VALUE ((uint8_t)0xee)
+#define STEER_NEUTRAL_RESPONSE_FAILURE_VALUE ((uint8_t)0xff)
+
+typedef struct {
+  uint8_t request;
+  uint8_t reserved0;
+  uint8_t reserved1;
+  uint8_t reserved2;
+  uint8_t reserved3;
+  uint8_t reserved4;
+  uint8_t reserved5;
+  uint8_t reserved6;
+} VersionRequestFrame;
+
+//typedef struct {
+//  struct16_t controller_hw_version;
+//  struct16_t motor_driver_hw_version;
+//  struct16_t controller_sw_version;
+//  struct16_t motor_driver_sw_version;
+//} VersionResponseFrame;
+
+typedef struct {
+  uint8_t res0;
+  uint8_t res1;
+  uint8_t res2;
+  uint8_t res3;
+  uint8_t res4;
+  uint8_t res5;
+  uint8_t res6;
+  uint8_t res7;
+} VersionResponseFrame;
+
+
+typedef struct {
+  uint8_t mode;
+  uint8_t reserved0;
+  uint8_t reserved1;
+  uint8_t reserved2;
+  uint8_t reserved3;
+  uint8_t reserved4;
+  uint8_t reserved5;
+  uint8_t reserved6;
+} ControlModeConfigFrame;
+
+typedef struct {
+  uint8_t mode;
+  uint8_t reserved0;
+  uint8_t reserved1;
+  uint8_t reserved2;
+  uint8_t reserved3;
+  uint8_t reserved4;
+  uint8_t reserved5;
+  uint8_t reserved6;
+} BrakeModeConfigFrame;
+
+typedef struct {
+  uint8_t set_as_neutral;
+  uint8_t reserved0;
+  uint8_t reserved1;
+  uint8_t reserved2;
+  uint8_t reserved3;
+  uint8_t reserved4;
+  uint8_t reserved5;
+  uint8_t reserved6;
+} SteerNeutralRequestFrame;
+
+typedef struct {
+  uint8_t neutral_set_successful;
+  uint8_t reserved0;
+  uint8_t reserved1;
+  uint8_t reserved2;
+  uint8_t reserved3;
+  uint8_t reserved4;
+  uint8_t reserved5;
+  uint8_t reserved6;
+} SteerNeutralResponseFrame;
+
+typedef struct {
+  uint8_t error_clear_byte;
+  uint8_t reserved0;
+  uint8_t reserved1;
+  uint8_t reserved2;
+  uint8_t reserved3;
+  uint8_t reserved4;
+  uint8_t reserved5;
+  uint8_t reserved6;
+} StateResetConfigFrame;
+
+typedef struct {
+  struct16_t angle_5;
+  struct16_t angle_6;
+  struct16_t angle_7;
+  struct16_t angle_8;
+} MoterAngleFrame;
+
+typedef struct {
+  struct16_t speed_1;
+  struct16_t speed_2;
+  struct16_t speed_3;
+  struct16_t speed_4;
+} MoterSpeedFrame;
+
+#pragma pack(pop)
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* AGILEX_PROTOCOL_V2_H */

--- a/src/drivers/rover_interface/scout_sdk/include/scout_sdk/agilex_protocol/agilex_protocol_v2_parser.hpp
+++ b/src/drivers/rover_interface/scout_sdk/include/scout_sdk/agilex_protocol/agilex_protocol_v2_parser.hpp
@@ -1,0 +1,20 @@
+#ifndef AGILEX_PROTOCOL_V2_PARSER_HPP
+#define AGILEX_PROTOCOL_V2_PARSER_HPP
+
+#include "agilex_message.h"
+#include "agilex_msg_parser_v2.h"
+#include "../CAN/SocketCAN.hpp"
+
+namespace scoutsdk
+{
+enum class ProtocolVersion { UNKNOWN, AGX_V1, AGX_V2 };
+
+class AgileXProtocolV2Parser
+{
+ public:
+	bool DecodeMessage(const RxFrame *rxf, AgxMessage *msg);
+	bool EncodeMessage(const AgxMessage *msg, TxFrame *txf);
+	uint8_t CalculateChecksum(uint16_t id, uint8_t *data, uint8_t dlc);
+};
+}	// namespace scoutsdk
+#endif /* AGILEX_PROTOCOL_V2_PARSER_HPP */

--- a/src/drivers/rover_interface/scout_sdk/include/scout_sdk/agilex_protocol/agilex_types.h
+++ b/src/drivers/rover_interface/scout_sdk/include/scout_sdk/agilex_protocol/agilex_types.h
@@ -1,0 +1,60 @@
+/*
+ * agilex_types.h
+ *
+ * Created on: Jul 09, 2021 21:57
+ * Description:
+ *
+ * Copyright (c) 2021 Ruixiang Du (rdu)
+ */
+
+#ifndef AGILEX_TYPES_H
+#define AGILEX_TYPES_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <stdint.h>
+
+typedef enum {
+	CONST_OFF = 0x00,
+	CONST_ON = 0x01,
+	BREATH = 0x02,
+	CUSTOM = 0x03
+} LightMode;
+
+typedef struct {
+	LightMode mode;
+	uint8_t custom_value;
+} LightOperation;
+
+typedef enum {
+	VehicleStateNormal = 0x00,
+	VehicleStateEStop = 0x01,
+	VehicleStateException = 0x02
+} VehicleState;
+
+typedef enum {
+	//   CONTROL_MODE_STANDBY = 0x00,
+	CONTROL_MODE_RC = 0x00,
+	CONTROL_MODE_CAN = 0x01,
+	CONTROL_MODE_UART = 0x02
+} ControlMode;
+
+typedef enum {
+	//   CONTROL_MODE_STANDBY = 0x00,
+	BRAKE_MODE_UNLOCK = 0x00,
+	BRAKE_MODE_LOCK = 0x01
+} BrakeMode;
+
+typedef enum {
+	RC_SWITCH_UP = 0,
+	RC_SWITCH_MIDDLE,
+	RC_SWITCH_DOWN
+} RcSwitchState;
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* AGILEX_TYPES_H */

--- a/src/drivers/rover_interface/scout_sdk/src/CAN/SocketCAN.cpp
+++ b/src/drivers/rover_interface/scout_sdk/src/CAN/SocketCAN.cpp
@@ -1,0 +1,251 @@
+/****************************************************************************
+ *
+ *   Copyright (c) 2020 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+#include "scout_sdk/CAN/SocketCAN.hpp"
+
+#include <net/if.h>
+#include <sys/ioctl.h>
+
+#define MODULE_NAME "SCOUT_SDK"
+
+#include <px4_platform_common/log.h>
+
+uint64_t getMonotonicTimestampUSec(void)
+{
+	struct timespec ts {};
+
+	clock_gettime(CLOCK_MONOTONIC, &ts);
+
+	return ts.tv_sec * 1000000ULL + ts.tv_nsec / 1000ULL;
+}
+
+
+namespace scoutsdk
+{
+int SocketCAN::Init(const char* const can_iface_name)
+{
+	struct sockaddr_can addr;
+	struct ifreq ifr;
+
+	// Disable CAN FD mode
+	bool can_fd = 0;
+
+	_can_fd = can_fd;
+
+	/* Open socket */
+	if ((_fd = socket(PF_CAN, SOCK_RAW, CAN_RAW)) < 0)
+	{
+		PX4_ERR("Opening socket failed");
+		return -1;
+	}
+
+	strncpy(ifr.ifr_name, can_iface_name, IFNAMSIZ - 1);
+	ifr.ifr_name[IFNAMSIZ - 1] = '\0';
+	ifr.ifr_ifindex = if_nametoindex(ifr.ifr_name);
+
+	if (!ifr.ifr_ifindex)
+	{
+		PX4_ERR("if_nametoindex");
+		return -1;
+	}
+
+	memset(&addr, 0, sizeof(addr));
+	addr.can_family = AF_CAN;
+	addr.can_ifindex = ifr.ifr_ifindex;
+
+	const int on = 1;
+	/* RX Timestamping */
+
+	if (setsockopt(_fd, SOL_SOCKET, SO_TIMESTAMP, &on, sizeof(on)) < 0)
+	{
+		PX4_ERR("SO_TIMESTAMP is disabled");
+		return -1;
+	}
+
+	/* NuttX Feature: Enable TX deadline when sending CAN frames
+	 * When a deadline occurs the driver will remove the CAN frame
+	 */
+
+	if (setsockopt(_fd, SOL_CAN_RAW, CAN_RAW_TX_DEADLINE, &on, sizeof(on)) < 0)
+	{
+		PX4_ERR("CAN_RAW_TX_DEADLINE is disabled");
+		return -1;
+	}
+
+	if (can_fd)
+	{
+		if (setsockopt(_fd, SOL_CAN_RAW, CAN_RAW_FD_FRAMES, &on, sizeof(on)) < 0)
+		{
+			PX4_ERR("no CAN FD support");
+			return -1;
+		}
+	}
+
+	if (bind(_fd, (struct sockaddr *)&addr, sizeof(addr)) < 0)
+	{
+		PX4_ERR("bind");
+		return -1;
+	}
+
+	// Setup TX msg
+	_send_iov.iov_base = &_send_frame;
+
+	if (_can_fd) { _send_iov.iov_len = sizeof(struct canfd_frame); }
+	else { _send_iov.iov_len = sizeof(struct can_frame); }
+
+	memset(&_send_control, 0x00, sizeof(_send_control));
+
+	_send_msg.msg_iov    = &_send_iov;
+	_send_msg.msg_iovlen = 1;
+	_send_msg.msg_control = &_send_control;
+	_send_msg.msg_controllen = sizeof(_send_control);
+
+	_send_cmsg = CMSG_FIRSTHDR(&_send_msg);
+	_send_cmsg->cmsg_level = SOL_CAN_RAW;
+	_send_cmsg->cmsg_type = CAN_RAW_TX_DEADLINE;
+	_send_cmsg->cmsg_len = sizeof(struct timeval);
+	_send_tv = (struct timeval *)CMSG_DATA(_send_cmsg);
+
+	// Setup RX msg
+	_recv_iov.iov_base = &_recv_frame;
+
+	if (can_fd) { _recv_iov.iov_len = sizeof(struct canfd_frame); }
+	else { _recv_iov.iov_len = sizeof(struct can_frame); }
+
+	memset(_recv_control, 0x00, sizeof(_recv_control));
+
+	_recv_msg.msg_iov = &_recv_iov;
+	_recv_msg.msg_iovlen = 1;
+	_recv_msg.msg_control = &_recv_control;
+	_recv_msg.msg_controllen = sizeof(_recv_control);
+	_recv_cmsg = CMSG_FIRSTHDR(&_recv_msg);
+
+	// Setup RX range filter [ RANGE FILTER NEEDS TO BE SET BEFORE ANY BIT FILTER]
+	ifr.ifr_ifru.ifru_can_filter.fid1 = 0x211;	// lower end
+	ifr.ifr_ifru.ifru_can_filter.fid2 = 0x231;	// higher end
+	ifr.ifr_ifru.ifru_can_filter.ftype = CAN_FILTER_RANGE;
+	ifr.ifr_ifru.ifru_can_filter.fprio = CAN_MSGPRIO_LOW;
+	if (ioctl(_fd, SIOCACANSTDFILTER, &ifr) < 0)
+	{
+		PX4_ERR("Setting RX range filter failed");
+		return -1;
+	}
+
+	// Setup RX bit filter
+	ifr.ifr_ifru.ifru_can_filter.fid1 = 0x41A;	// value
+	ifr.ifr_ifru.ifru_can_filter.fid2 = 0x7FF;	// mask
+	ifr.ifr_ifru.ifru_can_filter.ftype = CAN_FILTER_MASK;
+	ifr.ifr_ifru.ifru_can_filter.fprio = CAN_MSGPRIO_LOW;
+	if (ioctl(_fd, SIOCACANSTDFILTER, &ifr) < 0)
+	{
+		PX4_ERR("Setting RX bit filter A failed");
+		return -1;
+	}
+
+	return 0;
+}
+
+int16_t SocketCAN::SendFrame(const TxFrame &txf, int timeout_ms)
+{
+	/* Copy Frame to can_frame/canfd_frame */
+	if (_can_fd)
+	{
+		_send_frame.can_id = txf.frame.can_id | CAN_EFF_FLAG;
+		_send_frame.len = txf.frame.payload_size;
+		memcpy(&_send_frame.data, txf.frame.payload, txf.frame.payload_size);
+
+	}
+	else
+	{
+		struct can_frame *frame = (struct can_frame *)&_send_frame;
+		//frame->can_id = txf.frame.can_id | CAN_EFF_FLAG;
+		frame->can_id = txf.frame.can_id;
+		frame->can_dlc = txf.frame.payload_size;
+		memcpy(&frame->data, txf.frame.payload, txf.frame.payload_size);
+		PX4_DEBUG("cansend len %d; can_id: %03x", frame->can_dlc, frame->can_id);
+	}
+
+	uint64_t deadline_systick = getMonotonicTimestampUSec() + (txf.tx_deadline_usec - hrt_absolute_time()) +
+						CONFIG_USEC_PER_TICK; // Compensate for precision loss when converting hrt to systick
+
+	/* Set CAN_RAW_TX_DEADLINE timestamp  */
+	_send_tv->tv_usec = deadline_systick % 1000000ULL;
+	_send_tv->tv_sec = (deadline_systick - _send_tv->tv_usec) / 1000000ULL;
+
+	auto ret =  sendmsg(_fd, &_send_msg, 0);
+
+	return ret;
+}
+
+int16_t SocketCAN::ReceiveFrame(RxFrame *rxf)
+{
+	int32_t result = recvmsg(_fd, &_recv_msg, MSG_DONTWAIT);
+
+	if (result <= 0) { return result; }
+
+	/* Copy CAN frame to Frame */
+
+	if (_can_fd)
+	{
+		struct canfd_frame *recv_frame = (struct canfd_frame *)&_recv_frame;
+		rxf->frame.can_id = recv_frame->can_id & CAN_EFF_MASK;
+		rxf->frame.payload_size = recv_frame->len;
+		if (recv_frame->len > 0)
+		{
+			memcpy(rxf->frame.payload, &recv_frame->data, recv_frame->len);
+		}
+		}
+	else
+	{
+		struct can_frame *recv_frame = (struct can_frame *)&_recv_frame;
+		rxf->frame.can_id = recv_frame->can_id & CAN_SFF_MASK;
+		rxf->frame.payload_size = recv_frame->can_dlc;
+		if (recv_frame->can_dlc > 0 && recv_frame->can_dlc <= CAN_MAX_DLEN)
+		{
+			rxf->frame.payload_size = recv_frame->can_dlc;
+			memcpy(rxf->frame.payload, &recv_frame->data, recv_frame->can_dlc);
+			PX4_DEBUG("can len %d; can_id: %03x", recv_frame->can_dlc, recv_frame->can_id);
+		}
+	}
+
+	/* Read SO_TIMESTAMP value */
+
+	if (_recv_cmsg->cmsg_level == SOL_SOCKET && _recv_cmsg->cmsg_type == SO_TIMESTAMP)
+	{
+		struct timeval *tv = (struct timeval *)CMSG_DATA(_recv_cmsg);
+		rxf->timestamp_usec = tv->tv_sec * 1000000ULL + tv->tv_usec;
+	}
+
+	return result;
+}
+}	// namespace scoutsdk

--- a/src/drivers/rover_interface/scout_sdk/src/ScoutRobot.cpp
+++ b/src/drivers/rover_interface/scout_sdk/src/ScoutRobot.cpp
@@ -1,0 +1,301 @@
+#include "scout_sdk/ScoutRobot.hpp"
+
+#define MODULE_NAME "SCOUT_SDK"
+
+#include <px4_platform_common/log.h>
+
+namespace scoutsdk
+{
+ScoutRobot::ScoutRobot(ProtocolVersion protocol, bool is_mini_model)
+{
+	if (!is_mini_model)
+	{
+		PX4_ERR("Only Scout Mini model is supported. Aborted");
+	}
+	else
+	{
+		if (protocol == ProtocolVersion::AGX_V1)
+		{
+			PX4_ERR("Protocol AGX V1 is not supported. Aborted");
+		}
+		else if (protocol == ProtocolVersion::AGX_V2)
+		{
+			PX4_INFO("Protocol AGX V2 is supported");
+		}
+	}
+
+	// Setup buffers
+	_tx_frame.frame.payload = &_tx_data;
+	_rx_frame.frame.payload = &_rx_data;
+
+	_version_response_msgs.str_version_response = nullptr;
+}
+
+
+ScoutRobot::~ScoutRobot()
+{
+	if	(_version_response_msgs.str_version_response != nullptr)
+	{
+		free((char *)_version_response_msgs.str_version_response);
+		_version_response_msgs.str_version_response = nullptr;
+	}
+
+	Disconnect();
+}
+
+
+void ScoutRobot::Connect(const char *const can_dev)
+{
+	_can = new SocketCAN();
+	if (_can->Init(can_dev) == PX4_OK) { _can_connected = true; }
+}
+
+
+void ScoutRobot::Disconnect()
+{
+	if (_can_connected) { _can->Close(); }
+
+	if (_can != nullptr)
+	{
+		delete _can;
+		_can = nullptr;
+	}
+}
+
+
+void ScoutRobot::UpdateRobotCoreState(const AgxMessage &status_msg)
+{
+	switch (status_msg.type)
+	{
+		case AgxMsgSystemState:
+		{
+			//   std::cout << "system status feedback received" << std::endl;
+			_core_state_msgs.system_state = status_msg.body.system_state_msg;
+			break;
+		}
+		case AgxMsgMotionState:
+		{
+			// std::cout << "motion control feedback received" << std::endl;
+			_core_state_msgs.motion_state = status_msg.body.motion_state_msg;
+			break;
+		}
+		case AgxMsgLightState:
+		{
+			// std::cout << "light control feedback received" << std::endl;
+			_core_state_msgs.light_state = status_msg.body.light_state_msg;
+			break;
+		}
+		case AgxMsgRcState:
+		{
+			// std::cout << "rc feedback received" << std::endl;
+			_core_state_msgs.rc_state = status_msg.body.rc_state_msg;
+			break;
+		}
+		default:
+			break;
+	}
+}
+
+void ScoutRobot::UpdateActuatorState(const AgxMessage &status_msg)
+{
+	switch (status_msg.type)
+	{
+		case AgxMsgActuatorHSState:
+		{
+			// std::cout << "actuator hs feedback received" << std::endl;
+			_actuator_state_msgs
+					.actuator_hs_state[status_msg.body.actuator_hs_state_msg.motor_id] =
+					status_msg.body.actuator_hs_state_msg;
+			break;
+		}
+		case AgxMsgActuatorLSState:
+		{
+			// std::cout << "actuator ls feedback received" << std::endl;
+			_actuator_state_msgs
+					.actuator_ls_state[status_msg.body.actuator_ls_state_msg.motor_id] =
+					status_msg.body.actuator_ls_state_msg;
+			break;
+		}
+		default:
+			break;
+	}
+}
+
+
+void ScoutRobot::UpdateMotorState(const AgxMessage &status_msg){
+	switch (status_msg.type)
+	{
+		case AgxMsgMotorAngle:
+		{
+			_motor_state_msgs.MotorAngle.angle_5 = status_msg.body.motor_angle_msg.angle_5;
+			_motor_state_msgs.MotorAngle.angle_6 = status_msg.body.motor_angle_msg.angle_6;
+			_motor_state_msgs.MotorAngle.angle_7 = status_msg.body.motor_angle_msg.angle_7;
+			_motor_state_msgs.MotorAngle.angle_8 = status_msg.body.motor_angle_msg.angle_8;
+			break;
+		}
+	case AgxMsgMotorSpeed:
+	{
+			_motor_state_msgs.MotorSpeed.speed_1 = status_msg.body.motor_speed_msg.speed_1;
+			_motor_state_msgs.MotorSpeed.speed_2 = status_msg.body.motor_speed_msg.speed_2;
+			_motor_state_msgs.MotorSpeed.speed_3 = status_msg.body.motor_speed_msg.speed_3;
+			_motor_state_msgs.MotorSpeed.speed_4 = status_msg.body.motor_speed_msg.speed_4;
+		break;
+	}
+		default:
+			break;
+	}
+}
+
+
+void ScoutRobot::UpdateVersionResponse(const AgxMessage &status_msg)
+{
+	switch (status_msg.type)
+	{
+		case AgxMsgVersionResponse:
+		{
+			// Clear response version string
+			if	(_version_response_msgs.str_version_response != nullptr)
+			{
+				free((char *)_version_response_msgs.str_version_response);
+				_version_response_msgs.str_version_response = nullptr;
+			}
+
+			char temp_version_response[9] = {0};
+			for (int i = 0; i < 8; i++)
+			{
+				uint8_t data = status_msg.body.version_str[i];
+				if(data < 32 || data>126) { data = 32; }
+				snprintf(temp_version_response + i, 2, "%c", data);
+			}
+			_version_response_msgs.str_version_response = strdup(temp_version_response);
+			break;
+		}
+		default:
+			break;
+	}
+}
+
+
+/******************
+ * PUBLIC METHODS *
+******************/
+void ScoutRobot::CheckUpdateFromRover()
+{
+	_can->ReceiveFrame(&_rx_frame);
+
+	AgxMessage status_msg;
+	if (_parser.DecodeMessage(&_rx_frame, &status_msg))
+	{
+		UpdateRobotCoreState(status_msg);	// 0x211
+		UpdateActuatorState(status_msg);	// 0x251-0x254
+		UpdateMotorState(status_msg);
+	}
+}
+
+void ScoutRobot::EnableCommandMode()
+{
+	PX4_INFO("EnableCommandMode");
+	// Construct message
+	AgxMessage msg;
+	msg.type = AgxMsgControlModeConfig;
+	msg.body.control_mode_config_msg.mode = CONTROL_MODE_CAN;
+
+	// Encode msg to can frame and send to bus
+	if (_parser.EncodeMessage(&msg, &_tx_frame))
+	{
+		uint64_t count = 0;
+		while(count < 100)
+		{
+			count++;
+			_can->SendFrame(_tx_frame);
+		}
+	}
+}
+
+void ScoutRobot::QuerySystemVersion(const uint64_t timeout_msec)
+{
+	// Construct message
+	AgxMessage msg;
+	msg.type = AgxMsgVersionRequest;
+	msg.body.version_request_msg.request = 1;
+
+	// Clear current system version string value
+	if	(_version_response_msgs.str_version_response != nullptr)
+	{
+		free((char *)_version_response_msgs.str_version_response);
+		_version_response_msgs.str_version_response = nullptr;
+	}
+
+	const hrt_abstime begin = hrt_absolute_time();
+	while(hrt_elapsed_time(&begin) < timeout_msec)
+	{
+		// Send request
+		if (_parser.EncodeMessage(&msg, &_tx_frame)) { _can->SendFrame(_tx_frame); }
+
+		// Receive response
+		_can->ReceiveFrame(&_rx_frame);
+
+		AgxMessage status_msg;
+		if (_parser.DecodeMessage(&_rx_frame, &status_msg))
+		{
+			UpdateVersionResponse(status_msg);
+		}
+
+		if(_version_response_msgs.str_version_response != nullptr) { break; }
+	}
+}
+
+
+void ScoutRobot::SetMotionCommand(float linear_vel, float angular_vel)
+{
+	if (_can_connected)
+	{
+		// motion control message
+		AgxMessage msg;
+		msg.type = AgxMsgMotionCommand;
+		msg.body.motion_command_msg.linear_velocity = linear_vel;
+		msg.body.motion_command_msg.angular_velocity = angular_vel;
+		msg.body.motion_command_msg.lateral_velocity = 0.0;
+		msg.body.motion_command_msg.steering_angle = 0.0;
+
+		PX4_DEBUG("SetMotionCommand: linear_vel: %f, angular_vel: %f", static_cast<double>(linear_vel), static_cast<double>(angular_vel));
+
+		// send to can bus
+		if (_parser.EncodeMessage(&msg, &_tx_frame)) { _can->SendFrame(_tx_frame); }
+	}
+}
+
+
+void ScoutRobot::SetLightCommand(LightMode f_mode, uint8_t f_value,
+																 LightMode r_mode, uint8_t r_value)
+{
+	if (_can_connected)
+	{
+		AgxMessage msg;
+		msg.type = AgxMsgLightCommand;
+		msg.body.light_command_msg.enable_cmd_ctrl = true;
+		msg.body.light_command_msg.front_light.mode = f_mode;
+		msg.body.light_command_msg.front_light.custom_value = f_value;
+		msg.body.light_command_msg.rear_light.mode = r_mode;
+		msg.body.light_command_msg.rear_light.custom_value = r_value;
+
+		// send to can bus
+		if (_parser.EncodeMessage(&msg, &_tx_frame)) { _can->SendFrame(_tx_frame); }
+	}
+}
+
+
+void ScoutRobot::DisableLightControl()
+{
+	if (_can_connected)
+	{
+		AgxMessage msg;
+		msg.type = AgxMsgLightCommand;
+
+		msg.body.light_command_msg.enable_cmd_ctrl = false;
+
+		// send to can bus
+		if (_parser.EncodeMessage(&msg, &_tx_frame)) { _can->SendFrame(_tx_frame); }
+	}
+}
+} // namespace scoutsdk

--- a/src/drivers/rover_interface/scout_sdk/src/Utilities.cpp
+++ b/src/drivers/rover_interface/scout_sdk/src/Utilities.cpp
@@ -1,0 +1,92 @@
+#include "scout_sdk/Utilities.hpp"
+#include <px4_platform_common/time.h>
+#include <px4_platform_common/defines.h>
+#include <px4_platform_common/log.h>
+
+#define MODULE_NAME "SCOUT_SDK"
+
+namespace scoutsdk
+{
+
+ProtocolDetector::ProtocolDetector() : _can(nullptr), _msg_v1_detected(false), _msg_v2_detected(false) {}
+
+ProtocolDetector::~ProtocolDetector()
+{
+	if (_can != nullptr)
+	{
+		_can->Close();
+		delete _can;
+		_can = nullptr;
+	}
+}
+
+bool ProtocolDetector::Connect(const char* const _canname)
+{
+	_can = new SocketCAN();
+	if (_can->Init(_canname) == PX4_OK) { return true; } else { return false; }
+}
+
+ProtocolVersion ProtocolDetector::DetectProtocolVersion(const uint64_t timeout_msec)
+{
+	_msg_v1_detected = false;
+	_msg_v2_detected = false;
+
+	const hrt_abstime start_time = hrt_absolute_time();
+	while (hrt_elapsed_time(&start_time) < timeout_msec)
+	{
+		//ParseCANFrame();
+		if (_msg_v1_detected || _msg_v2_detected) { break; }
+	}
+
+	// remove
+	_msg_v2_detected = true;
+
+	// make sure only one version is detected
+	if (_msg_v1_detected && _msg_v2_detected)
+	{
+		return ProtocolVersion::UNKNOWN;
+	}
+	else if (_msg_v1_detected)
+	{
+		return ProtocolVersion::AGX_V1;
+	}
+	else if (_msg_v2_detected)
+	{
+		return ProtocolVersion::AGX_V2;
+	}
+	else
+	{
+		return ProtocolVersion::UNKNOWN;
+	}
+};
+
+void ProtocolDetector::ParseCANFrame()
+{
+	uint8_t data[8] {0};
+	RxFrame rxf{};
+	rxf.frame.payload = &data;
+
+	if(_can->ReceiveFrame(&rxf) <= 0) { return; }
+
+	switch (rxf.frame.can_id)
+	{
+		// state feedback frame with id 0x151 is unique to V1 protocol
+		case 0x151:
+		{
+			PX4_INFO("Protocol V1 detected");
+			_msg_v1_detected = true;
+			break;
+		}
+
+		// motion control feedback frame with id 0x221 is unique to V2 protocol
+		case 0x221:
+		// rc state feedback frame with id 0x241 is unique to V2 protocol
+		case 0x241:
+		{
+			PX4_INFO("Protocol V2 detected");
+			_msg_v2_detected = true;
+			break;
+		}
+	}
+}
+}  // namespace scoutsdk

--- a/src/drivers/rover_interface/scout_sdk/src/agilex_protocol/agilex_msg_parser_v2.c
+++ b/src/drivers/rover_interface/scout_sdk/src/agilex_protocol/agilex_msg_parser_v2.c
@@ -1,0 +1,511 @@
+#include "scout_sdk/agilex_protocol/agilex_protocol_v2.h"
+#include "scout_sdk/agilex_protocol/agilex_msg_parser_v2.h"
+
+#include "stdio.h"
+#include "string.h"
+
+bool DecodeCanFrameV2(const CANFrame *can_frame, AgxMessage *msg)
+{
+	msg->type = AgxMsgUnknown;
+
+	switch (can_frame->can_id)
+	{
+		/***************** command frame *****************/
+		case CAN_MSG_MOTION_COMMAND_ID:
+		{
+			msg->type = AgxMsgMotionCommand;
+			// parse frame buffer to message
+			MotionCommandFrame *frame = (MotionCommandFrame *)(can_frame->payload);
+			msg->body.motion_command_msg.linear_velocity =
+					(int16_t)((uint16_t)(frame->linear_velocity.low_byte) |
+										(uint16_t)(frame->linear_velocity.high_byte) << 8) /
+					1000.0;
+			msg->body.motion_command_msg.angular_velocity =
+					(int16_t)((uint16_t)(frame->angular_velocity.low_byte) |
+										(uint16_t)(frame->angular_velocity.high_byte) << 8) /
+					1000.0;
+			msg->body.motion_command_msg.lateral_velocity =
+					(int16_t)((uint16_t)(frame->lateral_velocity.low_byte) |
+										(uint16_t)(frame->lateral_velocity.high_byte) << 8) /
+					1000.0;
+			msg->body.motion_command_msg.steering_angle =
+					(int16_t)((uint16_t)(frame->steering_angle.low_byte) |
+										(uint16_t)(frame->steering_angle.high_byte) << 8) /
+					1000.0;
+			break;
+		}
+		case CAN_MSG_LIGHT_COMMAND_ID:
+		{
+			msg->type = AgxMsgLightCommand;
+			// parse frame buffer to message
+			LightCommandFrame *frame = (LightCommandFrame *)(can_frame->payload);
+			msg->body.light_command_msg.enable_cmd_ctrl =
+					(frame->enable_cmd_ctrl != 0) ? true : false;
+			msg->body.light_command_msg.front_light.mode = frame->front_mode;
+			msg->body.light_command_msg.front_light.custom_value =
+					frame->front_custom;
+			msg->body.light_command_msg.rear_light.mode = frame->rear_mode;
+			msg->body.light_command_msg.rear_light.custom_value = frame->rear_custom;
+			break;
+		}
+		case CAN_MSG_BRAKING_COMMAND_ID:
+		{
+			msg->type = AgxMsgBrakingCommand;
+			break;
+		}
+		/***************** feedback frame ****************/
+		case CAN_MSG_SYSTEM_STATE_ID:
+		{
+			msg->type = AgxMsgSystemState;
+			SystemStateFrame *frame = (SystemStateFrame *)(can_frame->payload);
+			msg->body.system_state_msg.vehicle_state = frame->vehicle_state;
+			msg->body.system_state_msg.control_mode = frame->control_mode;
+			msg->body.system_state_msg.battery_voltage =
+					(int16_t)((uint16_t)(frame->battery_voltage.low_byte) |
+										(uint16_t)(frame->battery_voltage.high_byte) << 8) *
+					0.1;
+			msg->body.system_state_msg.error_code =
+					(uint16_t)(frame->error_code.low_byte) |
+					(uint16_t)(frame->error_code.high_byte) << 8;
+			break;
+		}
+		case CAN_MSG_MOTION_STATE_ID:
+		{
+			msg->type = AgxMsgMotionState;
+			MotionStateFrame *frame = (MotionStateFrame *)(can_frame->payload);
+			msg->body.motion_state_msg.linear_velocity =
+					(int16_t)((uint16_t)(frame->linear_velocity.low_byte) |
+										(uint16_t)(frame->linear_velocity.high_byte) << 8) /
+					1000.0;
+			msg->body.motion_state_msg.angular_velocity =
+					(int16_t)((uint16_t)(frame->angular_velocity.low_byte) |
+										(uint16_t)(frame->angular_velocity.high_byte) << 8) /
+					1000.0;
+			msg->body.motion_state_msg.lateral_velocity =
+					(int16_t)((uint16_t)(frame->lateral_velocity.low_byte) |
+										(uint16_t)(frame->lateral_velocity.high_byte) << 8) /
+					1000.0;
+			msg->body.motion_state_msg.steering_angle =
+					(int16_t)((uint16_t)(frame->steering_angle.low_byte) |
+										(uint16_t)(frame->steering_angle.high_byte) << 8) /
+					100.0;
+			break;
+		}
+		case CAN_MSG_LIGHT_STATE_ID:
+		{
+			msg->type = AgxMsgLightState;
+			LightStateFrame *frame = (LightStateFrame *)(can_frame->payload);
+			msg->body.light_command_msg.enable_cmd_ctrl =
+					(frame->enable_cmd_ctrl != 0) ? true : false;
+			msg->body.light_command_msg.front_light.mode = frame->front_mode;
+			msg->body.light_command_msg.front_light.custom_value =
+					frame->front_custom;
+			msg->body.light_command_msg.rear_light.mode = frame->rear_mode;
+			msg->body.light_command_msg.rear_light.custom_value = frame->rear_custom;
+			break;
+		}
+		case CAN_MSG_RC_STATE_ID:
+		{
+			msg->type = AgxMsgRcState;
+			RcStateFrame *frame = (RcStateFrame *)(can_frame->payload);
+			// switch a
+			if ((frame->sws & RC_SWA_MASK) == RC_SWA_UP_MASK)
+				msg->body.rc_state_msg.swa = RC_SWITCH_UP;
+			else if ((frame->sws & RC_SWA_MASK) == RC_SWA_DOWN_MASK)
+				msg->body.rc_state_msg.swa = RC_SWITCH_DOWN;
+			// switch b
+			if ((frame->sws & RC_SWB_MASK) == RC_SWB_UP_MASK)
+				msg->body.rc_state_msg.swb = RC_SWITCH_UP;
+			else if ((frame->sws & RC_SWB_MASK) == RC_SWB_MIDDLE_MASK)
+				msg->body.rc_state_msg.swb = RC_SWITCH_MIDDLE;
+			else if ((frame->sws & RC_SWB_MASK) == RC_SWB_DOWN_MASK)
+				msg->body.rc_state_msg.swb = RC_SWITCH_DOWN;
+			// switch c
+			if ((frame->sws & RC_SWC_MASK) == RC_SWC_UP_MASK)
+				msg->body.rc_state_msg.swc = RC_SWITCH_UP;
+			else if ((frame->sws & RC_SWC_MASK) == RC_SWC_MIDDLE_MASK)
+				msg->body.rc_state_msg.swc = RC_SWITCH_MIDDLE;
+			else if ((frame->sws & RC_SWC_MASK) == RC_SWC_DOWN_MASK)
+				msg->body.rc_state_msg.swc = RC_SWITCH_DOWN;
+			// switch d
+			if ((frame->sws & RC_SWD_MASK) == RC_SWD_UP_MASK)
+				msg->body.rc_state_msg.swd = RC_SWITCH_UP;
+			else if ((frame->sws & RC_SWD_MASK) == RC_SWD_DOWN_MASK)
+				msg->body.rc_state_msg.swd = RC_SWITCH_DOWN;
+			msg->body.rc_state_msg.stick_right_v = frame->stick_right_v;
+			msg->body.rc_state_msg.stick_right_h = frame->stick_right_h;
+			msg->body.rc_state_msg.stick_left_v = frame->stick_left_v;
+			msg->body.rc_state_msg.stick_left_h = frame->stick_left_h;
+			msg->body.rc_state_msg.var_a = frame->var_a;
+			break;
+		}
+		case CAN_MSG_ACTUATOR1_HS_STATE_ID:
+		case CAN_MSG_ACTUATOR2_HS_STATE_ID:
+		case CAN_MSG_ACTUATOR3_HS_STATE_ID:
+		case CAN_MSG_ACTUATOR4_HS_STATE_ID:
+		case CAN_MSG_ACTUATOR5_HS_STATE_ID:
+		case CAN_MSG_ACTUATOR6_HS_STATE_ID:
+		case CAN_MSG_ACTUATOR7_HS_STATE_ID:
+		case CAN_MSG_ACTUATOR8_HS_STATE_ID:
+		{
+			msg->type = AgxMsgActuatorHSState;
+			ActuatorHSStateFrame *frame = (ActuatorHSStateFrame *)(can_frame->payload);
+			msg->body.actuator_hs_state_msg.motor_id =
+					can_frame->can_id - CAN_MSG_ACTUATOR1_HS_STATE_ID;
+			msg->body.actuator_hs_state_msg.rpm =
+					(int16_t)((uint16_t)(frame->rpm.low_byte) |
+										(uint16_t)(frame->rpm.high_byte) << 8);
+			msg->body.actuator_hs_state_msg.current =
+					((uint16_t)(frame->current.low_byte) |
+					 (uint16_t)(frame->current.high_byte) << 8) * 0.1;
+			msg->body.actuator_hs_state_msg.pulse_count =
+					(int32_t)((uint32_t)(frame->pulse_count.lsb) |
+										(uint32_t)(frame->pulse_count.low_byte) << 8 |
+										(uint32_t)(frame->pulse_count.high_byte) << 16 |
+										(uint32_t)(frame->pulse_count.msb) << 24);
+			break;
+		}
+		case CAN_MSG_ACTUATOR1_LS_STATE_ID:
+		case CAN_MSG_ACTUATOR2_LS_STATE_ID:
+		case CAN_MSG_ACTUATOR3_LS_STATE_ID:
+		case CAN_MSG_ACTUATOR4_LS_STATE_ID:
+		case CAN_MSG_ACTUATOR5_LS_STATE_ID:
+		case CAN_MSG_ACTUATOR6_LS_STATE_ID:
+		case CAN_MSG_ACTUATOR7_LS_STATE_ID:
+		case CAN_MSG_ACTUATOR8_LS_STATE_ID:
+		{
+			msg->type = AgxMsgActuatorLSState;
+			ActuatorLSStateFrame *frame = (ActuatorLSStateFrame *)(can_frame->payload);
+			msg->body.actuator_hs_state_msg.motor_id =
+					can_frame->can_id - CAN_MSG_ACTUATOR1_LS_STATE_ID;
+			msg->body.actuator_ls_state_msg.driver_voltage =
+					((uint16_t)(frame->driver_voltage.low_byte) |
+					 (uint16_t)(frame->driver_voltage.high_byte) << 8) *
+					0.1;
+			msg->body.actuator_ls_state_msg.driver_temp =
+					(int16_t)((uint16_t)(frame->driver_temp.low_byte) |
+										(uint16_t)(frame->driver_temp.high_byte) << 8);
+			msg->body.actuator_ls_state_msg.motor_temp =
+					frame->motor_temp;
+			msg->body.actuator_ls_state_msg.driver_state = frame->driver_state;
+			break;
+		}
+		case CAN_MSG_CURRENT_CTRL_MODE:
+		{
+			msg->type = AgxMsgMotionModeState;
+			MotionModeStateFrame *frame = (MotionModeStateFrame *)(can_frame->payload);
+			msg->body.motion_mode_state_msg.motion_mode = frame->motion_mode;
+			msg->body.motion_mode_state_msg.mode_changing = frame->mode_changing;
+			break;
+		}
+		/****************** sensor frame *****************/
+		case CAN_MSG_ODOMETRY_ID:
+		{
+			msg->type = AgxMsgOdometry;
+			OdometryFrame *frame = (OdometryFrame *)(can_frame->payload);
+			msg->body.odometry_msg.left_wheel =
+					(int32_t)((uint32_t)(frame->left_wheel.lsb) |
+										(uint32_t)(frame->left_wheel.low_byte) << 8 |
+										(uint32_t)(frame->left_wheel.high_byte) << 16 |
+										(uint32_t)(frame->left_wheel.msb) << 24);
+			msg->body.odometry_msg.right_wheel =
+					(int32_t)((uint32_t)(frame->right_wheel.lsb) |
+										(uint32_t)(frame->right_wheel.low_byte) << 8 |
+										(uint32_t)(frame->right_wheel.high_byte) << 16 |
+										(uint32_t)(frame->right_wheel.msb) << 24);
+			break;
+		}
+		case CAN_MSG_IMU_ACCEL_ID:
+		{
+			msg->type = AgxMsgImuAccel;
+			break;
+		}
+		case CAN_MSG_IMU_GYRO_ID:
+		{
+			msg->type = AgxMsgImuGyro;
+			break;
+		}
+		case CAN_MSG_IMU_EULER_ID:
+		{
+			msg->type = AgxMsgImuEuler;
+			break;
+		}
+		case CAN_MSG_SAFETY_BUMPER_ID:
+		{
+			msg->type = AgxMsgSafetyBumper;
+			break;
+		}
+		case CAN_MSG_ULTRASONIC_1_ID:
+		case CAN_MSG_ULTRASONIC_2_ID:
+		case CAN_MSG_ULTRASONIC_3_ID:
+		case CAN_MSG_ULTRASONIC_4_ID:
+		case CAN_MSG_ULTRASONIC_5_ID:
+		case CAN_MSG_ULTRASONIC_6_ID:
+		case CAN_MSG_ULTRASONIC_7_ID:
+		case CAN_MSG_ULTRASONIC_8_ID:
+		{
+			msg->type = AgxMsgUltrasonic;
+			break;
+		}
+		case CAN_MSG_UWB_1_ID:
+		case CAN_MSG_UWB_2_ID:
+		case CAN_MSG_UWB_3_ID:
+		case CAN_MSG_UWB_4_ID:
+		{
+			msg->type = AgxMsgUwb;
+			break;
+		}
+		case CAN_MSG_BMS_BASIC_ID:
+		{
+			msg->type = AgxMsgBmsBasic;
+			BmsBasicFrame *frame = (BmsBasicFrame *)(can_frame->payload);
+			msg->body.bms_basic_msg.battery_soc = frame->battery_soc;
+			msg->body.bms_basic_msg.battery_soh = frame->battery_soh;
+			msg->body.bms_basic_msg.voltage =
+					(int16_t)((uint16_t)(frame->voltage.low_byte) |
+										(uint16_t)(frame->voltage.high_byte) << 8) * 0.1;
+			msg->body.bms_basic_msg.current =
+					(int16_t)((uint16_t)(frame->current.low_byte) |
+										(uint16_t)(frame->current.high_byte) << 8) * 0.1;
+			msg->body.bms_basic_msg.temperature =
+					(int16_t)((uint16_t)(frame->temperature.low_byte) |
+										(uint16_t)(frame->temperature.high_byte) << 8) * 0.1;
+			break;
+		}
+		case CAN_MSG_BMS_EXTENDED_ID:
+		{
+			msg->type = AgxMsgBmsExtended;
+			break;
+		}
+		/*************** query/config frame **************/
+		case CAN_MSG_VERSION_REQUEST_ID:
+		{
+			msg->type = AgxMsgVersionRequest;
+			break;
+		}
+		case CAN_MSG_VERSION_RESPONSE_ID:
+		{
+			msg->type = AgxMsgVersionResponse;
+			VersionResponseFrame *frame = (VersionResponseFrame *)(can_frame->payload);
+			memcpy(msg->body.version_str, (uint8_t *)frame ,8);
+			break;
+		}
+		case CAN_MSG_CTRL_MODE_CONFIG_ID:
+		{
+			msg->type = AgxMsgControlModeConfig;
+			ControlModeConfigFrame *frame = (ControlModeConfigFrame *)(can_frame->payload);
+			msg->body.control_mode_config_msg.mode = frame->mode;
+			break;
+		}
+		case CAN_MSG_STEER_NEUTRAL_REQUEST_ID:
+		{
+			msg->type = AgxMsgSteerNeutralRequest;
+			break;
+		}
+		case CAN_MSG_STEER_NEUTRAL_RESPONSE_ID:
+		{
+			msg->type = AgxMsgSteerNeutralResponse;
+			break;
+		}
+		case CAN_MSG_STATE_RESET_CONFIG_ID:
+		{
+			msg->type = AgxMsgStateResetConfig;
+			StateResetConfigFrame *frame = (StateResetConfigFrame *)(can_frame->payload);
+			msg->body.state_reset_config_msg.error_clear_byte =
+					frame->error_clear_byte;
+			break;
+		}
+		case CAN_MSG_MOTOR_ANGLE_INFO:
+		{
+			msg->type = AgxMsgMotorAngle;
+			MoterAngleFrame *frame = (MoterAngleFrame *)(can_frame->payload);
+			msg->body.motor_angle_msg.angle_5 =
+					(int16_t)((uint16_t)(frame->angle_5.low_byte) |
+										(uint16_t)(frame->angle_5.high_byte) << 8)*0.01;
+			msg->body.motor_angle_msg.angle_6 =
+					(int16_t)((uint16_t)(frame->angle_6.low_byte) |
+										(uint16_t)(frame->angle_6.high_byte) << 8)*0.01;
+			msg->body.motor_angle_msg.angle_7 =
+					(int16_t)((uint16_t)(frame->angle_7.low_byte) |
+										(uint16_t)(frame->angle_7.high_byte) << 8)*0.01;
+			msg->body.motor_angle_msg.angle_8 =
+					(int16_t)((uint16_t)(frame->angle_8.low_byte) |
+										(uint16_t)(frame->angle_8.high_byte) << 8)*0.01;
+			break;
+		}
+		case CAN_MSG_MOTOR_SPEED_INFO:
+		{
+			msg->type = AgxMsgMotorSpeed;
+			MoterSpeedFrame *frame = (MoterSpeedFrame *)(can_frame->payload);
+			msg->body.motor_speed_msg.speed_1 =
+					(int16_t)((uint16_t)(frame->speed_1.low_byte) |
+										(uint16_t)(frame->speed_1.high_byte) << 8)*0.001;
+			msg->body.motor_speed_msg.speed_2 =
+					(int16_t)((uint16_t)(frame->speed_2.low_byte) |
+										(uint16_t)(frame->speed_2.high_byte) << 8)*0.001;
+			msg->body.motor_speed_msg.speed_3 =
+					(int16_t)((uint16_t)(frame->speed_3.low_byte) |
+										(uint16_t)(frame->speed_3.high_byte) << 8)*0.001;
+			msg->body.motor_speed_msg.speed_4 =
+					(int16_t)((uint16_t)(frame->speed_4.low_byte) |
+										(uint16_t)(frame->speed_4.high_byte) << 8)*0.001;
+			break;
+		}
+		default:
+			break;
+	}
+
+	return true;
+}
+
+bool EncodeCanFrameV2(const AgxMessage *msg, CANFrame *can_frame)
+{
+	bool ret = true;
+	switch (msg->type)
+	{
+		/***************** command frame *****************/
+		case AgxMsgMotionCommand:
+		{
+			can_frame->can_id = CAN_MSG_MOTION_COMMAND_ID;
+			can_frame->payload_size = 8;
+			MotionCommandFrame frame;
+			int16_t linear_cmd =
+					(int16_t)(msg->body.motion_command_msg.linear_velocity * 1000);
+			int16_t angular_cmd =
+					(int16_t)(msg->body.motion_command_msg.angular_velocity * 1000);
+			int16_t lateral_cmd =
+					(int16_t)(msg->body.motion_command_msg.lateral_velocity * 1000);
+			int16_t steering_cmd =
+					(int16_t)(msg->body.motion_command_msg.steering_angle * 1000);
+			frame.linear_velocity.high_byte = (uint8_t)(linear_cmd >> 8);
+			frame.linear_velocity.low_byte = (uint8_t)(linear_cmd & 0x00ff);
+			frame.angular_velocity.high_byte = (uint8_t)(angular_cmd >> 8);
+			frame.angular_velocity.low_byte = (uint8_t)(angular_cmd & 0x00ff);
+			frame.lateral_velocity.high_byte = (uint8_t)(lateral_cmd >> 8);
+			frame.lateral_velocity.low_byte = (uint8_t)(lateral_cmd & 0x00ff);
+			frame.steering_angle.high_byte = (uint8_t)(steering_cmd >> 8);
+			frame.steering_angle.low_byte = (uint8_t)(steering_cmd & 0x00ff);
+			memcpy(can_frame->payload, (uint8_t *)(&frame), can_frame->payload_size);
+			break;
+		}
+		case AgxMsgLightCommand:
+		{
+			static uint8_t count = 0;
+			can_frame->can_id = CAN_MSG_LIGHT_COMMAND_ID;
+			can_frame->payload_size = 8;
+			LightCommandFrame frame;
+			if (msg->body.light_command_msg.enable_cmd_ctrl)
+			{
+				frame.enable_cmd_ctrl = LIGHT_ENABLE_CMD_CTRL;
+				frame.front_mode = msg->body.light_command_msg.front_light.mode;
+				frame.front_custom =
+						msg->body.light_command_msg.front_light.custom_value;
+				frame.rear_mode = msg->body.light_command_msg.rear_light.mode;
+				frame.rear_custom = msg->body.light_command_msg.rear_light.custom_value;
+			}
+			else
+			{
+				frame.enable_cmd_ctrl = LIGHT_DISABLE_CMD_CTRL;
+				frame.front_mode = 0;
+				frame.front_custom = 0;
+				frame.rear_mode = 0;
+				frame.rear_custom = 0;
+			}
+			frame.reserved0 = 0;
+			frame.reserved1 = 0;
+			frame.count = count++;
+			memcpy(can_frame->payload, (uint8_t *)(&frame), can_frame->payload_size);
+			break;
+		}
+		case AgxMsgBrakingCommand:
+		{
+			static uint8_t count = 0;
+			can_frame->can_id = CAN_MSG_BRAKING_COMMAND_ID;
+			can_frame->payload_size = 2;
+			BrakingCommandFrame frame;
+			frame.enable_brake = msg->body.braking_command_msg.enable_braking;
+			frame.count = count++;
+			memcpy(can_frame->payload, (uint8_t *)(&frame), can_frame->payload_size);
+			break;
+		}
+		case AgxMsgSetMotionModeCommand:
+		{
+			can_frame->can_id = CAN_MSG_SET_MOTION_MODE_ID;
+			can_frame->payload_size = 8;
+			SetMotionModeFrame frame;
+			frame.motion_mode = msg->body.motion_mode_msg.motion_mode;
+			frame.reserved0 = 0;
+			frame.reserved1 = 0;
+			frame.reserved2 = 0;
+			frame.reserved3 = 0;
+			frame.reserved4 = 0;
+			frame.reserved5 = 0;
+			frame.reserved6 = 0;
+			memcpy(can_frame->payload, (uint8_t *)(&frame), can_frame->payload_size);
+			break;
+		}
+		/*************** query/config frame **************/
+		case AgxMsgVersionRequest:
+		{
+			can_frame->can_id = CAN_MSG_VERSION_REQUEST_ID;
+			can_frame->payload_size = 8;
+			VersionRequestFrame frame;
+			frame.request = msg->body.version_request_msg.request;
+			frame.reserved0 = 0;
+			frame.reserved1 = 0;
+			frame.reserved2 = 0;
+			frame.reserved3 = 0;
+			frame.reserved4 = 0;
+			frame.reserved5 = 0;
+			frame.reserved6 = 0;
+			memcpy(can_frame->payload, (uint8_t *)(&frame), can_frame->payload_size);
+			break;
+		}
+		case AgxMsgControlModeConfig:
+		{
+			can_frame->can_id = CAN_MSG_CTRL_MODE_CONFIG_ID;
+			can_frame->payload_size = 8;
+			ControlModeConfigFrame frame;
+			frame.mode = msg->body.control_mode_config_msg.mode;
+			frame.reserved0 = 0;
+			frame.reserved1 = 0;
+			frame.reserved2 = 0;
+			frame.reserved3 = 0;
+			frame.reserved4 = 0;
+			frame.reserved5 = 0;
+			frame.reserved6 = 0;
+			memcpy(can_frame->payload, (uint8_t *)(&frame), can_frame->payload_size);
+			break;
+		}
+		case AgxMsgBrakeModeConfig:
+		{
+			can_frame->can_id = CAN_MSG_BRAKING_COMMAND_ID;
+			can_frame->payload_size = 8;
+			BrakeModeConfigFrame frame;
+			frame.mode = msg->body.control_mode_config_msg.mode;
+			frame.reserved0 = 0;
+			frame.reserved1 = 0;
+			frame.reserved2 = 0;
+			frame.reserved3 = 0;
+			frame.reserved4 = 0;
+			frame.reserved5 = 0;
+			frame.reserved6 = 0;
+			memcpy(can_frame->payload, (uint8_t *)(&frame), can_frame->payload_size);
+			break;
+		}
+		default:
+		{
+			ret = false;
+			break;
+		}
+	}
+	return ret;
+}
+
+uint8_t CalcCanFrameChecksumV2(uint16_t id, uint8_t *data, uint8_t dlc)
+{
+	uint8_t checksum = 0x00;
+	checksum = (uint8_t)(id & 0x00ff) + (uint8_t)(id >> 8) + dlc;
+	for (int i = 0; i < (dlc - 1); ++i) checksum += data[i];
+	return checksum;
+}

--- a/src/drivers/rover_interface/scout_sdk/src/agilex_protocol/agilex_protocol_v2_parser.cpp
+++ b/src/drivers/rover_interface/scout_sdk/src/agilex_protocol/agilex_protocol_v2_parser.cpp
@@ -1,0 +1,19 @@
+#include "scout_sdk/agilex_protocol/agilex_protocol_v2_parser.hpp"
+
+namespace scoutsdk
+{
+bool AgileXProtocolV2Parser::DecodeMessage(const RxFrame *rxf, AgxMessage *msg)
+{
+	return DecodeCanFrameV2(&rxf->frame, msg);
+}
+
+bool AgileXProtocolV2Parser::EncodeMessage(const AgxMessage *msg, TxFrame *txf)
+{
+	return EncodeCanFrameV2(msg, &txf->frame);
+}
+
+uint8_t AgileXProtocolV2Parser::CalculateChecksum(uint16_t id, uint8_t *data, uint8_t dlc)
+{
+	return CalcCanFrameChecksumV2(id, data, dlc);
+}
+} // namespace scoutsdk


### PR DESCRIPTION
Add rover interface CAN driver. 
Currently only **AgileX Scout Mini** rover and protocol V2 is supported.
This driver is a high level CAN driver that interfaces with the socketCAN iface expose by the low level can driver.
It takes `actuator_control` msg from `rover_pos_control` module and forward that to the rover.
It listens to rover status and publish the uorb topic `rover_status`

**ROS2 (fognav)** --> trajectory_setpoint --> **PX4 (rover_pos_control)** --> actuator_controls_0 --> **PX4 (Rover Interface CAN Driver)** --> **Nuttx (canfd driver)** --> CAN Steering & Throttle Msg --> **Rover**
