### PR TITLE
Reset continue boot option

### DIFF
--- a/platforms/common/include/px4_platform_common/shutdown.h
+++ b/platforms/common/include/px4_platform_common/shutdown.h
@@ -83,7 +83,7 @@ __EXPORT int px4_unregister_shutdown_hook(shutdown_hook_t hook);
  * @return 0 on success, <0 on error
  */
 #if defined(CONFIG_BOARDCTL_RESET)
-__EXPORT int px4_reboot_request(bool to_bootloader = false, uint32_t delay_us = 0);
+__EXPORT int px4_reboot_request(bool to_bootloader = false, uint32_t delay_us = 0, bool continue_boot = false);
 #endif // CONFIG_BOARDCTL_RESET
 
 

--- a/platforms/common/shutdown.cpp
+++ b/platforms/common/shutdown.cpp
@@ -108,6 +108,8 @@ static uint16_t shutdown_counter = 0; ///< count how many times the shutdown wor
 #define SHUTDOWN_ARG_IN_PROGRESS (1<<0)
 #define SHUTDOWN_ARG_REBOOT (1<<1)
 #define SHUTDOWN_ARG_TO_BOOTLOADER (1<<2)
+#define SHUTDOWN_ARG_BL_CONTINUE_BOOT (1<<3)
+
 static uint8_t shutdown_args = 0;
 
 static constexpr int max_shutdown_hooks = 1;
@@ -175,7 +177,18 @@ static void shutdown_worker(void *arg)
 		if (shutdown_args & SHUTDOWN_ARG_REBOOT) {
 #if defined(CONFIG_BOARDCTL_RESET)
 			PX4_INFO_RAW("Reboot NOW.");
-			boardctl(BOARDIOC_RESET, (shutdown_args & SHUTDOWN_ARG_TO_BOOTLOADER) ? 1 : 0);
+			uintptr_t reboot_arg = 0;
+
+			if (shutdown_args & SHUTDOWN_ARG_TO_BOOTLOADER) {
+				if (shutdown_args & SHUTDOWN_ARG_BL_CONTINUE_BOOT) {
+					reboot_arg = 2;
+
+				} else {
+					reboot_arg = 1;
+				}
+			}
+
+			boardctl(BOARDIOC_RESET, reboot_arg);
 #else
 			PX4_PANIC("board reset not available");
 #endif
@@ -206,7 +219,7 @@ static void shutdown_worker(void *arg)
 }
 
 #if defined(CONFIG_BOARDCTL_RESET)
-int px4_reboot_request(bool to_bootloader, uint32_t delay_us)
+int px4_reboot_request(bool to_bootloader, uint32_t delay_us, bool continue_boot)
 {
 	pthread_mutex_lock(&shutdown_mutex);
 
@@ -224,6 +237,10 @@ int px4_reboot_request(bool to_bootloader, uint32_t delay_us)
 
 	if (to_bootloader) {
 		shutdown_args |= SHUTDOWN_ARG_TO_BOOTLOADER;
+
+		if (continue_boot) {
+			shutdown_args |= SHUTDOWN_ARG_BL_CONTINUE_BOOT;
+		}
 	}
 
 	shutdown_time_us = hrt_absolute_time();

--- a/platforms/nuttx/src/px4/microchip/mpfs/board_reset/board_reset.cpp
+++ b/platforms/nuttx/src/px4/microchip/mpfs/board_reset/board_reset.cpp
@@ -40,6 +40,7 @@
 #include <px4_platform_common/px4_config.h>
 #include <errno.h>
 #include <nuttx/board.h>
+#include <hardware/mpfs_wdog.h>
 
 #include "riscv_internal.h"
 
@@ -50,6 +51,17 @@ static void board_reset_enter_bootloader()
 	/* Reset the whole SoC */
 
 	up_systemreset();
+}
+
+static void board_reset_enter_bootloader_and_continue_boot()
+{
+	/* Reset by triggering WDOG */
+
+	putreg32(WDOG_FORCE_IMMEDIATE_RESET, MPFS_WDOG0_LO_BASE + MPFS_WDOG_FORCE_OFFSET);
+
+	/* Wait for the reset */
+
+	for (; ;);
 }
 
 static void board_reset_enter_app(uintptr_t hartid)
@@ -71,6 +83,9 @@ int board_reset(int status)
 
 	if (status == 1) {
 		board_reset_enter_bootloader();
+
+	} else if (status == 2) {
+		board_reset_enter_bootloader_and_continue_boot();
 	}
 
 	/* Just reboot via reset vector */

--- a/src/systemcmds/reboot/reboot.cpp
+++ b/src/systemcmds/reboot/reboot.cpp
@@ -51,6 +51,7 @@ static void print_usage()
 
 	PRINT_MODULE_USAGE_NAME_SIMPLE("reboot", "command");
 	PRINT_MODULE_USAGE_PARAM_FLAG('b', "Reboot into bootloader", true);
+	PRINT_MODULE_USAGE_PARAM_FLAG('c', "Bootloader continue boot", true);
 
 	PRINT_MODULE_USAGE_ARG("lock|unlock", "Take/release the shutdown lock (for testing)", true);
 }
@@ -59,14 +60,19 @@ extern "C" __EXPORT int reboot_main(int argc, char *argv[])
 {
 	int ch;
 	bool to_bootloader = false;
+	bool bl_continue_boot = false;
 
 	int myoptind = 1;
 	const char *myoptarg = nullptr;
 
-	while ((ch = px4_getopt(argc, argv, "b", &myoptind, &myoptarg)) != -1) {
+	while ((ch = px4_getopt(argc, argv, "bc", &myoptind, &myoptarg)) != -1) {
 		switch (ch) {
 		case 'b':
 			to_bootloader = true;
+			break;
+
+		case 'c':
+			bl_continue_boot = true;
 			break;
 
 		default:
@@ -98,7 +104,7 @@ extern "C" __EXPORT int reboot_main(int argc, char *argv[])
 		return ret;
 	}
 
-	int ret = px4_reboot_request(to_bootloader);
+	int ret = px4_reboot_request(to_bootloader, 0, bl_continue_boot);
 
 	if (ret < 0) {
 		PX4_ERR("reboot failed (%i)", ret);


### PR DESCRIPTION
Support for calling reboot with "continue boot" flag to let bootloader to start PX4 instead of keep looping and waiting for reflashing. This feature makes possible in LMC case to update PX4 firmware into mounted root partition and call "reboot-and-continue-boot" to take the new PX4 image into use.

Reset in "continue boot" case is performed by watchdog reset, so bootloader does not stay looping for reflash.
The reboot systemcmd also updated to have "-c" flag in addition to "-b" to reboot to bootloader and continue boot back to PX4.
