### PR TITLE
drivers/ads1115: Fix consecutive warning "ADS1115 not ready!"

### DIFF
--- a/src/drivers/adc/ads1115/ADS1115.cpp
+++ b/src/drivers/adc/ads1115/ADS1115.cpp
@@ -56,7 +56,7 @@ int ADS1115::init()
 
 	setChannel(ADS1115::A0);  // prepare for the first measure.
 
-	ScheduleOnInterval(SAMPLE_INTERVAL / 4, SAMPLE_INTERVAL / 4);
+	ScheduleDelayed(SAMPLE_INTERVAL / 4);
 
 	return PX4_OK;
 }

--- a/src/drivers/adc/ads1115/ads1115_main.cpp
+++ b/src/drivers/adc/ads1115/ads1115_main.cpp
@@ -121,6 +121,9 @@ void ADS1115::RunImpl()
 		PX4_WARN("ADS1115 not ready!");
 	}
 
+	// Schedule the next sample reading (regardless of isSampleReady())
+	ScheduleDelayed(SAMPLE_INTERVAL / 4);
+
 	perf_end(_cycle_perf);
 }
 


### PR DESCRIPTION
ADS1115 is first commanded to start sampling and after 1/4 of the sample period the single channel sample is read out.

However, when using ScheduleOnInterval this fails if the sample reading is blocked for long enough.

The resulting _average_ sample rate is still correct (80Hz) but the time between triggering the new sample on the ADC and reading it out can be anything. If the call to ADS1115::RunImpl() happens too soon after starting the new sample, reading it will obviously fail.

Fix this by scheduling the sample reading _after_ the sampling has been triggered on the ADC. This ensures the sample is ready the next time when ADS1115::RunImpl() is executed.
