### PR TITLE
blockingqueue.hpp: Block reading from queue until someone actually posts into it

### DIFF
--- a/src/include/containers/BlockingQueue.hpp
+++ b/src/include/containers/BlockingQueue.hpp
@@ -56,7 +56,7 @@ public:
 
 	void push(T newItem)
 	{
-		px4_sem_wait(&_sem_head);
+		do {} while (px4_sem_wait(&_sem_head) != 0);
 
 		_data[_tail] = newItem;
 		_tail = (_tail + 1) % N;
@@ -66,7 +66,7 @@ public:
 
 	T pop()
 	{
-		px4_sem_wait(&_sem_tail);
+		do {} while (px4_sem_wait(&_sem_tail) != 0);
 
 		T ret = _data[_head];
 		_head = (_head + 1) % N;

--- a/src/include/containers/BlockingQueue.hpp
+++ b/src/include/containers/BlockingQueue.hpp
@@ -69,7 +69,6 @@ public:
 		px4_sem_wait(&_sem_tail);
 
 		T ret = _data[_head];
-		_data[_head] = nullptr;
 		_head = (_head + 1) % N;
 
 		px4_sem_post(&_sem_head);


### PR DESCRIPTION
Apparently the initial fix of returning NULL if queue is empty is wrong, the queue should block until there is something in it.

px4_sem_wait can be interrupted by signal, thus need to loop until the semaphore is actually obtained.