### PR TITLE
Remove building ssrc target bootloaders in CI

### DIFF
--- a/.github/workflows/tiiuae-pixhawk-and-saluki.yaml
+++ b/.github/workflows/tiiuae-pixhawk-and-saluki.yaml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        product: [pixhawk, saluki-v2_default, saluki-v2_bootloader, saluki-v2_amp, saluki-v2_protected, saluki-v2_kernel, saluki-pi_default, saluki-pi_bootloader, saluki-pi_amp, saluki-pi_protected, saluki-v3_default, saluki-v3_amp]
+        product: [pixhawk, saluki-v2_default, saluki-v2_amp, saluki-v2_protected, saluki-v2_kernel, saluki-pi_default, saluki-pi_amp, saluki-pi_protected, saluki-v3_default, saluki-v3_amp]
 
     uses: ./.github/workflows/tiiuae-pixhawk-and-saluki-builder.yaml
     with:

--- a/.github/workflows/tiiuae-pixhawk-artifact-publish.yaml
+++ b/.github/workflows/tiiuae-pixhawk-artifact-publish.yaml
@@ -241,17 +241,11 @@ jobs:
                         "$ARTIFACTORY_GEN_REPO/builds/px4-firmware/saluki/$saluki_amp_pkg_name" \
                         "$ARTIFACTORY_GEN_REPO/builds/px4-firmware/saluki/latest/ssrc_saluki-v1_amp.bin"
             jfrog rt cp --flat \
-                        "$ARTIFACTORY_GEN_REPO/builds/px4-firmware/saluki/$saluki_bl_pkg_name" \
-                        "$ARTIFACTORY_GEN_REPO/builds/px4-firmware/saluki/latest/ssrc_saluki-v1_bootloader.elf"
-            jfrog rt cp --flat \
                         "$ARTIFACTORY_GEN_REPO/builds/px4-firmware/saluki/$saluki_v2_pkg_name" \
                         "$ARTIFACTORY_GEN_REPO/builds/px4-firmware/saluki/latest/ssrc_saluki-v2_default.px4"
             jfrog rt cp --flat \
                         "$ARTIFACTORY_GEN_REPO/builds/px4-firmware/saluki/$saluki_v2_amp_pkg_name" \
                         "$ARTIFACTORY_GEN_REPO/builds/px4-firmware/saluki/latest/ssrc_saluki-v2_amp.bin"
-            jfrog rt cp --flat \
-                        "$ARTIFACTORY_GEN_REPO/builds/px4-firmware/saluki/$saluki_v2_bl_pkg_name" \
-                        "$ARTIFACTORY_GEN_REPO/builds/px4-firmware/saluki/latest/ssrc_saluki-v2_bootloader.elf"
           fi
       - name: Upload px4-fwupdater build to Artifactory
         env:

--- a/build.sh
+++ b/build.sh
@@ -11,15 +11,12 @@ usage() {
   echo "     saluki-v1_default"
   echo "     saluki-v1_protected"
   echo "     saluki-v1_amp"
-  echo "     saluki-v1_bootloader"
   echo "     saluki-v2_default"
   echo "     saluki-v2_amp"
-  echo "     saluki-v2_bootloader"
   echo "     saluki-v2_protected"
   echo "     saluki-v2_kernel"
   echo "     saluki-pi_default"
   echo "     saluki-pi_amp"
-  echo "     saluki-pi_bootloader"
   echo "     saluki-pi_protected"
   echo "     saluki-v3_default"
   echo "     saluki-v3_amp"
@@ -71,10 +68,6 @@ case $target in
     $build_cmd_fw ssrc_saluki-v1_amp
     cp ${script_dir}/build/ssrc_saluki-v1_amp/ssrc_saluki-v1_amp.bin ${dest_dir}/ssrc_saluki-v1_amp-${version}.bin
     ;;
-  "saluki-v1_bootloader")
-    $build_cmd_fw ssrc_saluki-v1_bootloader
-    cp ${script_dir}/build/ssrc_saluki-v1_bootloader/ssrc_saluki-v1_bootloader.elf ${dest_dir}/ssrc_saluki-v1_bootloader-${version}.elf
-    ;;
   "saluki-v2_default")
     $build_cmd_fw ssrc_saluki-v2_default
     cp ${script_dir}/build/ssrc_saluki-v2_default/ssrc_saluki-v2_default.px4 ${dest_dir}/ssrc_saluki-v2_default-${version}.px4
@@ -86,10 +79,6 @@ case $target in
   "saluki-v2_amp")
     $build_cmd_fw ssrc_saluki-v2_amp
     cp ${script_dir}/build/ssrc_saluki-v2_amp/ssrc_saluki-v2_amp.bin ${dest_dir}/ssrc_saluki-v2_amp-${version}.bin
-    ;;
-  "saluki-v2_bootloader")
-    $build_cmd_fw ssrc_saluki-v2_bootloader
-    cp ${script_dir}/build/ssrc_saluki-v2_bootloader/ssrc_saluki-v2_bootloader.elf ${dest_dir}/ssrc_saluki-v2_bootloader-${version}.elf
     ;;
   "saluki-v2_kernel")
     $build_cmd_fw ssrc_saluki-v2_kernel
@@ -115,10 +104,6 @@ case $target in
   "saluki-pi_amp")
     $build_cmd_fw ssrc_saluki-pi_amp
     cp ${script_dir}/build/ssrc_saluki-pi_amp/ssrc_saluki-pi_amp.bin ${dest_dir}/ssrc_saluki-pi_amp-${version}.bin
-    ;;
-  "saluki-pi_bootloader")
-    $build_cmd_fw ssrc_saluki-pi_bootloader
-    cp ${script_dir}/build/ssrc_saluki-pi_bootloader/ssrc_saluki-pi_bootloader.elf ${dest_dir}/ssrc_saluki-pi_bootloader-${version}.elf
     ;;
    *)
     usage


### PR DESCRIPTION
The "px4 bootloader" is no longer supported for these

Target to be removed later in submodules