### PR TITLE
uxrce_client: Do not send PositionSetpointTriplet

### DIFF
--- a/src/modules/uxrce_dds_client/dds_topics.yaml
+++ b/src/modules/uxrce_dds_client/dds_topics.yaml
@@ -11,9 +11,6 @@ publications:
   - topic: /fmu/out/failsafe_flags
     type: px4_msgs::msg::FailsafeFlags
 
-  - topic: /fmu/out/position_setpoint_triplet
-    type: px4_msgs::msg::PositionSetpointTriplet
-
   - topic: /fmu/out/sensor_combined
     type: px4_msgs::msg::SensorCombined
 


### PR DESCRIPTION
There is no one using the position_setpoint_triplet messages in MC side currently and because no users there, it causes SROS ACL errors about uxrce-agent has no permissions to write to topic.
