### PR TITLE
Add version messages

### DIFF
--- a/msg/CMakeLists.txt
+++ b/msg/CMakeLists.txt
@@ -177,6 +177,8 @@ set(msg_files
 	SensorsStatusImu.msg
 	SensorUwb.msg
 	SystemPower.msg
+	SystemVersion.msg
+	SystemVersionString.msg
 	TakeoffStatus.msg
 	TaskStackInfo.msg
 	TecsStatus.msg

--- a/msg/SystemVersion.msg
+++ b/msg/SystemVersion.msg
@@ -1,0 +1,9 @@
+# System version information in hash (binary) format
+
+uint64 timestamp		# time since system start (microseconds)
+uint64 hw_version		# main autopilot hw version
+uint64 sw_version		# main autopilot sw version
+uint64 os_version		# OS or middleware version
+uint64 bl_version		# bootloader version
+uint64 component_version1	# vendor specific component version
+uint64 component_version2	# vendor specific component version

--- a/msg/SystemVersionString.msg
+++ b/msg/SystemVersionString.msg
@@ -1,0 +1,9 @@
+# System version information in user readable string format
+
+uint64 timestamp		# time since system start (microseconds)
+char[32] hw_version		# main autopilot hw version
+char[32] sw_version		# main autopilot sw version
+char[32] os_version		# OS or middleware version
+char[32] bl_version		# bootloader version
+char[32] component_version1	# vendor specific component version
+char[32] component_version2	# vendor specific component version

--- a/platforms/nuttx/src/px4/microchip/microchip_common/include/px4_arch/device_info.h
+++ b/platforms/nuttx/src/px4/microchip/microchip_common/include/px4_arch/device_info.h
@@ -59,7 +59,11 @@ typedef struct __attribute__((__packed__))
 
 	char bl_version[32];
 
+	/* FPGA version info */
+
+	uint32_t fpga_version;
+
 	/* Reserved for future use */
 
-	uint8_t reserved[428];
+	uint8_t reserved[424];
 } devinfo_t;


### PR DESCRIPTION
This adds version information into uORB topics, allowing easy version information pulishing to ROS (uXRCE) and access from applications in memory protected build modes of PX4
