### PR TITLE
uORB/uORBManager.hpp: Fix pre-processor condition

### DIFF
--- a/platforms/common/uORB/uORBManager.hpp
+++ b/platforms/common/uORB/uORBManager.hpp
@@ -659,7 +659,7 @@ private: //class methods
 			{
 				px4_sem_init(&_sem, 1, 0);
 				px4_sem_init(&_lock, 1, 1);
-#if __PX4_NUTTX
+#if defined(__PX4_NUTTX)
 				sem_setprotocol(&_sem, SEM_PRIO_NONE);
 				sem_setprotocol(&_lock, SEM_PRIO_NONE);
 #endif


### PR DESCRIPTION
This fixes the uORB signaling semaphores, they should not use priority inheritance

#if __PX4_NUTTX does nothing, change it to #if defined()
