### PR TITLE
Disable ekf2 multi-imu for HITL mode

### DIFF
--- a/ssrc_config/config_hitl_eth.txt
+++ b/ssrc_config/config_hitl_eth.txt
@@ -22,3 +22,6 @@ param set CBRK_IO_SAFETY 22027
 
 # Disable RC controller check
 param set NAV_RCL_ACT 0
+
+# Disable ekf2 multi-imu, because gazebo provides only one
+param set EKF2_MULTI_IMU 1


### PR DESCRIPTION
Because Gazebo provides only one IMU sensor data stream, the ekf2 shall wait for only one IMU instance.