### PR TITLE
Uorb optimization3

### DIFF
--- a/platforms/common/uORB/IndexedStack.hpp
+++ b/platforms/common/uORB/IndexedStack.hpp
@@ -67,7 +67,7 @@ private:
 
 		if (!handle_valid(handle) ||
 		    !handle_valid(p)) {
-			return r;
+			return false;
 		}
 
 		if (p == handle) {

--- a/platforms/common/uORB/uORBManager.cpp
+++ b/platforms/common/uORB/uORBManager.cpp
@@ -43,6 +43,7 @@
 #include <px4_platform_common/px4_config.h>
 #include <px4_platform_common/posix.h>
 #include <px4_platform_common/tasks.h>
+#include <px4_platform_common/px4_work_queue/WorkQueueManager.hpp>
 
 #include "uORBDeviceNode.hpp"
 #include "uORBUtils.hpp"
@@ -474,10 +475,14 @@ uORB::Manager::launchCallbackThread()
 		return -1;
 	}
 
+	/* Set the priority to 1 higher than the highest controller, which is always nav_and_controllers */
+
+	int priority = sched_get_priority_max(SCHED_FIFO) + px4::wq_configurations::nav_and_controllers.relative_priority + 1;
+
 	if (per_process_cb_thread == -1) {
 		per_process_cb_thread = px4_task_spawn_cmd("orb_callback",
 					SCHED_DEFAULT,
-					SCHED_PRIORITY_MAX - 1,
+					priority,
 					PX4_STACK_ADJUSTED(1024),
 					callback_thread,
 					nullptr);


### PR DESCRIPTION
This changes the way how uORB callbacks are executed;

- The callback subscriptions are collected in a list withing each process
- The priority of the processes' callback thread is set to the maximum thread priority within the process
- All the triggred callbacks are executed in a loop when the callback thread gets to run

Signalling the callback

- The publisher marks the callback as "triggered" and signals the callback thread. There is no synchronization back from the callback thread potentially allowing the publisher to fire all the registered callbacks/polls at once withouth scheduling away at each signalling semaphore post.
