### PR TITLE
uORB: Increase MAX_EVENT_WAITERS to 32 for protected mode as well

### DIFF
--- a/platforms/common/uORB/uORBDeviceNode.hpp
+++ b/platforms/common/uORB/uORBDeviceNode.hpp
@@ -57,11 +57,7 @@ typedef void *uorb_cb_handle_t;
 #define UORB_INVALID_CB_HANDLE nullptr
 #define uorb_cb_handle_valid(x) ((x) != nullptr)
 #else
-#if defined(CONFIG_BUILD_KERNEL)
 #define MAX_EVENT_WAITERS 32
-#else
-#define MAX_EVENT_WAITERS 5
-#endif
 #define UORB_INVALID_CB_HANDLE -1
 typedef int8_t uorb_cb_handle_t;
 #define uorb_cb_handle_valid(x) ((x) >= 0)


### PR DESCRIPTION
Protected mode needs more of these as well

<!--

Thank you for your contribution!

Get early feedback through
- Dronecode Discord: https://discord.gg/dronecode
- PX4 Discuss: http://discuss.px4.io/
- opening a draft pr and sharing the link

-->

### Solved Problem
When ... I found that ...

Fixes #{Github issue ID}

### Solution
- Add ... for ...
- Refactor ...

### Alternatives
We could also ...

### Test coverage
- Unit/integration test: ...
- Simulation/hardware testing logs: https://review.px4.io/

### Context
Related links, screenshot before/after, video
