### PR TITLE
Parallel_logging: Disable reliable_transfer for dynamic ADD_LOGGED_MSG

### DIFF
--- a/src/modules/logger/logger.cpp
+++ b/src/modules/logger/logger.cpp
@@ -1922,11 +1922,7 @@ void Logger::write_add_logged_msg(LogType type, LoggerSubscription &subscription
 
 	bool prev_reliable = _writer.need_reliable_transfer();
 	_writer.set_need_reliable_transfer(true);
-#ifdef LOGGER_PARALLEL_LOGGING
-	write_message(type, &msg, msg_size, true);
-#else
-	write_message(type, &msg, msg_size);
-#endif
+	write_message(type, &msg, msg_size, acked);
 	_writer.set_need_reliable_transfer(prev_reliable);
 }
 


### PR DESCRIPTION
Due to the current structure, if there is reliable transfer done in dynamic data stream while the static data transfer is still ongoing, the acked data stream gets corrupted (two consecutive data transfer).
Until the logger implementation is restructured to have dedicated fifo for reliable transfer data, we need to disable reliable transfers from dynamic data stream in parallel logging case.