### PR TITLE
blockingqueue.hpp: remove entry from list when popping

### DIFF
--- a/src/include/containers/BlockingQueue.hpp
+++ b/src/include/containers/BlockingQueue.hpp
@@ -69,6 +69,7 @@ public:
 		px4_sem_wait(&_sem_tail);
 
 		T ret = _data[_head];
+		_data[_head] = nullptr;
 		_head = (_head + 1) % N;
 
 		px4_sem_post(&_sem_head);


### PR DESCRIPTION
Popping did not remove old entry from the queue, resulting in duplicates when popping again from an empty queue (the same value is returned again).

Happens every time if queue size is 1, and multiple consecutive pops are performed without anyone pushing to the queue.
