### PR TITLE
UGV improvements

### DIFF
--- a/ROMFS/px4fmu_common/init.d/airframes/50005_ssrc_scout_mini_rover
+++ b/ROMFS/px4fmu_common/init.d/airframes/50005_ssrc_scout_mini_rover
@@ -15,11 +15,19 @@
 
 param set-default RI_ROVER_TYPE 0
 
-param set-default BAT1_N_CELLS 4
+# Battery setting
+param set-default BAT1_N_CELLS 7
+param set-default BAT1_V_EMPTY 3.3
+param set-default BAT1_V_CHARGED 4.2
 
+# EKF2
 param set-default EKF2_GBIAS_INIT 0.01
 param set-default EKF2_ANGERR_INIT 0.01
 param set-default EKF2_MAG_TYPE 1
+param set-default EKF2_REQ_SACC 1.0
+param set-default EKF2_REQ_VDRIFT 0.4
+param set-default EKF2_REQ_HDRIFT 0.2
+
 
 param set-default FW_AIRSPD_MIN 0
 param set-default FW_AIRSPD_TRIM 1

--- a/src/drivers/rover_interface/RoverInterface.cpp
+++ b/src/drivers/rover_interface/RoverInterface.cpp
@@ -68,36 +68,47 @@ void RoverInterface::Init()
 	_initialized = false;
 
 	// Check rover type
-	if (_rover_type == 0) {
+	switch (_rover_type) {
+	case 0:
 		// Scout Mini
 		PX4_INFO("Scout Mini (rover type 0) is supported. Initializing...");
+		break;
 
-	} else if (_rover_type == 1) {
+	case 1:
 		// Scout
 		PX4_INFO("Scout (rover type 1) is not supported. Aborted");
 		return;
 
-	} else if (_rover_type == 2) {
+	case 2:
 		// Scout Pro
-		PX4_INFO("Scout Pro (rover type 0) is not supported. Aborted");
+		PX4_INFO("Scout Pro (rover type 2) is not supported. Aborted");
 		return;
 
-	} else if (_rover_type == 3) {
+	case 3:
 		// Scout 2
 		PX4_INFO("Scout 2 (rover type 3) is not supported. Aborted");
 		return;
 
-	} else if (_rover_type == 4) {
+	case 4:
 		// Scout 2 Pro
 		PX4_INFO("Scout 2 Pro (rover type 4) is not supported. Aborted");
 		return;
 
-	} else {
+	case 5:
+		// Bunker
+		PX4_INFO("Bunker (rover type 5) is supported. Initializing...");
+		return;
+
+	case 6:
+		// Bunker Mini
+		PX4_INFO("Bunker Mini (rover type 6) is supported. Initializing...");
+		return;
+
+	default:
 		// Unknown Rover type
 		PX4_INFO("Unknown rover type. Aborted");
 		return;
 	}
-
 
 	// Check protocol version and create ScoutRobot object
 	if (_protocol_version == scoutsdk::ProtocolVersion::AGX_V1) {
@@ -293,8 +304,8 @@ void RoverInterface::print_status()
 
 	// Rover info
 	if (_scout->GetCANConnected()) {
-		PX4_INFO("Rover Type: %s. Protocol Version: %s",
-			 _rover_type == 0 ? "Scout Mini" : "Unknown",
+		PX4_INFO("Rover Type: %d. Protocol Version: %s",
+			 _rover_type,
 			 _protocol_version == scoutsdk::ProtocolVersion::AGX_V2 ? "AGX_V2" : "Unknown");
 		PX4_INFO("Rover system version: %s", _scout->GetSystemVersion());
 	}

--- a/src/drivers/rover_interface/RoverInterface.cpp
+++ b/src/drivers/rover_interface/RoverInterface.cpp
@@ -6,11 +6,12 @@ RoverInterface *RoverInterface::_instance;
 // CAN interface | default is can0
 const char *const RoverInterface::CAN_IFACE = "can0";
 
-RoverInterface::RoverInterface(uint8_t rover_type, uint32_t bitrate)
+RoverInterface::RoverInterface(uint8_t rover_type, uint32_t bitrate, uint8_t manual_throttle_max)
 	: ModuleParams(nullptr),
 	  ScheduledWorkItem(MODULE_NAME, px4::wq_configurations::rover_interface),
 	  _rover_type(rover_type),
-	  _bitrate(bitrate)
+	  _bitrate(bitrate),
+		_manual_throttle_max(manual_throttle_max)
 {
 	pthread_mutex_init(&_node_mutex, nullptr);
 }
@@ -42,14 +43,14 @@ RoverInterface::~RoverInterface()
 }
 
 
-int RoverInterface::start(uint8_t rover_type, uint32_t bitrate)
+int RoverInterface::start(uint8_t rover_type, uint32_t bitrate, uint8_t manual_throttle_max)
 {
 	if (_instance != nullptr) {
 		PX4_ERR("Already started");
 		return -1;
 	}
 
-	_instance = new RoverInterface(rover_type, bitrate);
+	_instance = new RoverInterface(rover_type, bitrate, manual_throttle_max);
 
 	if (_instance == nullptr) {
 		PX4_ERR("Failed to allocate RoverInterface object");
@@ -184,6 +185,9 @@ void RoverInterface::Run()
 	// Check for actuator armed command to rover
 	ActuatorArmedUpdate();
 
+	// Check for vehicle control mode
+	VehicleControlModeUpdate();
+
 	// Check for receive msgs from the rover
 	_scout->CheckUpdateFromRover();
 
@@ -204,7 +208,8 @@ void RoverInterface::ActuatorControlsUpdate()
 		actuator_controls_s actuator_controls_msg;
 
 		if (_actuator_controls_sub.copy(&actuator_controls_msg)) {
-			auto throttle = actuator_controls_msg.control[actuator_controls_s::INDEX_THROTTLE];
+			auto throttle = (_is_manual_mode ? _manual_throttle_max : 1.0f) *
+											actuator_controls_msg.control[actuator_controls_s::INDEX_THROTTLE];
 			auto steering = actuator_controls_msg.control[actuator_controls_s::INDEX_YAW];
 			_scout->SetMotionCommand(throttle, steering);
 		}
@@ -220,7 +225,7 @@ void RoverInterface::ActuatorArmedUpdate()
 		if (_actuator_armed_sub.copy(&actuator_armed_msg)) {
 			// Arm or disarm the rover
 			if (!_armed && actuator_armed_msg.armed) {
-				_scout->SetLightCommand(LightMode::CONST_ON, 0);
+				_scout->SetLightCommand(LightMode::CONST_OFF, 0);
 				_armed = true;
 
 			} else if (_armed && !actuator_armed_msg.armed) {
@@ -230,6 +235,17 @@ void RoverInterface::ActuatorArmedUpdate()
 
 			// Kill switch
 			_manual_lockdown = actuator_armed_msg.manual_lockdown;
+		}
+	}
+}
+
+void RoverInterface::VehicleControlModeUpdate()
+{
+	if (_vehicle_control_mode_sub.updated()) {
+		vehicle_control_mode_s vehicle_control_mode_msg;
+
+		if (_vehicle_control_mode_sub.copy(&vehicle_control_mode_msg)) {
+			_is_manual_mode = vehicle_control_mode_msg.flag_control_manual_enabled;
 		}
 	}
 }
@@ -329,10 +345,16 @@ extern "C" __EXPORT int rover_interface_main(int argc, char *argv[])
 		int32_t can_bitrate = 0;
 		param_get(param_find("RI_CAN_BITRATE"), &can_bitrate);
 
+		// Manual control mode max throttle (1m/s to 3m/s)
+		int32_t manual_throttle_max = 1;
+		param_get(param_find("RI_MAN_THR_MAX"), &manual_throttle_max);
+
 		// Start
 		PX4_INFO("Start Rover Interface to rover type %d at CAN iface %s with bitrate %d bit/s",
 			 rover_type, RoverInterface::CAN_IFACE, can_bitrate);
-		return RoverInterface::start(static_cast<uint8_t>(rover_type), can_bitrate);
+		return RoverInterface::start(static_cast<uint8_t>(rover_type),
+																 can_bitrate,
+																 static_cast<uint8_t>(manual_throttle_max));
 	}
 
 	/* commands below assume that the app has been already started */

--- a/src/drivers/rover_interface/RoverInterface.cpp
+++ b/src/drivers/rover_interface/RoverInterface.cpp
@@ -11,7 +11,7 @@ RoverInterface::RoverInterface(uint8_t rover_type, uint32_t bitrate, uint8_t man
 	  ScheduledWorkItem(MODULE_NAME, px4::wq_configurations::rover_interface),
 	  _rover_type(rover_type),
 	  _bitrate(bitrate),
-		_manual_throttle_max(manual_throttle_max)
+	  _manual_throttle_max(manual_throttle_max)
 {
 	pthread_mutex_init(&_node_mutex, nullptr);
 }
@@ -209,7 +209,7 @@ void RoverInterface::ActuatorControlsUpdate()
 
 		if (_actuator_controls_sub.copy(&actuator_controls_msg)) {
 			auto throttle = (_is_manual_mode ? _manual_throttle_max : 1.0f) *
-											actuator_controls_msg.control[actuator_controls_s::INDEX_THROTTLE];
+					actuator_controls_msg.control[actuator_controls_s::INDEX_THROTTLE];
 			auto steering = actuator_controls_msg.control[actuator_controls_s::INDEX_YAW];
 			_scout->SetMotionCommand(throttle, steering);
 		}
@@ -225,7 +225,7 @@ void RoverInterface::ActuatorArmedUpdate()
 		if (_actuator_armed_sub.copy(&actuator_armed_msg)) {
 			// Arm or disarm the rover
 			if (!_armed && actuator_armed_msg.armed) {
-				_scout->SetLightCommand(LightMode::CONST_OFF, 0);
+				_scout->SetLightCommand(LightMode::CONST_ON, 0);
 				_armed = true;
 
 			} else if (_armed && !actuator_armed_msg.armed) {
@@ -353,8 +353,8 @@ extern "C" __EXPORT int rover_interface_main(int argc, char *argv[])
 		PX4_INFO("Start Rover Interface to rover type %d at CAN iface %s with bitrate %d bit/s",
 			 rover_type, RoverInterface::CAN_IFACE, can_bitrate);
 		return RoverInterface::start(static_cast<uint8_t>(rover_type),
-																 can_bitrate,
-																 static_cast<uint8_t>(manual_throttle_max));
+					     can_bitrate,
+					     static_cast<uint8_t>(manual_throttle_max));
 	}
 
 	/* commands below assume that the app has been already started */

--- a/src/drivers/rover_interface/RoverInterface.hpp
+++ b/src/drivers/rover_interface/RoverInterface.hpp
@@ -14,6 +14,7 @@
 #include <uORB/topics/actuator_controls.h>
 #include <uORB/topics/actuator_armed.h>
 #include <uORB/topics/rover_status.h>
+#include <uORB/topics/vehicle_control_mode.h>
 
 #include "scout_sdk/ScoutRobot.hpp"
 
@@ -38,10 +39,10 @@ class RoverInterface : public ModuleParams, public px4::ScheduledWorkItem
 public:
 	static const char *const CAN_IFACE;
 
-	RoverInterface(uint8_t rover_type, uint32_t bitrate);
+	RoverInterface(uint8_t rover_type, uint32_t bitrate, uint8_t manual_throttle_max);
 	~RoverInterface() override;
 
-	static int start(uint8_t rover_type, uint32_t bitrate);
+	static int start(uint8_t rover_type, uint32_t bitrate, uint8_t manual_throttle_max);
 
 	void print_status();
 
@@ -53,6 +54,7 @@ private:
 
 	void ActuatorControlsUpdate();
 	void ActuatorArmedUpdate();
+	void VehicleControlModeUpdate();
 	void PublishRoverState();
 
 	// Flag to indicate to tear down the rover interface
@@ -66,6 +68,8 @@ private:
 
 	uint8_t _init_try_count{0};
 
+	bool _is_manual_mode{false};
+
 	static RoverInterface *_instance;
 
 	pthread_mutex_t _node_mutex;
@@ -73,6 +77,8 @@ private:
 	uint8_t _rover_type;
 
 	uint32_t _bitrate;
+
+	uint8_t _manual_throttle_max;
 
 	scoutsdk::ProtocolVersion _protocol_version{scoutsdk::ProtocolVersion::AGX_V2};
 
@@ -83,6 +89,7 @@ private:
 	// Subscription
 	uORB::SubscriptionInterval _actuator_controls_sub{ORB_ID(actuator_controls_0), ActuatorControlSubIntervalMs};
 	uORB::SubscriptionInterval _actuator_armed_sub{ORB_ID(actuator_armed), ActuatorArmedSubIntervalMs};
+	uORB::Subscription _vehicle_control_mode_sub{ORB_ID(vehicle_control_mode)};
 
 	// Publication
 	orb_advert_t _rover_status_pub{ORB_ADVERT_INVALID};

--- a/src/drivers/rover_interface/rover_interface_params.c
+++ b/src/drivers/rover_interface/rover_interface_params.c
@@ -53,3 +53,15 @@ PARAM_DEFINE_INT32(RI_ROVER_TYPE, 0);
  * @group RoverInterface
  */
 PARAM_DEFINE_INT32(RI_CAN_BITRATE, 500000);
+
+
+/**
+ * Rover interface manual control throttle max.
+ *
+ * @unit m/s
+ * @min 1
+ * @max 3
+ * @reboot_required true
+ * @group RoverInterface
+ */
+PARAM_DEFINE_INT32(RI_MAN_THR_MAX, 1);

--- a/src/drivers/rover_interface/rover_interface_params.c
+++ b/src/drivers/rover_interface/rover_interface_params.c
@@ -39,6 +39,8 @@
  * @value 2 Scout Pro
  * @value 3 Scout 2
  * @value 4 Scout 2 Pro
+ * @value 5 Bunker
+ * @value 6 Bunker Mini
  * @group RoverInterface
  */
 PARAM_DEFINE_INT32(RI_ROVER_TYPE, 0);


### PR DESCRIPTION
- Allow configurable manual control speed of up to Scout Mini maximum speed of 3m/s
- Configure battery cell count and voltage range
- Configure more tolerant EKF2 GPS errors
- Add support for Bunker and Bunker Mini rover

Tested on UGV2 with Saluki v2 and X86