### PR TITLE
logger/log_writer_file: Disable HARDFAULT_LOG properly

### DIFF
--- a/src/modules/logger/log_writer_file.cpp
+++ b/src/modules/logger/log_writer_file.cpp
@@ -40,9 +40,10 @@
 
 #include <mathlib/mathlib.h>
 #include <px4_platform_common/posix.h>
+#include <px4_platform_common/px4_config.h>
 #include <px4_platform_common/crypto.h>
 #include <px4_platform_common/log.h>
-#ifdef __PX4_NUTTX
+#if defined(__PX4_NUTTX) && defined(SYSTEMCMDS_HARDFAULT_LOG)
 #include <systemlib/hardfault_log.h>
 #endif /* __PX4_NUTTX */
 
@@ -256,7 +257,7 @@ void LogWriterFile::start_log(LogType type, const char *filename)
 
 int LogWriterFile::hardfault_store_filename(const char *log_file)
 {
-#if defined(__PX4_NUTTX) && defined(px4_savepanic)
+#if defined(__PX4_NUTTX) && defined(px4_savepanic) && defined(SYSTEMCMDS_HARDFAULT_LOG)
 	int fd = open(HARDFAULT_ULOG_PATH, O_TRUNC | O_WRONLY | O_CREAT);
 
 	if (fd < 0) {


### PR DESCRIPTION
Disable all code regarding hardfaults (ARM specific trap) when they are not used / needed. Fixes build issue with NuttX upstream:

In file included from /src/modules/logger/log_writer_file.cpp:46: /src/lib/systemlib/hardfault_log.h:144:3: error: conflicting declaration 'typedef struct stack_t stack_t'
  144 | } stack_t;
