### PR TITLE
src/drivers/sw_crypto: Fix buffer lengths for xchacha20 crypto

### DIFF
--- a/src/drivers/sw_crypto/crypto.c
+++ b/src/drivers/sw_crypto/crypto.c
@@ -286,8 +286,9 @@ bool crypto_encrypt_data(crypto_session_handle_t handle,
 			uint8_t *key = (uint8_t *)crypto_get_key_ptr(handle.keystore_handle, key_idx, &key_sz);
 			chacha20_context_t *context = handle.context;
 
-			if (key_sz == 32) {
-				context->ctr = crypto_xchacha20_ctr(cipher, message, *cipher_size, key, context->nonce, context->ctr);
+			if (key_sz == 32 && *cipher_size >= message_size) {
+				context->ctr = crypto_xchacha20_ctr(cipher, message, message_size, key, context->nonce, context->ctr);
+				*cipher_size = message_size;
 				ret = true;
 			}
 		}


### PR DESCRIPTION
This is a cherry-pick from upstream

-----------------
The size input argument for monocypher crypto_xchacha20_ctr should be the plaintext message length.

The promise of the interface is, that the call to encrypt_data updates the ciphertext message length after the call succeeds.

The crypto should check that the output buffer length (cipher length) is large enough to contain the encrypted data.

Fix these issues; these have gone unnoticed for a long time since the interface has been only used by logger, and passing the same size for both in and out.

