### PR TITLE
build.sh: Copy the binary file for kernel build as well

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -92,6 +92,7 @@ case $target in
   "saluki-v2_kernel")
     $build_cmd_fw ssrc_saluki-v2_kernel
     cp ${script_dir}/build/ssrc_saluki-v2_kernel/ssrc_saluki-v2_kernel.px4 ${dest_dir}/ssrc_saluki-v2_kernel-${version}.px4
+    cp ${script_dir}/build/ssrc_saluki-v2_kernel/ssrc_saluki-v2_kernel.bin ${dest_dir}/ssrc_saluki-v2_kernel-${version}.bin
     ;;
   "saluki-pi_default")
     $build_cmd_fw ssrc_saluki-pi_default


### PR DESCRIPTION
The binary is ~20MB so it is not really feasible to upload it via the px4 updater script (which eats a .px4 file); it would take an eternity to uload it with 1 Mbit/s.

<!--

Thank you for your contribution!

Get early feedback through
- Dronecode Discord: https://discord.gg/dronecode
- PX4 Discuss: http://discuss.px4.io/
- opening a draft pr and sharing the link

-->

### Solved Problem
When ... I found that ...

Fixes #{Github issue ID}

### Solution
- Add ... for ...
- Refactor ...

### Alternatives
We could also ...

### Test coverage
- Unit/integration test: ...
- Simulation/hardware testing logs: https://review.px4.io/

### Context
Related links, screenshot before/after, video
