### PR TITLE
Add version numberings to ver

### DIFF
--- a/platforms/nuttx/src/bootloader/microchip/mpfs/main.c
+++ b/platforms/nuttx/src/bootloader/microchip/mpfs/main.c
@@ -44,6 +44,7 @@
 #include <fcntl.h>
 #include <unistd.h>
 #include <debug.h>
+#include <stdio.h>
 
 #include "hw_config.h"
 #include "board_type.h"
@@ -57,6 +58,8 @@
 #include <nuttx/board.h>
 
 #include <mpfs_entrypoints.h>
+
+#include <px4_arch/device_info.h>
 
 #include "image_toc.h"
 #include "crypto.h"
@@ -162,6 +165,8 @@ static bool g_led_state[3];
 
 /* State of an inserted USB cable */
 static bool usb_connected = false;
+
+devinfo_t device_info __attribute__((section(".deviceinfo")));
 
 /* PX4 image TOC 'reserved' field for vendor specific info_bits
  * Bit 0 marks for whether SBI should be used or not
@@ -941,7 +946,8 @@ bootloader_main(int argc, char *argv[])
 {
 	unsigned timeout = BOOTLOADER_DELAY;	 /* if nonzero, drop out of the bootloader after this time */
 	bool try_boot;
-	_alert("Version: %s\n", VERSION);
+	snprintf(device_info.bl_version, sizeof(device_info.bl_version), VERSION);
+	_alert("Version: %s\n", device_info.bl_version);
 
 	/* do board-specific initialisation */
 	board_init();

--- a/platforms/nuttx/src/px4/microchip/microchip_common/include/px4_arch/device_info.h
+++ b/platforms/nuttx/src/px4/microchip/microchip_common/include/px4_arch/device_info.h
@@ -1,0 +1,65 @@
+/****************************************************************************
+ *
+ *   Copyright (c) 2023 Technology Innovation Institute. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *	notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *	notice, this list of conditions and the following disclaimer in
+ *	the documentation and/or other materials provided with the
+ *	distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *	used to endorse or promote products derived from this software
+ *	without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+#pragma once
+
+#include <image_toc.h>
+
+typedef struct __attribute__((__packed__))
+{
+	/* Magic, matches characters "DNFO" when valid */
+
+	uint32_t magic;
+
+	/* Anti-rollback counters for different payloads */
+
+	uint16_t arb[IMAGE_NUM_TYPES];
+
+	/* Feature flags. RD certificate feature bits are ORd to this.
+	 * Passed to payload OSs for enabling / disabling features
+	 */
+
+	uint32_t features;
+
+	/* Device MAC addresses */
+
+	uint8_t mac[6][4];
+
+	/* Bootloader version info */
+
+	char bl_version[32];
+
+	/* Reserved for future use */
+
+	uint8_t reserved[428];
+} devinfo_t;

--- a/platforms/nuttx/src/px4/microchip/mpfs/include/px4_arch/device_info.h
+++ b/platforms/nuttx/src/px4/microchip/mpfs/include/px4_arch/device_info.h
@@ -1,0 +1,36 @@
+/****************************************************************************
+ *
+ *   Copyright (c) 2023 Technology Innovation Institute. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *	notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *	notice, this list of conditions and the following disclaimer in
+ *	the documentation and/or other materials provided with the
+ *	distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *	used to endorse or promote products derived from this software
+ *	without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+#pragma once
+
+#include "../../../microchip_common/include/px4_arch/device_info.h"

--- a/platforms/nuttx/src/px4/microchip/mpfs/version/board_mcu_version.c
+++ b/platforms/nuttx/src/px4/microchip/mpfs/version/board_mcu_version.c
@@ -39,6 +39,7 @@
 #include <px4_platform_common/log.h>
 #include <px4_platform_common/px4_config.h>
 #include <px4_platform/board_determine_hw_info.h>
+#include <px4_arch/device_info.h>
 #include <stdint.h>
 
 #include <board_config.h>
@@ -73,6 +74,8 @@ static unsigned fpga_version_minor;
 static char hw_info[HW_INFO_SIZE] = {0};
 
 static mfguid_t device_serial_number = { 0 };
+
+devinfo_t device_info __attribute__((section(".deviceinfo")));
 
 static void determine_hw(void);
 
@@ -123,6 +126,11 @@ int board_mcu_version(char *rev, const char **revstr, const char **errata)
 	}
 
 	return hw_version;
+}
+
+const char *board_bl_version_string(void)
+{
+	return device_info.bl_version;
 }
 
 int board_get_px4_guid(px4_guid_t px4_guid)

--- a/src/systemcmds/ver/ver.cpp
+++ b/src/systemcmds/ver/ver.cpp
@@ -47,6 +47,10 @@
 #include <string.h>
 #include <version/version.h>
 
+#ifndef PX4_BL_VERSION
+#define PX4_BL_VERSION NULL
+#endif
+
 /* string constants for version commands */
 static const char sz_ver_hw_str[] 	= "hw";
 static const char sz_ver_hwcmp_str[]    = "hwcmp";
@@ -177,6 +181,13 @@ extern "C" __EXPORT int ver_main(int argc, char *argv[])
 					if (git_branch && git_branch[0]) {
 						printf("PX4 git-branch: %s\n", git_branch);
 					}
+
+					const char *bl_version = PX4_BL_VERSION;
+
+					if (bl_version) {
+						printf("Bootloader version: %s\n", bl_version);
+					}
+
 				}
 
 				fwver = px4_os_version();


### PR DESCRIPTION
This adds the bootloader and FPGA version numbers to PX4 "ver" command. Cherry-picked from fc-only branch
