### PR TITLE
uORB/callbacks: Increase amount of callbacks to 32 in kernel mode

### DIFF
--- a/platforms/common/uORB/uORBDeviceNode.hpp
+++ b/platforms/common/uORB/uORBDeviceNode.hpp
@@ -57,7 +57,11 @@ typedef void *uorb_cb_handle_t;
 #define UORB_INVALID_CB_HANDLE nullptr
 #define uorb_cb_handle_valid(x) ((x) != nullptr)
 #else
+#if defined(CONFIG_BUILD_KERNEL)
+#define MAX_EVENT_WAITERS 32
+#else
 #define MAX_EVENT_WAITERS 5
+#endif
 #define UORB_INVALID_CB_HANDLE -1
 typedef int8_t uorb_cb_handle_t;
 #define uorb_cb_handle_valid(x) ((x) >= 0)


### PR DESCRIPTION
In kernel mode there might be quite a lot of waiters, so increase the callback list size substantially. Leave the other modes unaffected.
