### PR TITLE
pid tuning to avoid high frequency oscillations

### DIFF
--- a/ROMFS/px4fmu_common/init.d/airframes/4401_ssrc_fog_x_tmotor
+++ b/ROMFS/px4fmu_common/init.d/airframes/4401_ssrc_fog_x_tmotor
@@ -23,6 +23,10 @@ param set-default MC_PITCHRATE_I 0.3
 param set-default MC_ROLLRATE_D 0.004
 param set-default MC_PITCHRATE_D 0.004
 
+# Master gain parameters
+param set-default MC_ROLLRATE_K 0.4
+param set-default MC_PITCHRATE_K 0.4
+
 # Control allocator parameters
 param set-default CA_ROTOR_COUNT 4
 param set-default CA_ROTOR0_PX 0.25


### PR DESCRIPTION
T-motor M690 airframe (4401) had high frequency oscillations during test flight. By setting K gains for roll and pitch rate to 0.4 reduces the oscillations.

Analysis for default parameters: https://px4-flight-review.ssrc.fi/plot_app?log=e097664b-c33c-4ae1-9fb0-76329603cf3e
Analysis for modified parameters: https://px4-flight-review.ssrc.fi/plot_app?log=69b49fc4-0d12-4c16-8693-c7d49fe0fb52
