### PR TITLE
uORB: Add some trivial sanity checks / fix possible race conditions

### DIFF
--- a/platforms/common/uORB/SubscriptionCallback.hpp
+++ b/platforms/common/uORB/SubscriptionCallback.hpp
@@ -87,10 +87,10 @@ public:
 	void unregisterCallback()
 	{
 		if (registered()) {
-			DeviceNode::unregister_callback(_subscription.get_node(), _cb_handle);
+			uorb_cb_handle_t handle = _cb_handle;
+			_cb_handle = UORB_INVALID_CB_HANDLE;
+			DeviceNode::unregister_callback(_subscription.get_node(), handle);
 		}
-
-		_cb_handle = UORB_INVALID_CB_HANDLE;
 	}
 
 	/**
@@ -203,8 +203,9 @@ public:
 
 	void unregisterPoll()
 	{
-		DeviceNode::unregister_callback(_subscription.get_node(), _cb_handle);
+		uorb_cb_handle_t handle = _cb_handle;
 		_cb_handle = UORB_INVALID_CB_HANDLE;
+		DeviceNode::unregister_callback(_subscription.get_node(), handle);
 	}
 private:
 	uorb_cb_handle_t _cb_handle{UORB_INVALID_CB_HANDLE};

--- a/platforms/common/uORB/uORBManager.cpp
+++ b/platforms/common/uORB/uORBManager.cpp
@@ -492,6 +492,10 @@ uORB::Manager::callback_thread(int argc, char *argv[])
 			break;
 		}
 
+		if (!sub->registered()) {
+			continue;
+		}
+
 		sub->call();
 	}
 

--- a/platforms/common/uORB/uORBManager.hpp
+++ b/platforms/common/uORB/uORBManager.hpp
@@ -446,15 +446,22 @@ public:
 
 	static void queueCallback(class SubscriptionCallback *sub, int idx)
 	{
-		_Instance->g_sem_pool.cb_lock(idx);
-		_Instance->g_sem_pool.cb_set(idx, sub);
-		// The manager is unlocked in callback thread
+		if (idx >= 0) {
+			_Instance->g_sem_pool.cb_lock(idx);
+			_Instance->g_sem_pool.cb_set(idx, sub);
+			// The manager is unlocked in callback thread
+		}
 	}
 
 	static class SubscriptionCallback *dequeueCallback(int idx)
 	{
-		class SubscriptionCallback *sub = _Instance->g_sem_pool.cb_get(idx);
-		_Instance->g_sem_pool.cb_unlock(idx);
+		class SubscriptionCallback *sub = nullptr;
+
+		if (idx >= 0) {
+			sub = _Instance->g_sem_pool.cb_get(idx);
+			_Instance->g_sem_pool.cb_unlock(idx);
+		}
+
 		return sub;
 	}
 


### PR DESCRIPTION
Just some sanity checks added.

The uORB crash is "fixed" by the !sub->registered() check. Root cause for problem unknown.