### PR TITLE
Reenable installing libignition-transport8-dev pkg in sitl image

### DIFF
--- a/build_sitl.sh
+++ b/build_sitl.sh
@@ -22,6 +22,7 @@ docker build \
   --build-arg UID=$(id -u) \
   --build-arg GID=$(id -g) \
   --pull \
+  --output type=docker \
   -f ./packaging/Dockerfile.build_env -t ${iname_env} .
 
 # Build Saluki image

--- a/packaging/Dockerfile.sitl
+++ b/packaging/Dockerfile.sitl
@@ -1,13 +1,13 @@
-FROM ghcr.io/tiiuae/fog-ros-baseimage-builder:dp-4266_humble_upgrade
+FROM ghcr.io/tiiuae/fog-ros-baseimage-builder:v2.1.0
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     wget
 
-#RUN echo "deb http://packages.osrfoundation.org/gazebo/ubuntu-stable `lsb_release -cs` main" > /etc/apt/sources.list.d/gazebo-stable.list
-#RUN wget http://packages.osrfoundation.org/gazebo.key -O - | apt-key add -
-#RUN apt-get update && apt-get install -y --no-install-recommends \
-#    libignition-transport8-dev \
-#    && rm -rf /var/lib/apt/lists/*
+RUN echo "deb http://packages.osrfoundation.org/gazebo/ubuntu-stable `lsb_release -cs` main" > /etc/apt/sources.list.d/gazebo-stable.list
+RUN wget http://packages.osrfoundation.org/gazebo.key -O - | apt-key add -
+RUN apt-get update && apt-get install -y --no-install-recommends \
+   libignition-transport8-dev \
+   && rm -rf /var/lib/apt/lists/*
 
 # Install PX4 SITL
 WORKDIR /packages


### PR DESCRIPTION
### Solved Problem
The tii-px4-sitl package is missing the libignition-transport8-dev package, resulting in error like below. Not sure why it was disabled in the first place. 

```
px4: error while loading shared libraries: libignition-transport8.so.8: cannot open shared object file: No such file or directory
```

### Solution
- Reenable commented out libignition-transport8-dev package. Tested on a locally built image, it worked OK after the change.
- Additionally updated the baseimage for the image, so it uses tag v2.1.0.
