### PR TITLE
common/px4_init.cpp: Add dummy dso_handle for kernel CPP modules

### DIFF
--- a/platforms/nuttx/src/px4/common/px4_init.cpp
+++ b/platforms/nuttx/src/px4/common/px4_init.cpp
@@ -74,6 +74,9 @@ extern initializer_t _einit[];
 extern uint8_t _stext[];
 extern uint8_t _etext[];
 
+extern FAR void *__dso_handle weak_data;
+FAR void *__dso_handle = &__dso_handle;
+
 static void cxx_initialize(void)
 {
 	initializer_t *initp;


### PR DESCRIPTION
Some modules might want it, removes link error for uavcan:

libuavcan/libuavcan/include/uavcan/node/global_data_type_registry.hpp:215: more undefined references to `__dso_handle'

