### PR TITLE
px4_platform_common/sem.h: Enable SEM_PRIO_INHERIT by default

### DIFF
--- a/platforms/common/include/px4_platform_common/sem.h
+++ b/platforms/common/include/px4_platform_common/sem.h
@@ -89,7 +89,12 @@ typedef sem_t px4_sem_t;
 
 __BEGIN_DECLS
 
-#define px4_sem_init		sem_init
+#define px4_sem_init(s, p, v) ({ \
+		int __ret; \
+		do { __ret = sem_init(s, p, v); sem_setprotocol(s, SEM_PRIO_INHERIT); } while(0); \
+		__ret; \
+	})
+
 #define px4_sem_setprotocol	sem_setprotocol
 #define px4_sem_wait		sem_wait
 #define px4_sem_trywait		sem_trywait


### PR DESCRIPTION
This is a (temporary) regression mitigation after NuttX 12.0 release, where priority inheritance (pi) was disabled by default. This changes the default behavior, as previously pi was enabled by default.

Patch it by enabling it within the px4_sem_init() call.

