### PR TITLE
Changes in UAVCAN for 2x CAN support

### DIFF
--- a/ROMFS/px4fmu_common/init.d/airframes/4400_ssrc_fog_x
+++ b/ROMFS/px4fmu_common/init.d/airframes/4400_ssrc_fog_x
@@ -55,6 +55,12 @@ param set-default HIL_ACT_FUNC2 102
 param set-default HIL_ACT_FUNC3 103
 param set-default HIL_ACT_FUNC4 104
 
+# UAVCAN_EC functions
+param set-default UAVCAN_EC_FUNC1 101
+param set-default UAVCAN_EC_FUNC2 102
+param set-default UAVCAN_EC_FUNC3 103
+param set-default UAVCAN_EC_FUNC4 104
+
 # Increase velocity controller P gain
 param set-default MPC_XY_VEL_P_ACC 2.4
 

--- a/src/drivers/uavcan/uavcan_main.hpp
+++ b/src/drivers/uavcan/uavcan_main.hpp
@@ -153,7 +153,7 @@ class UavcanNode : public px4::ScheduledWorkItem, public ModuleParams
 	static constexpr unsigned FramePerSecond	= MaxBitRatePerSec / bitPerFrame;
 	static constexpr unsigned FramePerMSecond	= ((FramePerSecond / 1000) + 1);
 
-	static constexpr unsigned ScheduleIntervalMs		= 3;
+	static constexpr unsigned ScheduleIntervalMs		= 1;
 
 
 	/*
@@ -265,7 +265,7 @@ private:
 
 	uORB::SubscriptionInterval	_parameter_update_sub{ORB_ID(parameter_update), 1_s};
 	uORB::Subscription _vcmd_sub{ORB_ID(vehicle_command)};
-	uORB::SubscriptionInterval _param_request_sub{ORB_ID(uavcan_parameter_request), 100_us};
+	uORB::SubscriptionInterval _param_request_sub{ORB_ID(uavcan_parameter_request), 50_ms};
 
 	uORB::Publication<uavcan_parameter_value_s> _param_response_pub{ORB_ID(uavcan_parameter_value)};
 	uORB::Publication<vehicle_command_ack_s>	_command_ack_pub{ORB_ID(vehicle_command_ack)};


### PR DESCRIPTION
- Add missing UAVCAN EC functions for 4 ESCs
- Increase handling rate due to double traffic with 2x CAN
- Decrease param request update rate to avoid spike on CAN traffic which could lead to erroneous frames when QGC is open