### PR TITLE
gz_bridge: Increase sleep_count_limit to avoid timeout in local gz env

### DIFF
--- a/src/modules/simulation/gz_bridge/GZBridge.cpp
+++ b/src/modules/simulation/gz_bridge/GZBridge.cpp
@@ -307,7 +307,7 @@ int GZBridge::task_spawn(int argc, char *argv[])
 
 #if defined(ENABLE_LOCKSTEP_SCHEDULER)
 			// lockstep scheduler wait for initial clock set before returning
-			int sleep_count_limit = 1000;
+			int sleep_count_limit = 10000;
 
 			while ((instance->world_time_us() == 0) && sleep_count_limit > 0) {
 				// wait for first clock message


### PR DESCRIPTION
Increased limit value to avoid timeout while waiting for simulation clock in locally started simulation (make px4_sitl gz_x500)