### PR TITLE
Select mavlink logging only if there is no SD card available

### DIFF
--- a/ROMFS/px4fmu_common/init.d/rc.logging
+++ b/ROMFS/px4fmu_common/init.d/rc.logging
@@ -23,6 +23,11 @@ then
 	set LOGGER_ARGS "${LOGGER_ARGS} -x"
 fi
 
+if [ $SDCARD_AVAILABLE = no ]
+then
+	set LOGGER_ARGS "${LOGGER_ARGS} -m mavlink"
+fi
+
 if ! param compare SDLOG_MODE -1
 then
 	logger start -b ${LOGGER_BUF} -t ${LOGGER_ARGS}


### PR DESCRIPTION
Configure logger to use mavlink logging only in case SDCARD not available/accessible