### PR TITLE
rover_interface: add support for runtime bitrate setting

### DIFF
--- a/src/drivers/rover_interface/RoverInterface.hpp
+++ b/src/drivers/rover_interface/RoverInterface.hpp
@@ -38,10 +38,10 @@ class RoverInterface : public ModuleParams, public px4::ScheduledWorkItem
 public:
 	static const char *const CAN_IFACE;
 
-	RoverInterface(uint8_t rover_type);
+	RoverInterface(uint8_t rover_type, uint32_t bitrate);
 	~RoverInterface() override;
 
-	static int start(uint8_t rover_type);
+	static int start(uint8_t rover_type, uint32_t bitrate);
 
 	void print_status();
 
@@ -71,6 +71,8 @@ private:
 	pthread_mutex_t _node_mutex;
 
 	uint8_t _rover_type;
+
+	uint32_t _bitrate;
 
 	scoutsdk::ProtocolVersion _protocol_version{scoutsdk::ProtocolVersion::AGX_V2};
 

--- a/src/drivers/rover_interface/rover_interface_params.c
+++ b/src/drivers/rover_interface/rover_interface_params.c
@@ -42,3 +42,14 @@
  * @group RoverInterface
  */
 PARAM_DEFINE_INT32(RI_ROVER_TYPE, 0);
+
+/**
+ * Rover interface CAN bitrate.
+ *
+ * @unit bit/s
+ * @min 20000
+ * @max 1000000
+ * @reboot_required true
+ * @group RoverInterface
+ */
+PARAM_DEFINE_INT32(RI_CAN_BITRATE, 500000);

--- a/src/drivers/rover_interface/scout_sdk/include/scout_sdk/CAN/SocketCAN.hpp
+++ b/src/drivers/rover_interface/scout_sdk/include/scout_sdk/CAN/SocketCAN.hpp
@@ -42,7 +42,7 @@ public:
 	/// Also sets up the message structures required for socketcanTransmit & socketcanReceive
 	/// can_fd determines to use CAN FD frame when is 1, and classical CAN frame when is 0
 	/// The return value is 0 on success and -1 on error
-	int Init(const char *const can_iface_name);
+	int Init(const char *const can_iface_name, const uint32_t can_bitrate);
 
 	/// Close socket connection
 	int Close()

--- a/src/drivers/rover_interface/scout_sdk/include/scout_sdk/ScoutRobot.hpp
+++ b/src/drivers/rover_interface/scout_sdk/include/scout_sdk/ScoutRobot.hpp
@@ -45,7 +45,7 @@ public:
 	ScoutRobot &operator=(const ScoutRobot &robot) = delete;
 
 	// CAN connection
-	void Connect(const char *const can_dev);
+	void Connect(const char *const can_dev, const uint32_t can_bitrate);
 	void Disconnect();
 
 	// Send commands

--- a/src/drivers/rover_interface/scout_sdk/include/scout_sdk/Utilities.hpp
+++ b/src/drivers/rover_interface/scout_sdk/include/scout_sdk/Utilities.hpp
@@ -13,7 +13,7 @@ public:
 	ProtocolDetector();
 	~ProtocolDetector();
 
-	bool Connect(const char *const can_name);
+	bool Connect(const char *const can_name, const uint32_t bitrate);
 
 	ProtocolVersion DetectProtocolVersion(const uint64_t timeout_sec);
 

--- a/src/drivers/rover_interface/scout_sdk/src/ScoutRobot.cpp
+++ b/src/drivers/rover_interface/scout_sdk/src/ScoutRobot.cpp
@@ -34,11 +34,11 @@ ScoutRobot::~ScoutRobot()
 }
 
 
-void ScoutRobot::Connect(const char *const can_dev)
+void ScoutRobot::Connect(const char *const can_dev, const uint32_t can_bitrate)
 {
 	_can = new SocketCAN();
 
-	if (_can->Init(can_dev) == PX4_OK) { _can_connected = true; }
+	if (_can->Init(can_dev, can_bitrate) == PX4_OK) { _can_connected = true; }
 }
 
 

--- a/src/drivers/rover_interface/scout_sdk/src/Utilities.cpp
+++ b/src/drivers/rover_interface/scout_sdk/src/Utilities.cpp
@@ -19,11 +19,11 @@ ProtocolDetector::~ProtocolDetector()
 	}
 }
 
-bool ProtocolDetector::Connect(const char *const _canname)
+bool ProtocolDetector::Connect(const char *const _canname, const uint32_t bitrate)
 {
 	_can = new SocketCAN();
 
-	if (_can->Init(_canname) == PX4_OK) { return true; } else { return false; }
+	if (_can->Init(_canname, bitrate) == PX4_OK) { return true; } else { return false; }
 }
 
 ProtocolVersion ProtocolDetector::DetectProtocolVersion(const uint64_t timeout_msec)


### PR DESCRIPTION
Set CAN bitrate from rover interface driver to 500kbit/s from default 1Mbit/s
The rover interface bitrate is configuratble as a PX4 parameter