### PR TITLE
Ugv support upgrade

### DIFF
--- a/ROMFS/px4fmu_common/init.d/rc.rover_apps
+++ b/ROMFS/px4fmu_common/init.d/rc.rover_apps
@@ -6,9 +6,10 @@
 #
 
 #
-# Start the rover interface CAN driver if airframe is one of SSRC supported rover types (50005, ..)
+# Start the rover interface CAN driver if rover type is one of SSRC supported
+# rover types (scout mini, bunker, ..)
 #
-if param compare SYS_AUTOSTART 50005
+if param greater RI_ROVER_TYPE -1
 then
   ifup can0
   rover_interface start

--- a/src/drivers/rover_interface/RoverInterface.cpp
+++ b/src/drivers/rover_interface/RoverInterface.cpp
@@ -194,7 +194,7 @@ void RoverInterface::Run()
 	// Check for actuator armed command to rover
 	ActuatorArmedUpdate();
 
-	// Check for action request (manual lock down)
+	// Check for action request (kill switch)
 	ActionRequestUpdate();
 
 	// Check for actuator controls command to rover

--- a/src/drivers/rover_interface/RoverInterface.cpp
+++ b/src/drivers/rover_interface/RoverInterface.cpp
@@ -246,6 +246,7 @@ void RoverInterface::ActuatorArmedUpdate()
 
 			// Kill switch
 			_manual_lockdown = actuator_armed_msg.manual_lockdown;
+			if (_manual_lockdown) { _scout->SetMotionCommand(0.0, 0.0); }
 		}
 	}
 }

--- a/src/drivers/rover_interface/RoverInterface.hpp
+++ b/src/drivers/rover_interface/RoverInterface.hpp
@@ -13,6 +13,7 @@
 #include <uORB/Publication.hpp>
 #include <uORB/topics/actuator_controls.h>
 #include <uORB/topics/actuator_armed.h>
+#include <uORB/topics/action_request.h>
 #include <uORB/topics/rover_status.h>
 #include <uORB/topics/vehicle_control_mode.h>
 
@@ -34,8 +35,6 @@ class RoverInterface : public ModuleParams, public px4::ScheduledWorkItem
 
 	static constexpr uint64_t ActuatorControlSubIntervalMs{50_ms};
 
-	static constexpr uint64_t ActuatorArmedSubIntervalMs{500_ms};
-
 public:
 	static const char *const CAN_IFACE;
 
@@ -54,6 +53,7 @@ private:
 
 	void ActuatorControlsUpdate();
 	void ActuatorArmedUpdate();
+	void ActionRequestUpdate();
 	void VehicleControlModeUpdate();
 	void PublishRoverState();
 
@@ -62,7 +62,7 @@ private:
 
 	bool _armed{false};
 
-	bool _manual_lockdown{false};
+	bool _kill_switch{false};
 
 	bool _initialized{false};
 
@@ -88,7 +88,8 @@ private:
 
 	// Subscription
 	uORB::SubscriptionInterval _actuator_controls_sub{ORB_ID(actuator_controls_0), ActuatorControlSubIntervalMs};
-	uORB::SubscriptionInterval _actuator_armed_sub{ORB_ID(actuator_armed), ActuatorArmedSubIntervalMs};
+	uORB::SubscriptionInterval _actuator_armed_sub{ORB_ID(actuator_armed)};
+	uORB::Subscription _action_request_sub{ORB_ID(action_request)};
 	uORB::Subscription _vehicle_control_mode_sub{ORB_ID(vehicle_control_mode)};
 
 	// Publication

--- a/src/drivers/rover_interface/RoverInterface.hpp
+++ b/src/drivers/rover_interface/RoverInterface.hpp
@@ -32,7 +32,7 @@ class RoverInterface : public ModuleParams, public px4::ScheduledWorkItem
 
 	static constexpr uint64_t SystemVersionQueryLimitMs{10_ms};
 
-	static constexpr uint64_t ActuatorControlSubIntervalMs{20_ms};
+	static constexpr uint64_t ActuatorControlSubIntervalMs{50_ms};
 
 	static constexpr uint64_t ActuatorArmedSubIntervalMs{500_ms};
 

--- a/src/drivers/rover_interface/RoverInterface.hpp
+++ b/src/drivers/rover_interface/RoverInterface.hpp
@@ -34,7 +34,7 @@ class RoverInterface : public ModuleParams, public px4::ScheduledWorkItem
 
 	static constexpr uint64_t ActuatorControlSubIntervalMs{20_ms};
 
-	static constexpr uint64_t ActuatorArmedSubIntervalMs{1000_ms};
+	static constexpr uint64_t ActuatorArmedSubIntervalMs{500_ms};
 
 public:
 	static const char *const CAN_IFACE;

--- a/src/drivers/rover_interface/rover_interface_params.c
+++ b/src/drivers/rover_interface/rover_interface_params.c
@@ -34,6 +34,7 @@
 /**
  * Rover type.
  *
+ * @value -1 Not selected
  * @value 0 Scout Mini
  * @value 1 Scout
  * @value 2 Scout Pro
@@ -41,9 +42,9 @@
  * @value 4 Scout 2 Pro
  * @value 5 Bunker
  * @value 6 Bunker Mini
- * @group RoverInterface
+ * @group Rover Interface
  */
-PARAM_DEFINE_INT32(RI_ROVER_TYPE, 0);
+PARAM_DEFINE_INT32(RI_ROVER_TYPE, -1);
 
 /**
  * Rover interface CAN bitrate.
@@ -52,7 +53,7 @@ PARAM_DEFINE_INT32(RI_ROVER_TYPE, 0);
  * @min 20000
  * @max 1000000
  * @reboot_required true
- * @group RoverInterface
+ * @group Rover Interface
  */
 PARAM_DEFINE_INT32(RI_CAN_BITRATE, 500000);
 
@@ -64,6 +65,6 @@ PARAM_DEFINE_INT32(RI_CAN_BITRATE, 500000);
  * @min 1.0
  * @max 3.0
  * @reboot_required true
- * @group RoverInterface
+ * @group Rover Interface
  */
 PARAM_DEFINE_FLOAT(RI_MAN_THR_MAX, 1.0);


### PR DESCRIPTION
- kill switch sub directly to action request topic, reducing delay from 500ms to ~200ms
- increase actuator control sub interval to 50ms (now matching fognav setpoint pub rate); this helps with the can connection drop issue due to low iob. Tested with UGV in UAE outdoor which lasted around 1.5hr back to back missions.
- enable bunker airframe 50006 in rc.rover_apps