### PR TITLE
Fix uorb queue wraparound

### DIFF
--- a/platforms/common/uORB/SubscriptionBlocking.hpp
+++ b/platforms/common/uORB/SubscriptionBlocking.hpp
@@ -129,7 +129,7 @@ public:
 
 				// Calculate an absolute time in the future
 				struct timespec ts;
-#if defined(ENABLE_LOCKSTEP_SCHEDULER)
+#if defined(CONFIG_ARCH_BOARD_PX4_SITL)
 				px4_clock_gettime(CLOCK_MONOTONIC, &ts);
 #else
 				px4_clock_gettime(CLOCK_REALTIME, &ts);

--- a/platforms/common/uORB/uORBManager.cpp
+++ b/platforms/common/uORB/uORBManager.cpp
@@ -420,7 +420,7 @@ int uORB::Manager::orb_poll(orb_poll_struct_t *fds, unsigned int nfds, int timeo
 		} else {
 			// Wait event for a maximum timeout time
 			struct timespec to;
-#if defined(ENABLE_LOCKSTEP_SCHEDULER)
+#if defined(CONFIG_ARCH_BOARD_PX4_SITL)
 			px4_clock_gettime(CLOCK_MONOTONIC, &to);
 #else
 			px4_clock_gettime(CLOCK_REALTIME, &to);


### PR DESCRIPTION

There was some weirdness in uORBDeviceNode::copy; the queue indicies are not managed properly at least in wrap-around case
