### PR TITLE
cdc_acm_check: Make cdc_acm_check into its own module

### DIFF
--- a/ROMFS/px4fmu_common/init.d/rcS
+++ b/ROMFS/px4fmu_common/init.d/rcS
@@ -530,6 +530,11 @@ else
 		fi
 	fi
 
+	#
+	# Start the CDC ACM monitor
+	#
+	cdcacm start
+
 #
 # End of autostart.
 #

--- a/src/modules/cdcacm/CMakeLists.txt
+++ b/src/modules/cdcacm/CMakeLists.txt
@@ -1,0 +1,39 @@
+############################################################################
+#
+#   Copyright (c) 2023 Technology Innovation Institute. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+# 1. Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in
+#    the documentation and/or other materials provided with the
+#    distribution.
+# 3. Neither the name PX4 nor the names of its contributors may be
+#    used to endorse or promote products derived from this software
+#    without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+# OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+# AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+# ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+#
+############################################################################
+
+px4_add_module(
+	MODULE modules__cdcacm
+	MAIN cdcacm
+	SRCS
+		cdcacm.cpp
+	)

--- a/src/modules/cdcacm/Kconfig
+++ b/src/modules/cdcacm/Kconfig
@@ -1,0 +1,12 @@
+menuconfig MODULES_CDCACM
+	bool "CDC ACM monitor process"
+	default n
+	---help---
+		Enable support for CDC ACM monitor
+
+menuconfig USER_CDCACM
+	bool "CDC ACM monitor running as userspace module"
+	default y
+	depends on BOARD_PROTECTED && MODULES_CDCACM
+	---help---
+		Put CDC ACM monitor in userspace memory

--- a/src/modules/cdcacm/cdcacm.hpp
+++ b/src/modules/cdcacm/cdcacm.hpp
@@ -1,6 +1,6 @@
 /****************************************************************************
  *
- *   Copyright (C) 2022 Technology Innovation Institute. All rights reserved.
+ *   Copyright (c) 2023 Technology Innovation Institute. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -31,30 +31,35 @@
  *
  ****************************************************************************/
 
-/**
- * @file px4_userspace_init.cpp
- *
- * Initialize px4 userspace in NuttX protected build
- */
+#pragma once
 
-#include <drivers/drv_hrt.h>
-#include <px4_platform_common/px4_work_queue/WorkQueueManager.hpp>
-#include <px4_platform_common/spi.h>
-#include <px4_platform_common/log.h>
+#include <px4_platform_common/px4_config.h>
+#include <px4_platform_common/defines.h>
+#include <px4_platform_common/sem.h>
+#include <px4_platform_common/module.h>
 
-extern void cdcacm_init(void);
-
-extern "C" void px4_userspace_init(void)
+class CdcAcm : public ModuleBase<CdcAcm>
 {
-	hrt_init();
+public:
+	CdcAcm();
+	~CdcAcm() = default;
 
-	px4_set_spi_buses_from_hw_version();
+	/** @see ModuleBase */
+	static int task_spawn(int argc, char *argv[]);
 
-	px4::WorkQueueManagerStart();
+	/** @see ModuleBase */
+	static CdcAcm *instantiate(int argc, char *argv[]);
 
-	px4_log_initialize();
+	/** @see ModuleBase */
+	static int custom_command(int argc, char *argv[]);
 
-#if defined(CONFIG_SYSTEM_CDCACM) && defined(CONFIG_BUILD_PROTECTED)
-	cdcacm_init();
-#endif
-}
+	/** @see ModuleBase */
+	static int print_usage(const char *reason = nullptr);
+
+	void request_stop() override;
+
+	/** @see ModuleBase::run() */
+	void run() override;
+private:
+	px4_sem_t _exit_wait;
+};


### PR DESCRIPTION
The code that checks for CDC ACM connection needs to be an actual process (module) as:
- It cannot run inside the NuttX kernel, it must be capable of starting mavlink
- It cannot run inside "the userspace" either, as with CONFIG_BUILD_KERNEL there are several "userspaces" / processes.

Do it by:
- Forklifting sercon_main() and serdis_main() from libapps, the reason is that with kernel build the symbols are NOT packed into libapps and thus are inaccessible.
- Create wrapper for builtin_exec() that can do file exec via posix_spawn()

