### PR TITLE
Fix osx build and git user conflict

### DIFF
--- a/packaging/Dockerfile.build_env
+++ b/packaging/Dockerfile.build_env
@@ -16,3 +16,5 @@ USER builder
 
 VOLUME /px4-firmware/sources
 WORKDIR /px4-firmware/sources
+
+RUN git config --global --add safe.directory /px4-firmware/sources

--- a/packaging/Dockerfile.build_env
+++ b/packaging/Dockerfile.build_env
@@ -4,7 +4,7 @@ FROM ghcr.io/tiiuae/px4-firmware-builder-base:latest
 ARG UID=1000
 ARG GID=1000
 
-RUN groupadd -g $GID builder && \
+RUN groupadd -o -g $GID builder && \
     useradd -m -u $UID -g $GID -g builder builder && \
     usermod -aG sudo builder && \
     echo 'builder ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers


### PR DESCRIPTION
### Solved Problem
When building under OSX the typical user group (staff) has a GID of 20 conflicting with some Ubuntu system group of the container. Additionally if the git users between the host and container don't match (repo cloned on host, used in container), git aborts with a fatal error. 


### Solution
- Add '-o' option to groupadd to allow for multiple group names pointing to the same GID
- Mark the sources directory as a 'safe.directory' for git inside the container


### Alternatives
- '-o' option: perhaps we could use the existing group name but I suppose that would add too much bloat in the dockerfile
- git safe dir: perhaps we could COPY the host's user git config over to the container though I'm not sure of how portable that can be.

### Test coverage
- Tested only under OSX.
