### PR TITLE
uorb: _POSIX_NAME_MAX -> NAME_MAX

### DIFF
--- a/platforms/common/uORB/uORBDeviceNode.cpp
+++ b/platforms/common/uORB/uORBDeviceNode.cpp
@@ -259,8 +259,9 @@ orb_advert_t uORB::DeviceNode::nodeOpen(const ORB_ID id, const uint8_t instance,
 	int ret = uORB::Utils::node_mkpath(nodepath, get_orb_meta(id), &inst);
 	bool created = false;
 
-	if (ret == -ENAMETOOLONG || strlen(nodepath) > _POSIX_NAME_MAX) {
-		PX4_ERR("Device node name too long! '%s'", get_orb_meta(id)->o_name);
+	if (ret == -ENAMETOOLONG || strlen(nodepath) > NAME_MAX) {
+		PX4_ERR("Device node name too long! '%s' (len: %lu vs. NAME_MAX: %lu)",
+			get_orb_meta(id)->o_name, ((long unsigned int) strlen(nodepath)), ((long unsigned int) NAME_MAX));
 	}
 
 	if (ret != OK) {


### PR DESCRIPTION
In SITL case the _POSIX_NAME_MAX is only 14, so it fails for every topic. Use NAME_MAX instead to get correct maximum filename value for both posix and nuttx cases.

log snippet from sitl-test run:
```
[   3.129|px4       ] ERROR [uORB] Device node name too long! 'sensor_baro'
[   3.137|px4       ] ERROR [uORB] Device node name too long! 'tune_control'
[   3.143|px4       ] ERROR [uORB] Device node name too long! 'manual_control_setpoint'
[   3.147|px4       ] ERROR [uORB] Device node name too long! 'sensors_status_mag'
[   3.147|px4       ] ERROR [uORB] Device node name too long! 'sensors_status_baro'
[   3.148|px4       ] ERROR [uORB] Device node name too long! 'sensor_selection'
[   3.148|px4       ] ERROR [uORB] Device node name too long! 'sensors_status_imu'
[   3.148|px4       ] ERROR [uORB] Device node name too long! 'vehicle_acceleration'
```