### PR TITLE
UAVCAN: use esc current absolute value

### DIFF
--- a/src/drivers/uavcan/actuators/esc.cpp
+++ b/src/drivers/uavcan/actuators/esc.cpp
@@ -138,7 +138,7 @@ UavcanEscController::esc_status_sub_cb(const uavcan::ReceivedDataStructure<uavca
 		ref.timestamp       = hrt_absolute_time();
 		ref.esc_address = msg.getSrcNodeID().get();
 		ref.esc_voltage     = msg.voltage;
-		ref.esc_current     = msg.current;
+		ref.esc_current     = fabs(msg.current);
 		ref.esc_temperature = msg.temperature;
 		ref.esc_rpm         = msg.rpm;
 		ref.esc_errorcount  = msg.error_count;


### PR DESCRIPTION
On UAVCAN drone, sometimes, due to randomness in installation, the motor spinning direction is reverted thus require reversed current and voltage from ESC. This is needed so that only the absolute current value is passed to PX4 system, preventing trigger of esc current < 0 warning