### PR TITLE
DP-5698 compile remaining targets even if one fails

### DIFF
--- a/.github/workflows/tiiuae-pixhawk-and-saluki.yaml
+++ b/.github/workflows/tiiuae-pixhawk-and-saluki.yaml
@@ -11,8 +11,10 @@ on:
 jobs:
   fc_matrix:
     strategy:
+      fail-fast: false
       matrix:
         product: [pixhawk, saluki-v1_default, saluki-v1_bootloader, saluki-v1_amp, saluki-v1_protected, saluki-v2_default, saluki-v2_bootloader, saluki-v2_amp, saluki-v2_protected, saluki-pi_default, saluki-pi_bootloader, saluki-pi_amp, saluki-pi_protected]
+
     uses: ./.github/workflows/tiiuae-pixhawk-and-saluki-builder.yaml
     with:
       product: ${{ matrix.product }}


### PR DESCRIPTION
Currently all build targets are cancelled if one target fails to compile. With this change the build continues on remaining targets.