### PR TITLE
Mavlink logger: do not use reliable transfer

### DIFF
--- a/msg/CMakeLists.txt
+++ b/msg/CMakeLists.txt
@@ -185,6 +185,7 @@ set(msg_files
 	UavcanParameterValue.msg
 	UlogStream.msg
 	UlogStreamAck.msg
+	UlogStreamAcked.msg
 	UwbDistance.msg
 	UwbGrid.msg
 	VehicleAcceleration.msg

--- a/msg/UlogStreamAck.msg
+++ b/msg/UlogStreamAck.msg
@@ -1,4 +1,4 @@
-# Ack a previously sent ulog_stream message that had
+# Ack a previously sent ulog_stream_acked message that had
 # the NEED_ACK flag set
 
 uint64 timestamp		# time since system start (microseconds)

--- a/msg/UlogStreamAcked.msg
+++ b/msg/UlogStreamAcked.msg
@@ -1,0 +1,19 @@
+# Message to stream ULog data from the logger. Corresponds to the LOGGING_DATA_ACKED
+# mavlink message
+
+uint64 timestamp		# time since system start (microseconds)
+
+# flags bitmasks
+uint8 FLAGS_NEED_ACK = 1	# if set, this message requires to be acked.
+				# Acked messages are published synchronous: a
+				# publisher waits for an ack before sending the
+				# next message
+
+uint8 length			# length of data
+uint8 first_message_offset	# offset into data where first message starts. This
+				# can be used for recovery, when a previous message got lost
+uint16 msg_sequence		# allows determine drops
+uint8 flags			# see FLAGS_*
+uint8[249] data		# ulog data
+
+uint8 ORB_QUEUE_LENGTH = 16	# TODO: we might be able to reduce this if mavlink polled on the topic

--- a/src/modules/logger/log_writer.cpp
+++ b/src/modules/logger/log_writer.cpp
@@ -158,7 +158,7 @@ void LogWriter::thread_stop()
 	}
 }
 
-int LogWriter::write_message(LogType type, void *ptr, size_t size, uint64_t dropout_start)
+int LogWriter::write_message(LogType type, void *ptr, size_t size, uint64_t dropout_start, bool acked)
 {
 	int ret_file = 0, ret_mavlink = 0;
 
@@ -167,7 +167,7 @@ int LogWriter::write_message(LogType type, void *ptr, size_t size, uint64_t drop
 	}
 
 	if (_log_writer_mavlink_for_write && type == LogType::Full) {
-		ret_mavlink = _log_writer_mavlink_for_write->write_message(ptr, size);
+		ret_mavlink = _log_writer_mavlink_for_write->write_message(ptr, size, acked);
 	}
 
 	// file backend errors takes precedence

--- a/src/modules/logger/log_writer.h
+++ b/src/modules/logger/log_writer.h
@@ -90,7 +90,7 @@ public:
 	 *         -1 if not enough space in the buffer left (file backend), -2 mavlink backend failed
 	 *  add type -> pass through, but not to mavlink if mission log
 	 */
-	int write_message(LogType type, void *ptr, size_t size, uint64_t dropout_start = 0);
+	int write_message(LogType type, void *ptr, size_t size, uint64_t dropout_start = 0, bool acked = false);
 
 	/**
 	 * Select a backend, so that future calls to write_message() only write to the selected

--- a/src/modules/logger/log_writer_mavlink.cpp
+++ b/src/modules/logger/log_writer_mavlink.cpp
@@ -48,6 +48,7 @@ namespace logger
 LogWriterMavlink::LogWriterMavlink()
 {
 	_ulog_stream_data.length = 0;
+	_ulog_stream_acked_data.length = 0;
 }
 
 bool LogWriterMavlink::init()
@@ -76,37 +77,51 @@ void LogWriterMavlink::start_log()
 	_ulog_stream_data.length = 0;
 	_ulog_stream_data.first_message_offset = 0;
 
+	_ulog_stream_acked_data.msg_sequence = 0;
+	_ulog_stream_acked_data.length = 0;
+	_ulog_stream_acked_data.first_message_offset = 0;
+
 	_is_started = true;
 }
 
 void LogWriterMavlink::stop_log()
 {
 	_ulog_stream_data.length = 0;
+	_ulog_stream_acked_data.length = 0;
 	_is_started = false;
 }
 
-int LogWriterMavlink::write_message(void *ptr, size_t size)
+int LogWriterMavlink::write_message(void *ptr, size_t size, bool acked)
 {
 	if (!is_started()) {
 		return 0;
 	}
 
-	const uint8_t data_len = (uint8_t)sizeof(_ulog_stream_data.data);
+	ulog_stream_s *ulog_s_p;
+
+	if (acked) {
+		ulog_s_p = &_ulog_stream_acked_data;
+
+	} else {
+		ulog_s_p = &_ulog_stream_data;
+	}
+
+	const uint8_t data_len = (uint8_t)sizeof(ulog_s_p->data);
 	uint8_t *ptr_data = (uint8_t *)ptr;
 
-	if (_ulog_stream_data.first_message_offset == 255) {
-		_ulog_stream_data.first_message_offset = _ulog_stream_data.length;
+	if (ulog_s_p->first_message_offset == 255) {
+		ulog_s_p->first_message_offset = ulog_s_p->length;
 	}
 
 	while (size > 0) {
-		size_t send_len = math::min((size_t)data_len - _ulog_stream_data.length, size);
-		memcpy(_ulog_stream_data.data + _ulog_stream_data.length, ptr_data, send_len);
-		_ulog_stream_data.length += send_len;
+		size_t send_len = math::min((size_t)data_len - ulog_s_p->length, size);
+		memcpy(ulog_s_p->data + ulog_s_p->length, ptr_data, send_len);
+		ulog_s_p->length += send_len;
 		ptr_data += send_len;
 		size -= send_len;
 
-		if (_ulog_stream_data.length >= data_len) {
-			if (publish_message()) {
+		if (ulog_s_p->length >= data_len) {
+			if (publish_message(acked)) {
 				return -2;
 			}
 		}
@@ -117,28 +132,29 @@ int LogWriterMavlink::write_message(void *ptr, size_t size)
 
 void LogWriterMavlink::set_need_reliable_transfer(bool need_reliable)
 {
-	if (!need_reliable && _need_reliable_transfer) {
-		if (_ulog_stream_data.length > 0) {
-			// make sure to send previous data using reliable transfer
-			publish_message();
-		}
-	}
-
-	_need_reliable_transfer = need_reliable;
 }
 
-int LogWriterMavlink::publish_message()
+int LogWriterMavlink::publish_message(bool acked)
 {
-	_ulog_stream_data.timestamp = hrt_absolute_time();
-	_ulog_stream_data.flags = 0;
+	ulog_stream_s *ulog_s_p;
 
-	if (_need_reliable_transfer) {
-		_ulog_stream_data.flags = _ulog_stream_data.FLAGS_NEED_ACK;
+	if (acked) {
+		ulog_s_p = &_ulog_stream_acked_data;
+
+	} else {
+		ulog_s_p = &_ulog_stream_data;
 	}
 
-	_ulog_stream_pub.publish(_ulog_stream_data);
+	ulog_s_p->timestamp = hrt_absolute_time();
+	ulog_s_p->flags = 0;
 
-	if (_need_reliable_transfer) {
+	if (!acked) {
+		_ulog_stream_pub.publish(_ulog_stream_data);
+
+	} else {
+		ulog_s_p->flags = ulog_s_p->FLAGS_NEED_ACK;
+		_ulog_stream_acked_pub.publish(*ulog_s_p);
+
 		// we need to wait for an ack. Note that this blocks the main logger thread, so if a file logging
 		// is already running, it will miss samples.
 		px4_pollfd_struct_t fds[1];
@@ -160,7 +176,7 @@ int LogWriterMavlink::publish_message()
 				ulog_stream_ack_s ack;
 				orb_copy(ORB_ID(ulog_stream_ack), _ulog_stream_ack_sub, &ack);
 
-				if (ack.msg_sequence == _ulog_stream_data.msg_sequence) {
+				if (ack.msg_sequence == ulog_s_p->msg_sequence) {
 					got_ack = true;
 				}
 
@@ -178,9 +194,9 @@ int LogWriterMavlink::publish_message()
 		PX4_DEBUG("got ack in %i ms", (int)(hrt_elapsed_time(&started) / 1000));
 	}
 
-	_ulog_stream_data.msg_sequence++;
-	_ulog_stream_data.length = 0;
-	_ulog_stream_data.first_message_offset = 255;
+	ulog_s_p->msg_sequence++;
+	ulog_s_p->length = 0;
+	ulog_s_p->first_message_offset = 255;
 	return 0;
 }
 

--- a/src/modules/logger/log_writer_mavlink.h
+++ b/src/modules/logger/log_writer_mavlink.h
@@ -36,6 +36,7 @@
 #include <stdint.h>
 #include <uORB/Publication.hpp>
 #include <uORB/topics/ulog_stream.h>
+#include <uORB/topics/ulog_stream_acked.h>
 #include <uORB/topics/ulog_stream_ack.h>
 
 namespace px4
@@ -62,7 +63,7 @@ public:
 	bool is_started() const { return _is_started; }
 
 	/** @see LogWriter::write_message() */
-	int write_message(void *ptr, size_t size);
+	int write_message(void *ptr, size_t size, bool acked = false);
 
 	void set_need_reliable_transfer(bool need_reliable);
 
@@ -74,10 +75,12 @@ public:
 private:
 
 	/** publish message, wait for ack if needed & reset message */
-	int publish_message();
+	int publish_message(bool acked);
 
 	ulog_stream_s _ulog_stream_data{};
+	ulog_stream_s _ulog_stream_acked_data{};
 	uORB::Publication<ulog_stream_s> _ulog_stream_pub{ORB_ID(ulog_stream)};
+	uORB::Publication<ulog_stream_s> _ulog_stream_acked_pub{ORB_ID(ulog_stream_acked)};
 	orb_sub_t _ulog_stream_ack_sub{ORB_SUB_INVALID};
 	bool _need_reliable_transfer{false};
 	bool _is_started{false};

--- a/src/modules/logger/logger.cpp
+++ b/src/modules/logger/logger.cpp
@@ -1182,8 +1182,15 @@ void Logger::handle_vehicle_command_update()
 	}
 }
 
-bool Logger::write_message(LogType type, void *ptr, size_t size)
+bool Logger::write_message(LogType type, void *ptr, size_t size, bool acked)
 {
+	if (acked) {
+		if (_writer.write_message(type, ptr, size, 0, true) != -1) {
+			return true;
+		}
+		return false;
+	}
+
 	Statistics &stats = _statistics[(int)type];
 
 	if (_writer.write_message(type, ptr, size, stats.dropout_start) != -1) {
@@ -1450,6 +1457,34 @@ void Logger::stop_log_file(LogType type)
 	_writer.stop_log_file(type);
 }
 
+void *Logger::mav_start_steps_helper(void *context)
+{
+	px4_prctl(PR_SET_NAME, "log_writer_mavlink_headers", px4_getpid());
+	static_cast<Logger *>(context)->mav_start_steps();
+	return nullptr;
+}
+
+void Logger::mav_start_steps()
+{
+	/* This is running in separate thread to keep logging data while sending header&descriptions */
+	PX4_INFO("[log_writer_mavlink_headers] - Begin");
+	LogWriter::Backend bkend = _writer.backend();
+	_writer.select_write_backend(LogWriter::BackendMavlink);
+	write_header(LogType::Full, true);
+	write_version(LogType::Full, true);
+	write_formats(LogType::Full, true);
+	write_parameters(LogType::Full, true);
+	write_parameter_defaults(LogType::Full, true);
+	write_perf_data(true, true);
+	write_console_output(true);
+	write_events_file(LogType::Full, true);
+	write_excluded_optional_topics(LogType::Full, true);
+	write_all_add_logged_msg(LogType::Full, true);
+	_writer.select_write_backend(bkend);
+	_writer.notify();
+	PX4_INFO("[log_writer_mavlink_headers] - End");
+}
+
 void Logger::start_log_mavlink()
 {
 	if (!can_start_mavlink_log()) {
@@ -1464,24 +1499,27 @@ void Logger::start_log_mavlink()
 	initialize_load_output(PrintLoadReason::Preflight);
 
 	PX4_INFO("Start mavlink log");
-
 	_writer.start_log_mavlink();
-	_writer.select_write_backend(LogWriter::BackendMavlink);
-	_writer.set_need_reliable_transfer(true);
-	write_header(LogType::Full);
-	write_version(LogType::Full);
-	write_formats(LogType::Full);
-	write_parameters(LogType::Full);
-	write_parameter_defaults(LogType::Full);
-	write_perf_data(true);
-	write_console_output();
-	write_events_file(LogType::Full);
-	write_excluded_optional_topics(LogType::Full);
-	write_all_add_logged_msg(LogType::Full);
-	_writer.set_need_reliable_transfer(false);
-	_writer.unselect_write_backend();
-	_writer.notify();
 
+	//mav_start_steps();
+
+	pthread_attr_t thr_attr;
+	pthread_attr_init(&thr_attr);
+	pthread_attr_setstacksize(&thr_attr, PX4_STACK_ADJUSTED(8500));
+	PX4_INFO("create mav_start_thread");
+	int ret = pthread_create(&_mav_start_thread, &thr_attr, &Logger::mav_start_steps_helper, this);
+	if (ret) {
+		PX4_WARN("mav_start_thread create failed: %d", ret);
+	}
+	pthread_attr_destroy(&thr_attr);
+/*
+	PX4_INFO("Wait for mav_start_thread end...");
+	ret = pthread_join(_mav_start_thread, nullptr);
+	if (ret) {
+		PX4_WARN("mav_start_thread join failed: %d", ret);
+	}
+*/
+	PX4_INFO("Mavlink logging started");
 	adjust_subscription_updates(); // redistribute updates as sending the header can take some time
 }
 
@@ -1490,12 +1528,16 @@ void Logger::stop_log_mavlink()
 	// don't write perf data since a client does not expect more data after a stop command
 	PX4_INFO("Stop mavlink log");
 
+	int ret = pthread_join(_mav_start_thread, nullptr);
+	if (ret) {
+		PX4_WARN("mav_start_thread join failed: %d", ret);
+	}
+
 	if (_writer.is_started(LogType::Full, LogWriter::BackendMavlink)) {
+		LogWriter::Backend bkend = _writer.backend();
 		_writer.select_write_backend(LogWriter::BackendMavlink);
-		_writer.set_need_reliable_transfer(true);
-		write_perf_data(false);
-		_writer.set_need_reliable_transfer(false);
-		_writer.unselect_write_backend();
+		write_perf_data(false, true);
+		_writer.select_write_backend(bkend);
 		_writer.notify();
 		_writer.stop_log_mavlink();
 	}
@@ -1505,6 +1547,7 @@ struct perf_callback_data_t {
 	Logger *logger;
 	int counter;
 	bool preflight;
+	bool acked;
 	char *buffer;
 };
 
@@ -1524,15 +1567,16 @@ void Logger::perf_iterate_callback(perf_counter_t handle, void *user)
 		perf_name = "perf_counter_postflight";
 	}
 
-	callback_data->logger->write_info_multiple(LogType::Full, perf_name, buffer, callback_data->counter != 0);
+	callback_data->logger->write_info_multiple(LogType::Full, perf_name, buffer, callback_data->counter != 0, callback_data->acked);
 	++callback_data->counter;
 }
 
-void Logger::write_perf_data(bool preflight)
+void Logger::write_perf_data(bool preflight, bool acked)
 {
 	perf_callback_data_t callback_data = {};
 	callback_data.logger = this;
 	callback_data.counter = 0;
+	callback_data.acked = acked;
 	callback_data.preflight = preflight;
 
 	// write the perf counters
@@ -1598,7 +1642,7 @@ void Logger::write_load_output()
 	_writer.set_need_reliable_transfer(false);
 }
 
-void Logger::write_console_output()
+void Logger::write_console_output(bool acked)
 {
 	const int buffer_length = 220;
 	char buffer[buffer_length];
@@ -1612,7 +1656,7 @@ void Logger::write_console_output()
 		if (read_size <= 0) { break; }
 
 		buffer[math::min(read_size, size)] = '\0';
-		write_info_multiple(LogType::Full, "boot_console_output", buffer, !first);
+		write_info_multiple(LogType::Full, "boot_console_output", buffer, !first, acked);
 
 		size -= read_size;
 		first = false;
@@ -1621,7 +1665,7 @@ void Logger::write_console_output()
 }
 
 void Logger::write_format(LogType type, const orb_metadata &meta, WrittenFormats &written_formats,
-			  ulog_message_format_s &msg, int subscription_index, int level)
+			  ulog_message_format_s &msg, int subscription_index, int level, bool acked)
 {
 	if (level > 3) {
 		// precaution: limit recursion level. If we land here it's either a bug or nested topic definitions. In the
@@ -1682,7 +1726,7 @@ void Logger::write_format(LogType type, const orb_metadata &meta, WrittenFormats
 	size_t msg_size = sizeof(msg) - sizeof(msg.format) + format_len;
 	msg.msg_size = msg_size - ULOG_MSG_HEADER_LEN;
 
-	write_message(type, &msg, msg_size);
+	write_message(type, &msg, msg_size, acked);
 
 	if (level > 1 && !written_formats.push_back(&meta)) {
 		PX4_ERR("Array too small");
@@ -1736,7 +1780,7 @@ void Logger::write_format(LogType type, const orb_metadata &meta, WrittenFormats
 
 			if (found_topic) {
 
-				write_format(type, *found_topic, written_formats, msg, subscription_index, level + 1);
+				write_format(type, *found_topic, written_formats, msg, subscription_index, level + 1, acked);
 
 			} else {
 				PX4_ERR("No definition for topic %s found", fmt);
@@ -1749,7 +1793,7 @@ void Logger::write_format(LogType type, const orb_metadata &meta, WrittenFormats
 	}
 }
 
-void Logger::write_formats(LogType type)
+void Logger::write_formats(LogType type, bool acked)
 {
 	_writer.lock();
 
@@ -1766,15 +1810,15 @@ void Logger::write_formats(LogType type)
 
 	for (int i = 0; i < sub_count; ++i) {
 		const LoggerSubscription &sub = _subscriptions[i];
-		write_format(type, *sub.get_topic(), written_formats, msg, i);
+		write_format(type, *sub.get_topic(), written_formats, msg, i, 1, acked);
 	}
 
-	write_format(type, *_event_subscription.get_topic(), written_formats, msg, sub_count);
+	write_format(type, *_event_subscription.get_topic(), written_formats, msg, sub_count, 1, acked);
 
 	_writer.unlock();
 }
 
-void Logger::write_all_add_logged_msg(LogType type)
+void Logger::write_all_add_logged_msg(LogType type, bool acked)
 {
 	_writer.lock();
 
@@ -1790,12 +1834,12 @@ void Logger::write_all_add_logged_msg(LogType type)
 		LoggerSubscription &sub = _subscriptions[i];
 
 		if (sub.valid()) {
-			write_add_logged_msg(type, sub);
+			write_add_logged_msg(type, sub, acked);
 			added_subscriptions = true;
 		}
 	}
 
-	write_add_logged_msg(type, _event_subscription); // always add, even if not valid
+	write_add_logged_msg(type, _event_subscription, acked); // always add, even if not valid
 
 	_writer.unlock();
 
@@ -1804,7 +1848,7 @@ void Logger::write_all_add_logged_msg(LogType type)
 	}
 }
 
-void Logger::write_add_logged_msg(LogType type, LoggerSubscription &subscription)
+void Logger::write_add_logged_msg(LogType type, LoggerSubscription &subscription, bool acked)
 {
 	ulog_message_add_logged_s msg;
 
@@ -1830,11 +1874,11 @@ void Logger::write_add_logged_msg(LogType type, LoggerSubscription &subscription
 
 	bool prev_reliable = _writer.need_reliable_transfer();
 	_writer.set_need_reliable_transfer(true);
-	write_message(type, &msg, msg_size);
+	write_message(type, &msg, msg_size, true);
 	_writer.set_need_reliable_transfer(prev_reliable);
 }
 
-void Logger::write_info(LogType type, const char *name, const char *value)
+void Logger::write_info(LogType type, const char *name, const char *value, bool acked)
 {
 	_writer.lock();
 	ulog_message_info_s msg = {};
@@ -1853,13 +1897,13 @@ void Logger::write_info(LogType type, const char *name, const char *value)
 
 		msg.msg_size = msg_size - ULOG_MSG_HEADER_LEN;
 
-		write_message(type, buffer, msg_size);
+		write_message(type, buffer, msg_size, acked);
 	}
 
 	_writer.unlock();
 }
 
-void Logger::write_info_multiple(LogType type, const char *name, const char *value, bool is_continued)
+void Logger::write_info_multiple(LogType type, const char *name, const char *value, bool is_continued, bool acked)
 {
 	_writer.lock();
 	ulog_message_info_multiple_s msg;
@@ -1879,7 +1923,7 @@ void Logger::write_info_multiple(LogType type, const char *name, const char *val
 
 		msg.msg_size = msg_size - ULOG_MSG_HEADER_LEN;
 
-		write_message(type, buffer, msg_size);
+		write_message(type, buffer, msg_size, acked);
 
 	} else {
 		PX4_ERR("info_multiple str too long (%" PRIu8 "), key=%s", msg.key_len, msg.key_value_str);
@@ -1888,7 +1932,7 @@ void Logger::write_info_multiple(LogType type, const char *name, const char *val
 	_writer.unlock();
 }
 
-void Logger::write_info_multiple(LogType type, const char *name, int fd)
+void Logger::write_info_multiple(LogType type, const char *name, int fd, bool acked)
 {
 	// Get the file length
 	struct stat stat_data;
@@ -1924,7 +1968,7 @@ void Logger::write_info_multiple(LogType type, const char *name, int fd)
 			msg_size += read_length;
 			msg.msg_size = msg_size - ULOG_MSG_HEADER_LEN;
 
-			write_message(type, buffer, msg_size);
+			write_message(type, buffer, msg_size, acked);
 			file_offset += ret;
 
 		} else {
@@ -1938,19 +1982,19 @@ void Logger::write_info_multiple(LogType type, const char *name, int fd)
 	}
 }
 
-void Logger::write_info(LogType type, const char *name, int32_t value)
+void Logger::write_info(LogType type, const char *name, int32_t value, bool acked)
 {
-	write_info_template<int32_t>(type, name, value, "int32_t");
+	write_info_template<int32_t>(type, name, value, "int32_t", acked);
 }
 
-void Logger::write_info(LogType type, const char *name, uint32_t value)
+void Logger::write_info(LogType type, const char *name, uint32_t value, bool acked)
 {
-	write_info_template<uint32_t>(type, name, value, "uint32_t");
+	write_info_template<uint32_t>(type, name, value, "uint32_t", acked);
 }
 
 
 template<typename T>
-void Logger::write_info_template(LogType type, const char *name, T value, const char *type_str)
+void Logger::write_info_template(LogType type, const char *name, T value, const char *type_str, bool acked)
 {
 	_writer.lock();
 	ulog_message_info_s msg = {};
@@ -1967,23 +2011,23 @@ void Logger::write_info_template(LogType type, const char *name, T value, const 
 
 	msg.msg_size = msg_size - ULOG_MSG_HEADER_LEN;
 
-	write_message(type, buffer, msg_size);
+	write_message(type, buffer, msg_size, acked);
 
 	_writer.unlock();
 }
 
-void Logger::write_excluded_optional_topics(LogType type)
+void Logger::write_excluded_optional_topics(LogType type, bool acked)
 {
 	for (int i = 0; i < _num_excluded_optional_topic_ids; ++i) {
 		orb_id_t meta = get_orb_meta((ORB_ID)_excluded_optional_topic_ids[i]);
 
 		if (meta) {
-			write_info_multiple(type, "excluded_optional_topics", meta->o_name, false);
+			write_info_multiple(type, "excluded_optional_topics", meta->o_name, false, acked);
 		}
 	}
 }
 
-void Logger::write_header(LogType type)
+void Logger::write_header(LogType type, bool acked)
 {
 	ulog_file_header_s header = {};
 	header.magic[0] = 'U';
@@ -1996,7 +2040,7 @@ void Logger::write_header(LogType type)
 	header.magic[7] = 0x01; //file version 1
 	header.timestamp = hrt_absolute_time();
 	_writer.lock();
-	write_message(type, &header, sizeof(header));
+	write_message(type, &header, sizeof(header), acked);
 
 	// write the Flags message: this MUST be written right after the ulog header
 	ulog_message_flag_bits_s flag_bits{};
@@ -2006,57 +2050,57 @@ void Logger::write_header(LogType type)
 	flag_bits.msg_size = sizeof(flag_bits) - ULOG_MSG_HEADER_LEN;
 	flag_bits.msg_type = static_cast<uint8_t>(ULogMessageType::FLAG_BITS);
 
-	write_message(type, &flag_bits, sizeof(flag_bits));
+	write_message(type, &flag_bits, sizeof(flag_bits), acked);
 
 	_writer.unlock();
 }
 
-void Logger::write_version(LogType type)
+void Logger::write_version(LogType type, bool acked)
 {
-	write_info(type, "ver_sw", px4_firmware_version_string());
-	write_info(type, "ver_sw_release", px4_firmware_version());
+	write_info(type, "ver_sw", px4_firmware_version_string(), acked);
+	write_info(type, "ver_sw_release", px4_firmware_version(), acked);
 	uint32_t vendor_version = px4_firmware_vendor_version();
 
 	if (vendor_version > 0) {
-		write_info(type, "ver_vendor_sw_release", vendor_version);
+		write_info(type, "ver_vendor_sw_release", vendor_version, acked);
 	}
 
-	write_info(type, "ver_hw", px4_board_name());
+	write_info(type, "ver_hw", px4_board_name(), acked);
 	const char *board_sub_type = px4_board_sub_type();
 
 	if (board_sub_type && board_sub_type[0]) {
-		write_info(type, "ver_hw_subtype", board_sub_type);
+		write_info(type, "ver_hw_subtype", board_sub_type, acked);
 	}
 
-	write_info(type, "sys_name", "PX4");
-	write_info(type, "sys_os_name", px4_os_name());
+	write_info(type, "sys_name", "PX4", acked);
+	write_info(type, "sys_os_name", px4_os_name(), acked);
 	const char *os_version = px4_os_version_string();
 
 	const char *git_branch = px4_firmware_git_branch();
 
 	if (git_branch && git_branch[0]) {
-		write_info(type, "ver_sw_branch", git_branch);
+		write_info(type, "ver_sw_branch", git_branch, acked);
 	}
 
 	if (os_version) {
-		write_info(type, "sys_os_ver", os_version);
+		write_info(type, "sys_os_ver", os_version, acked);
 	}
 
 	const char *oem_version = px4_firmware_oem_version_string();
 
 	if (oem_version && oem_version[0]) {
-		write_info(type, "ver_oem", oem_version);
+		write_info(type, "ver_oem", oem_version, acked);
 	}
 
 
-	write_info(type, "sys_os_ver_release", px4_os_version());
-	write_info(type, "sys_toolchain", px4_toolchain_name());
-	write_info(type, "sys_toolchain_ver", px4_toolchain_version());
+	write_info(type, "sys_os_ver_release", px4_os_version(), acked);
+	write_info(type, "sys_toolchain", px4_toolchain_name(), acked);
+	write_info(type, "sys_toolchain_ver", px4_toolchain_version(), acked);
 
 	const char *ecl_version = px4_ecl_lib_version_string();
 
 	if (ecl_version && ecl_version[0]) {
-		write_info(type, "sys_lib_ecl_ver", ecl_version);
+		write_info(type, "sys_lib_ecl_ver", ecl_version, acked);
 	}
 
 	char revision = 'U';
@@ -2065,12 +2109,12 @@ void Logger::write_version(LogType type)
 	if (board_mcu_version(&revision, &chip_name, nullptr) >= 0) {
 		char mcu_ver[64];
 		snprintf(mcu_ver, sizeof(mcu_ver), "%s, rev. %c", chip_name, revision);
-		write_info(type, "sys_mcu", mcu_ver);
+		write_info(type, "sys_mcu", mcu_ver, acked);
 	}
 
 	// data versioning: increase this on every larger data change (format/semantic)
 	// 1: switch to FIFO drivers (disabled on-chip DLPF)
-	write_info(type, "ver_data_format", static_cast<uint32_t>(1));
+	write_info(type, "ver_data_format", static_cast<uint32_t>(1), acked);
 
 #ifndef BOARD_HAS_NO_UUID
 
@@ -2078,23 +2122,23 @@ void Logger::write_version(LogType type)
 	if (_param_sdlog_uuid.get() == 1) {
 		char px4_uuid_string[PX4_GUID_FORMAT_SIZE];
 		board_get_px4_guid_formated(px4_uuid_string, sizeof(px4_uuid_string));
-		write_info(type, "sys_uuid", px4_uuid_string);
+		write_info(type, "sys_uuid", px4_uuid_string, acked);
 	}
 
 #endif /* BOARD_HAS_NO_UUID */
 
-	write_info(type, "time_ref_utc", _param_sdlog_utc_offset.get() * 60);
+	write_info(type, "time_ref_utc", _param_sdlog_utc_offset.get() * 60, acked);
 
 	if (_replay_file_name) {
-		write_info(type, "replay", _replay_file_name);
+		write_info(type, "replay", _replay_file_name, acked);
 	}
 
 	if (type == LogType::Mission) {
-		write_info(type, "log_type", "mission");
+		write_info(type, "log_type", "mission", acked);
 	}
 }
 
-void Logger::write_parameter_defaults(LogType type)
+void Logger::write_parameter_defaults(LogType type, bool acked)
 {
 	_writer.lock();
 	ulog_message_parameter_default_s msg = {};
@@ -2165,20 +2209,20 @@ void Logger::write_parameter_defaults(LogType type)
 				if (memcmp(&value, &default_value, value_size) != 0) {
 					memcpy(&buffer[msg_size - value_size], default_value, value_size);
 					msg.default_types = ulog_parameter_default_type_t::current_setup | ulog_parameter_default_type_t::system;
-					write_message(type, buffer, msg_size);
+					write_message(type, buffer, msg_size, acked);
 				}
 
 			} else {
 				if (memcmp(&value, &default_value, value_size) != 0) {
 					memcpy(&buffer[msg_size - value_size], default_value, value_size);
 					msg.default_types = ulog_parameter_default_type_t::current_setup;
-					write_message(type, buffer, msg_size);
+					write_message(type, buffer, msg_size, acked);
 				}
 
 				if (memcmp(&value, &system_default_value, value_size) != 0) {
 					memcpy(&buffer[msg_size - value_size], system_default_value, value_size);
 					msg.default_types = ulog_parameter_default_type_t::system;
-					write_message(type, buffer, msg_size);
+					write_message(type, buffer, msg_size, acked);
 				}
 			}
 		}
@@ -2188,7 +2232,7 @@ void Logger::write_parameter_defaults(LogType type)
 	_writer.notify();
 }
 
-void Logger::write_parameters(LogType type)
+void Logger::write_parameters(LogType type, bool acked)
 {
 	_writer.lock();
 	ulog_message_parameter_s msg = {};
@@ -2249,7 +2293,7 @@ void Logger::write_parameters(LogType type)
 
 			msg.msg_size = msg_size - ULOG_MSG_HEADER_LEN;
 
-			write_message(type, buffer, msg_size);
+			write_message(type, buffer, msg_size, acked);
 		}
 	} while ((param != PARAM_INVALID) && (param_idx < (int) param_count()));
 
@@ -2328,7 +2372,7 @@ void Logger::write_changed_parameters(LogType type)
 	_writer.notify();
 }
 
-void Logger::write_events_file(LogType type)
+void Logger::write_events_file(LogType type, bool acked)
 {
 	int fd = open(PX4_ROOTFSDIR "/etc/extras/all_events.json.xz", O_RDONLY);
 
@@ -2340,11 +2384,11 @@ void Logger::write_events_file(LogType type)
 		return;
 	}
 
-	write_info_multiple(type, "metadata_events", fd);
+	write_info_multiple(type, "metadata_events", fd, acked);
 
 	close(fd);
 
-	write_info(type, "metadata_events_sha256", component_information::all_events_sha256);
+	write_info(type, "metadata_events_sha256", component_information::all_events_sha256, acked);
 }
 
 void Logger::ack_vehicle_command(vehicle_command_s *cmd, uint32_t result)

--- a/src/modules/logger/logger.h
+++ b/src/modules/logger/logger.h
@@ -173,13 +173,13 @@ private:
 	/**
 	 * Write an ADD_LOGGED_MSG to the log for a all current subscriptions and instances
 	 */
-	void write_all_add_logged_msg(LogType type);
+	void write_all_add_logged_msg(LogType type, bool acked=false);
 
 	/**
 	 * Write an ADD_LOGGED_MSG to the log for a given subscription and instance.
 	 * _writer.lock() must be held when calling this.
 	 */
-	void write_add_logged_msg(LogType type, LoggerSubscription &subscription);
+	void write_add_logged_msg(LogType type, LoggerSubscription &subscription, bool acked=false);
 
 	/**
 	 * Create logging directory
@@ -204,6 +204,14 @@ private:
 
 	void stop_log_mavlink();
 
+	/**
+	 * Run in separate thread to continue data logging while sending header&descriptions
+	 */
+	void mav_start_steps();
+
+	static void *mav_start_steps_helper(void *);
+	pthread_t _mav_start_thread = 0;
+
 	/** check if mavlink logging can be started */
 	bool can_start_mavlink_log() const
 	{
@@ -217,25 +225,25 @@ private:
 	/**
 	 * write the file header with file magic and timestamp.
 	 */
-	void write_header(LogType type);
+	void write_header(LogType type, bool acked=false);
 
 	/// Array to store written formats for nested definitions (only)
 	using WrittenFormats = Array < const orb_metadata *, 20 >;
 
 	void write_format(LogType type, const orb_metadata &meta, WrittenFormats &written_formats, ulog_message_format_s &msg,
-			  int subscription_index, int level = 1);
-	void write_formats(LogType type);
+			  int subscription_index, int level = 1, bool acked=false);
+	void write_formats(LogType type, bool acked=false);
 
 	/**
 	 * write performance counters
 	 * @param preflight preflight if true, postflight otherwise
 	 */
-	void write_perf_data(bool preflight);
+	void write_perf_data(bool preflight, bool acked=false);
 
 	/**
 	 * write bootup console output
 	 */
-	void write_console_output();
+	void write_console_output(bool acked=false);
 
 	/**
 	 * callback to write the performance counters
@@ -247,25 +255,25 @@ private:
 	 */
 	static void print_load_callback(void *user);
 
-	void write_version(LogType type);
+	void write_version(LogType type, bool acked=false);
 
-	void write_excluded_optional_topics(LogType type);
+	void write_excluded_optional_topics(LogType type, bool acked=false);
 
-	void write_info(LogType type, const char *name, const char *value);
-	void write_info_multiple(LogType type, const char *name, const char *value, bool is_continued);
-	void write_info_multiple(LogType type, const char *name, int fd);
-	void write_info(LogType type, const char *name, int32_t value);
-	void write_info(LogType type, const char *name, uint32_t value);
+	void write_info(LogType type, const char *name, const char *value, bool acked=false);
+	void write_info_multiple(LogType type, const char *name, const char *value, bool is_continued, bool acked=false);
+	void write_info_multiple(LogType type, const char *name, int fd, bool acked=false);
+	void write_info(LogType type, const char *name, int32_t value, bool acked=false);
+	void write_info(LogType type, const char *name, uint32_t value, bool acked=false);
 
 	/** generic common template method for write_info variants */
 	template<typename T>
-	void write_info_template(LogType type, const char *name, T value, const char *type_str);
+	void write_info_template(LogType type, const char *name, T value, const char *type_str, bool acked=false);
 
-	void write_parameters(LogType type);
-	void write_parameter_defaults(LogType type);
+	void write_parameters(LogType type, bool acked=false);
+	void write_parameter_defaults(LogType type, bool acked=false);
 
 	void write_changed_parameters(LogType type);
-	void write_events_file(LogType type);
+	void write_events_file(LogType type, bool acked=false);
 
 	inline bool copy_if_updated(int sub_idx, void *buffer, bool try_to_subscribe);
 
@@ -274,7 +282,7 @@ private:
 	 * Must be called with _writer.lock() held.
 	 * @return true if data written, false otherwise (on overflow)
 	 */
-	bool write_message(LogType type, void *ptr, size_t size);
+	bool write_message(LogType type, void *ptr, size_t size, bool acked=false);
 
 	/**
 	 * Add topic subscriptions from SD file if it exists, otherwise add topics based on the configured profile.

--- a/src/modules/mavlink/mavlink_ulog.h
+++ b/src/modules/mavlink/mavlink_ulog.h
@@ -51,6 +51,7 @@
 #include <uORB/Subscription.hpp>
 #include <uORB/topics/ulog_stream.h>
 #include <uORB/topics/ulog_stream_ack.h>
+#include <uORB/topics/ulog_stream_acked.h>
 
 #include "mavlink_bridge_header.h"
 
@@ -123,6 +124,7 @@ private:
 	static const float _rate_calculation_delta_t; ///< rate update interval
 
 	uORB::SubscriptionData<ulog_stream_s> _ulog_stream_sub{ORB_ID(ulog_stream)};
+	uORB::SubscriptionData<ulog_stream_s> _ulog_stream_acked_sub{ORB_ID(ulog_stream_acked)};
 	uORB::Publication<ulog_stream_ack_s> _ulog_stream_ack_pub{ORB_ID(ulog_stream_ack)};
 	uint16_t _wait_for_ack_sequence;
 	uint8_t _sent_tries = 0;


### PR DESCRIPTION
Reliable transfer mode requires ack for every message send over mavlink. This slows down the logging start for several seconds causing buch of data missing in the beginning of the log.
