### PR TITLE
Add support to define PX4 signing key via env. variable

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -85,3 +85,6 @@
 [submodule "platforms/nuttx/src/px4/common/process"]
 	path = platforms/nuttx/src/px4/common/process
 	url = git@github.com:tiiuae/px4-kernel.git
+[submodule "Tools/saluki-sec-scripts"]
+	path = Tools/saluki-sec-scripts
+	url = git@github.com:tiiuae/saluki-sec-scripts.git

--- a/clone_public.sh
+++ b/clone_public.sh
@@ -5,6 +5,7 @@ set -euo pipefail
 while read -r repo
 do
   [[ "${repo}" == *saluki-?? ]] || \
+  [[ "${repo}" == *saluki-sec-scripts ]] || \
   [[ "${repo}" == *pfsoc_crypto ]]  || \
   [[ "${repo}" == *pfsoc_keystore ]]  || \
   [[ "${repo}" == *pf_crypto ]] || \

--- a/packaging/build_px4fw.sh
+++ b/packaging/build_px4fw.sh
@@ -20,8 +20,11 @@ else
         # use the PX4 default signing script and keys
         if [[ $NAME = saluki* ]]
         then
-            export SIGNING_TOOL=boards/ssrc/saluki-v1/tools/ed25519_sign.py
-            export SIGNING_ARGS=boards/ssrc/$NAME/tools/ed25519_test_key.pem
+            export SIGNING_TOOL=Tools/saluki-sec-scripts/ed25519_sign.py
+
+            if [ -z "$SIGNING_ARGS" ]; then
+                export SIGNING_ARGS=Tools/saluki-sec-scripts/test_keys/$NAME/ed25519_test_key.pem
+            fi
         else
             export SIGNING_TOOL=Tools/cryptotools.py
             unset SIGNING_ARGS
@@ -31,5 +34,9 @@ else
         rm -Rf build/${arg}
         # Build
         make ${arg}
+
+        if [ -n "$SIGNING_ARGS" ]; then
+            echo "Signing key: $SIGNING_ARGS"
+        fi
     done
 fi


### PR DESCRIPTION
This is a cherry-pick from 1.13.3 branch to 1.14

====================

If SIGNING_ARGS environment variable is defined, build script uses its value as a signing key location.

Also a new submodule saluki-sec-scripts is added. If SIGNING_ARGS is not defined test keys are used under Tools/saluki-sec-scripts/test_keys/

saluki-sec-scripts contains also signing tools and second set of keys (custom_keys), which are used in FPGA secure boot builds.

