### PR TITLE
Dependabot updates

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -43,7 +43,7 @@ jobs:
       run: make ${{matrix.check}}
     - name: upload coverage
       if: contains(matrix.check, 'coverage')
-      uses: codecov/codecov-action@v1
+      uses: codecov/codecov-action@v3
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
         flags: unittests

--- a/.github/workflows/compile_linux.yml
+++ b/.github/workflows/compile_linux.yml
@@ -32,7 +32,7 @@ jobs:
         string(TIMESTAMP current_date "%Y-%m-%d-%H;%M;%S" UTC)
         message("::set-output name=timestamp::${current_date}")
     - name: ccache cache files
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: ~/.ccache
         key: ${{matrix.config}}-ccache-${{steps.ccache_cache_timestamp.outputs.timestamp}}

--- a/.github/workflows/compile_linux_arm64.yml
+++ b/.github/workflows/compile_linux_arm64.yml
@@ -29,7 +29,7 @@ jobs:
         string(TIMESTAMP current_date "%Y-%m-%d-%H;%M;%S" UTC)
         message("::set-output name=timestamp::${current_date}")
     - name: ccache cache files
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: ~/.ccache
         key: ${{matrix.config}}-ccache-${{steps.ccache_cache_timestamp.outputs.timestamp}}

--- a/.github/workflows/compile_macos.yml
+++ b/.github/workflows/compile_macos.yml
@@ -33,7 +33,7 @@ jobs:
         string(TIMESTAMP current_date "%Y-%m-%d-%H;%M;%S" UTC)
         message("::set-output name=timestamp::${current_date}")
     - name: ccache cache files
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: ~/.ccache
         key: macos_${{matrix.config}}-ccache-${{steps.ccache_cache_timestamp.outputs.timestamp}}

--- a/.github/workflows/compile_nuttx.yml
+++ b/.github/workflows/compile_nuttx.yml
@@ -84,7 +84,7 @@ jobs:
         string(TIMESTAMP current_date "%Y-%m-%d-%H;%M;%S" UTC)
         message("::set-output name=timestamp::${current_date}")
     - name: ccache cache files
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: ~/.ccache
         key: ${{matrix.config}}-ccache-${{steps.ccache_cache_timestamp.outputs.timestamp}}
@@ -121,7 +121,7 @@ jobs:
       run: ccache -s
 
     - name: Upload px4 package
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3.1.3
       with:
         name: px4_package_${{matrix.config}}
         path: |

--- a/.github/workflows/ekf_update_change_indicator.yml
+++ b/.github/workflows/ekf_update_change_indicator.yml
@@ -19,7 +19,7 @@ jobs:
       run: echo "CHANGE_INDICATED=$(git diff --exit-code --output=/dev/null || echo $?)" >> $GITHUB_ENV
       working-directory: src/modules/ekf2/test/change_indication
     - name: auto-commit any changes to change indication
-      uses: stefanzweifel/git-auto-commit-action@v4
+      uses: stefanzweifel/git-auto-commit-action@v5
       with:
         commit_message: '[AUTO COMMIT] update change indication'
         commit_user_name: ${GIT_COMMITTER_NAME}

--- a/.github/workflows/mavros_mission_tests.yml
+++ b/.github/workflows/mavros_mission_tests.yml
@@ -39,7 +39,7 @@ jobs:
         string(TIMESTAMP current_date "%Y-%m-%d-%H;%M;%S" UTC)
         message("::set-output name=timestamp::${current_date}")
     - name: ccache cache files
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: ~/.ccache
         key: sitl_tests-${{matrix.config.build_type}}-ccache-${{steps.ccache_cache_timestamp.outputs.timestamp}}
@@ -86,7 +86,7 @@ jobs:
       run: gdb build/px4_sitl_default/bin/px4 px4.core -ex "thread apply all bt" -ex "quit"
     - name: Upload px4 coredump
       if: failure()
-      uses: actions/upload-artifact@v2-preview
+      uses: actions/upload-artifact@v3.1.3
       with:
         name: coredump
         path: px4.core
@@ -101,21 +101,21 @@ jobs:
 
     - name: Upload px4 binary
       if: failure()
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3.1.3
       with:
         name: binary
         path: build/px4_sitl_default/bin/px4
 
     - name: Store PX4 log
       if: failure()
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3.1.3
       with:
         name: px4_log
         path: ~/.ros/log/*/*.ulg
 
     - name: Store ROS log
       if: failure()
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3.1.3
       with:
         name: ros_log
         path: ~/.ros/**/rostest-*.log
@@ -132,7 +132,7 @@ jobs:
           lcov --directory build/px4_sitl_default --base-directory build/px4_sitl_default --gcov-tool gcov --capture -o coverage/lcov.info
     - name: Upload coverage information to Codecov
       if: contains(matrix.config.build_type, 'Coverage')
-      uses: codecov/codecov-action@v1
+      uses: codecov/codecov-action@v3
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
         flags: mavros_mission

--- a/.github/workflows/mavros_offboard_tests.yml
+++ b/.github/workflows/mavros_offboard_tests.yml
@@ -34,7 +34,7 @@ jobs:
         string(TIMESTAMP current_date "%Y-%m-%d-%H;%M;%S" UTC)
         message("::set-output name=timestamp::${current_date}")
     - name: ccache cache files
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: ~/.ccache
         key: sitl_tests-${{matrix.config.build_type}}-ccache-${{steps.ccache_cache_timestamp.outputs.timestamp}}
@@ -81,7 +81,7 @@ jobs:
       run: gdb build/px4_sitl_default/bin/px4 px4.core -ex "thread apply all bt" -ex "quit"
     - name: Upload px4 coredump
       if: failure()
-      uses: actions/upload-artifact@v2-preview
+      uses: actions/upload-artifact@v3.1.3
       with:
         name: coredump
         path: px4.core
@@ -96,21 +96,21 @@ jobs:
 
     - name: Upload px4 binary
       if: failure()
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3.1.3
       with:
         name: binary
         path: build/px4_sitl_default/bin/px4
 
     - name: Store PX4 log
       if: failure()
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3.1.3
       with:
         name: px4_log
         path: ~/.ros/log/*/*.ulg
 
     - name: Store ROS log
       if: failure()
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3.1.3
       with:
         name: ros_log
         path: ~/.ros/**/rostest-*.log
@@ -127,7 +127,7 @@ jobs:
           lcov --directory build/px4_sitl_default --base-directory build/px4_sitl_default --gcov-tool gcov --capture -o coverage/lcov.info
     - name: Upload coverage information to Codecov
       if: contains(matrix.config.build_type, 'Coverage')
-      uses: codecov/codecov-action@v1
+      uses: codecov/codecov-action@v3
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
         flags: mavros_offboard

--- a/.github/workflows/sitl_tests.yml
+++ b/.github/workflows/sitl_tests.yml
@@ -40,7 +40,7 @@ jobs:
         string(TIMESTAMP current_date "%Y-%m-%d-%H;%M;%S" UTC)
         message("::set-output name=timestamp::${current_date}")
     - name: ccache cache files
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: ~/.ccache
         key: sitl_tests-${{matrix.config.build_type}}-ccache-${{steps.ccache_cache_timestamp.outputs.timestamp}}
@@ -104,14 +104,14 @@ jobs:
       run: gdb build/px4_sitl_default/bin/px4 px4.core -ex "thread apply all bt" -ex "quit"
     - name: Upload px4 coredump
       if: failure()
-      uses: actions/upload-artifact@v2-preview
+      uses: actions/upload-artifact@v3.1.3
       with:
         name: coredump
         path: px4.core
 
     - name: Upload px4 binary
       if: failure()
-      uses: actions/upload-artifact@v2-preview
+      uses: actions/upload-artifact@v3.1.3
       with:
         name: binary
         path: build/px4_sitl_default/bin/px4
@@ -128,7 +128,7 @@ jobs:
           lcov --directory build/px4_sitl_default --base-directory build/px4_sitl_default --gcov-tool gcov --capture -o coverage/lcov.info
     - name: Upload coverage information to Codecov
       if: contains(matrix.config.build_type, 'Coverage')
-      uses: codecov/codecov-action@v1
+      uses: codecov/codecov-action@v3
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
         flags: mavsdk

--- a/.github/workflows/tiiuae-coverity-scan.yaml
+++ b/.github/workflows/tiiuae-coverity-scan.yaml
@@ -30,7 +30,7 @@ jobs:
         run:
           cat cov-analyze-result.txt >> $GITHUB_STEP_SUMMARY
       - name: Upload coverity scan results
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v3.1.3
         with:
           name: coverity-html-report-${{ github.event.repository.name }}
           path: coverity-output

--- a/.github/workflows/tiiuae-pixhawk-and-saluki-builder.yaml
+++ b/.github/workflows/tiiuae-pixhawk-and-saluki-builder.yaml
@@ -34,7 +34,7 @@ jobs:
           ./build.sh ../bin/ ${{ inputs.product }}
           ls ../bin
       - name: Upload ${{ inputs.product }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v3.1.3
         with:
           name: pixhawk
           path: bin/

--- a/.github/workflows/tiiuae-pixhawk-and-saluki.yaml
+++ b/.github/workflows/tiiuae-pixhawk-and-saluki.yaml
@@ -63,7 +63,7 @@ jobs:
           ./build.sh ../bin/ px4fwupdater
           ls ../bin
       - name: Upload px4fwupdater to tmp storage
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v3.1.3
         with:
           name: pixhawk
           path: bin/

--- a/.github/workflows/tiiuae-sitl.yaml
+++ b/.github/workflows/tiiuae-sitl.yaml
@@ -25,10 +25,10 @@ jobs:
           path: px4-firmware
           fetch-depth: 0
 
-      - uses: docker/setup-buildx-action@v2
+      - uses: docker/setup-buildx-action@v3
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
         with:
           driver-opts: network=host
 

--- a/src/modules/ekf2/EKF/python/tuning_tools/baro_static_pressure_compensation/requirements.txt
+++ b/src/modules/ekf2/EKF/python/tuning_tools/baro_static_pressure_compensation/requirements.txt
@@ -2,4 +2,4 @@ matplotlib==3.5.1
 numpy==1.22.2
 pyulog==0.9.0
 quaternion==3.5.2.post4
-scipy==1.8.0
+scipy==1.10.0

--- a/src/modules/ekf2/EKF/python/tuning_tools/mc_wind_estimator/requirements.txt
+++ b/src/modules/ekf2/EKF/python/tuning_tools/mc_wind_estimator/requirements.txt
@@ -2,5 +2,5 @@ matplotlib==3.5.1
 numpy==1.22.2
 pyulog==0.9.0
 quaternion==3.5.2.post4
-scipy==1.8.0
+scipy==1.10.0
 sympy==1.10.1


### PR DESCRIPTION
Combination of multiple dependabot updates:

build(deps): bump scipy
Bumps [scipy](https://github.com/scipy/scipy) from 1.8.0 to 1.10.0.
- [Release notes](https://github.com/scipy/scipy/releases)

build(deps): bump actions/upload-artifact from 2.pre.preview to 3.1.3 Bumps [actions/upload-artifact](https://github.com/actions/upload-artifact) from 2.pre.preview to 3.1.3.
- [Release notes](https://github.com/actions/upload-artifact/releases)

build(deps): bump docker/setup-buildx-action from 2 to 3 Bumps [docker/setup-buildx-action](https://github.com/docker/setup-buildx-action) from 2 to 3.
- [Release notes](https://github.com/docker/setup-buildx-action/releases)

build(deps): bump stefanzweifel/git-auto-commit-action from 4 to 5 Bumps [stefanzweifel/git-auto-commit-action](https://github.com/stefanzweifel/git-auto-commit-action) from 4 to 5.
- [Release notes](https://github.com/stefanzweifel/git-auto-commit-action/releases)

build(deps): bump codecov/codecov-action from 1 to 3 Bumps [codecov/codecov-action](https://github.com/codecov/codecov-action) from 1 to 3.
- [Release notes](https://github.com/codecov/codecov-action/releases)

build(deps): bump actions/cache from 2 to 3
Bumps [actions/cache](https://github.com/actions/cache) from 2 to 3.
- [Release notes](https://github.com/actions/cache/releases)
