### PR TITLE
DP-6244 enable coverity

### DIFF
--- a/.github/workflows/tiiuae-coverity-scan.yaml
+++ b/.github/workflows/tiiuae-coverity-scan.yaml
@@ -24,7 +24,7 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Run coverity scan
-        run:
+        run: |
           docker run --rm -v "$(pwd):/main_ws" ghcr.io/tiiuae/px4-coverity-scan-image:latest
       - name: Update summary
         run:

--- a/packaging/Dockerfile.coverity
+++ b/packaging/Dockerfile.coverity
@@ -23,5 +23,6 @@ RUN curl https://sig-repo.synopsys.com/artifactory/coverity-releases/2023.6.0/co
     && /coverity_install.sh -q --installation.dir=/cov --license.region=6 --license.agreement=agree --license.type.choice=0 --license.cov.path=/license.dat \
     && rm /coverity_install.sh
 
+RUN apt update && apt install -y --no-install-recommends xmlstarlet
 COPY px4-firmware/packaging/entrypoint_coverity.sh /
 ENTRYPOINT [ "/entrypoint_coverity.sh" ]

--- a/packaging/coverity.yaml
+++ b/packaging/coverity.yaml
@@ -5,6 +5,6 @@ capture:
 commit:
   connect:
     auth-key-file: /auth_key.txt
-    stream: px4-coverity-test
+    stream: px4-coverity
     url: https://coverity.ssrc.fi:443/
     on-new-cert: trust

--- a/packaging/entrypoint_coverity.sh
+++ b/packaging/entrypoint_coverity.sh
@@ -5,6 +5,8 @@ COVERITY_SCAN_OUT=/main_ws/cov-scan-output.txt
 COVERITY_REPORT_OUT=/main_ws/coverity-output
 
 cp /main_ws/packaging/coverity.yaml /main_ws/coverity.yaml
+cd /main_ws
+git config --global --add safe.directory '*'
 
 export PATH=$PATH:/cov/bin/
 cov-configure --gcc
@@ -29,4 +31,15 @@ echo '------' >> ${COVERITY_SUMMARY_OUT}
 
 # save coverity html output
 cov-format-errors --dir idir --html-output ${COVERITY_REPORT_OUT}
+
+# github output to format table
+echo "| checker | file |" >> ${COVERITY_SUMMARY_OUT}
+echo "| ------- | ---- |" >> ${COVERITY_SUMMARY_OUT}
+
+# findings from output xml, save error, filename and line number
+# grep away files which begins with "/" as they are from the environment and not from the project
+xmlstarlet sel -t -m "/coverity/error" -o "| " -v "checker" -o " | " -v "file" -o ":" -v "line" -o " |" -n ${COVERITY_REPORT_OUT}/index.xml | grep -v '.*[[:space:]]\/.*'>> ${COVERITY_SUMMARY_OUT}
+
+# echo an empty line to end table formatting
+echo '' >> ${COVERITY_SUMMARY_OUT}
 echo 'for more details please check attached html report from "Artifacts" -sections above' >> ${COVERITY_SUMMARY_OUT}


### PR DESCRIPTION
- update coverity 2023.06
- include list of scan findings in the action summary
- include full coverity report as zipped artifact on action
an example: https://github.com/tiiuae/px4-firmware/actions/runs/6635891574