### PR TITLE
Fix gazebo classic simulation

### DIFF
--- a/ROMFS/px4fmu_common/init.d-posix/airframes/4400_ssrc_fog_x
+++ b/ROMFS/px4fmu_common/init.d-posix/airframes/4400_ssrc_fog_x
@@ -13,32 +13,45 @@
 
 . ${R}etc/init.d/rc.mc_defaults
 
-set MIXER quad_x
-set PWM_OUT 1234
+param set IMU_GYRO_CUTOFF 60
+param set IMU_DGYRO_CUTOFF 30
+param set MC_ROLLRATE_P 0.14
+param set MC_PITCHRATE_P 0.14
+param set MC_ROLLRATE_I 0.3
+param set MC_PITCHRATE_I 0.3
+param set MC_ROLLRATE_D 0.004
+param set MC_PITCHRATE_D 0.004
 
-if [ $AUTOCNF = yes ]
-then
-	param set IMU_GYRO_CUTOFF 60
-	param set IMU_DGYRO_CUTOFF 30
-	param set MC_ROLLRATE_P 0.14
-	param set MC_PITCHRATE_P 0.14
-	param set MC_ROLLRATE_I 0.3
-	param set MC_PITCHRATE_I 0.3
-	param set MC_ROLLRATE_D 0.004
-	param set MC_PITCHRATE_D 0.004
+param set BAT_N_CELLS 4
 
-	param set BAT_N_CELLS 4
+# Control allocator parameters
+param set-default CA_ROTOR_COUNT 4
+param set-default CA_ROTOR0_PX 0.175
+param set-default CA_ROTOR0_PY 0.175
+param set-default CA_ROTOR1_PX -0.175
+param set-default CA_ROTOR1_PY -0.175
+param set-default CA_ROTOR2_PX 0.175
+param set-default CA_ROTOR2_PY -0.175
+param set-default CA_ROTOR2_KM -0.05
+param set-default CA_ROTOR3_PX -0.175
+param set-default CA_ROTOR3_PY 0.175
+param set-default CA_ROTOR3_KM -0.05
 
-	param set MAV_0_CONFIG 0
-	param set RTPS_MAV_CONFIG 101
-	param set SER_TEL1_BAUD 460800
 
-	# Disable Multi-EKF
-	param set EKF2_MULTI_IMU 0
-	param set SENS_IMU_MODE 1
-	param set EKF2_MULTI_MAG 0
-	param set SENS_MAG_MODE 1
+param set-default PWM_MAIN_FUNC1 101
+param set-default PWM_MAIN_FUNC2 102
+param set-default PWM_MAIN_FUNC3 103
+param set-default PWM_MAIN_FUNC4 104
 
-	# Logger used only while flying
-	param set SDLOG_MODE 0
-fi
+param set MAV_0_CONFIG 0
+param set RTPS_MAV_CONFIG 101
+param set SER_TEL1_BAUD 3000000
+
+# Disable Multi-EKF
+param set EKF2_MULTI_IMU 0
+param set SENS_IMU_MODE 1
+param set EKF2_MULTI_MAG 0
+param set SENS_MAG_MODE 1
+
+# Logger used only while flying
+param set SDLOG_MODE 0

--- a/ROMFS/px4fmu_common/init.d-posix/px4-rc.simulator
+++ b/ROMFS/px4fmu_common/init.d-posix/px4-rc.simulator
@@ -36,7 +36,7 @@ if [ "$PX4_SIMULATOR" = "sihsim" ] || [ "$(param show -q SYS_AUTOSTART)" -eq "0"
 		exit 1
 	fi
 
-elif [ "$PX4_SIMULATOR" = "gz" ] || [ "$(param show -q SIM_GZ_EN)" -eq "1" ]; then
+elif [ "$PX4_SIMULATOR" = "gz" ] || [ "$(param show -q SIM_GZ_EN)" = "1" ]; then
 
 	# allow starting of gz sim optionally
 	if [ "$(param show -q SIM_GZ_RUN_GZSIM)" -eq "1" ];

--- a/ROMFS/px4fmu_common/init.d-posix/rcS
+++ b/ROMFS/px4fmu_common/init.d-posix/rcS
@@ -29,7 +29,7 @@ fi
 set VEHICLE_TYPE                none
 set LOGGER_ARGS                 ""
 set LOGGER_BUF                  1000
-
+set SDCARD_AVAILABLE            no
 set RUN_MINIMAL_SHELL           no
 
 set SYS_AUTOSTART=0


### PR DESCRIPTION
## Changelog:
- Upstream commit to fix parse error on start with gazebo simulation.
  -  Fixes `etc/init.d-posix/rcS: 39: [: Illegal number:`
- Add `set SDCARD_AVAILABLE no` to prevent parse error.
  - Fixes `/px4_sitl_etc/init.d-posix/rcS.sim_udp: 26: [: =: unexpected operator`
- Fix ssrc_fog_x airframe for gazebo classic simulation. Original commit before rebase: https://github.com/tiiuae/px4-firmware/commit/fe293c4fcfb53cb40bed926d1b8e8fb2d64f8811

Not sure if this breaks anything with the gz-sim simulations. Needs to be verified.