### PR TITLE
SITL: select UDP/TCP-server/TCP-client according to ENV variables

### DIFF
--- a/ROMFS/px4fmu_common/init.d-posix/CMakeLists.txt
+++ b/ROMFS/px4fmu_common/init.d-posix/CMakeLists.txt
@@ -38,5 +38,7 @@ px4_add_romfs_files(
 	px4-rc.params
 	px4-rc.simulator
 	rc.replay
+	rcS.sim_tcp_server
+	rcS.sim_udp
 	rcS
 )

--- a/ROMFS/px4fmu_common/init.d-posix/px4-rc.simulator
+++ b/ROMFS/px4fmu_common/init.d-posix/px4-rc.simulator
@@ -234,6 +234,7 @@ elif [ "$PX4_SIM_MODEL" = "jmavsim_iris" ] || [ "$(param show -q SYS_AUTOSTART)"
 else
 	# otherwise start simulator (mavlink) module
 	simulator_tcp_port=$((4560+px4_instance))
+	simulator_udp_port=$((14560+px4_instance))
 
 	# Check if PX4_SIM_HOSTNAME environment variable is empty
 	# If empty check if PX4_SIM_HOST_ADDR environment variable is empty
@@ -241,8 +242,16 @@ else
 	if [ -z "${PX4_SIM_HOSTNAME}" ]; then
 
 		if [ -z "${PX4_SIM_HOST_ADDR}" ]; then
-			echo "INFO  [init] PX4_SIM_HOSTNAME: localhost"
-			simulator_mavlink start -c $simulator_tcp_port
+			if [ ! -z "${PX4_SIM_USE_TCP_SERVER}" ]; then
+				echo "INFO  [init] PX4_SIM_USE_TCP_SERVER"
+				simulator_mavlink start -s $simulator_tcp_port
+			elif [ ! -z "${PX4_SIM_USE_UDP}" ]; then
+				echo "INFO  [init] PX4_SIM_USE_UDP"
+				simulator_mavlink start -u $simulator_udp_port
+			else
+				echo "INFO  [init] PX4_SIM_HOSTNAME: localhost"
+				simulator_mavlink start -c $simulator_tcp_port
+			fi
 		else
 			echo "INFO  [init] PX4_SIM_HOSTNAME: ${PX4_SIM_HOST_ADDR}"
 			simulator_mavlink start -t "${PX4_SIM_HOST_ADDR}" "${simulator_tcp_port}"

--- a/ROMFS/px4fmu_common/init.d-posix/rcS.sim_tcp_server
+++ b/ROMFS/px4fmu_common/init.d-posix/rcS.sim_tcp_server
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+# search path for sourcing rcS
+PATH="$PATH:${R}etc/init.d-posix"
+
+# Define TCP server
+export PX4_SIM_USE_TCP_SERVER=1
+
+# Continue to the main startup script
+. rcS

--- a/ROMFS/px4fmu_common/init.d-posix/rcS.sim_udp
+++ b/ROMFS/px4fmu_common/init.d-posix/rcS.sim_udp
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+# search path for sourcing rcS
+PATH="$PATH:${R}etc/init.d-posix"
+
+# Define UDP
+export PX4_SIM_USE_UDP=1
+
+# Continue to the main startup script
+. rcS

--- a/packaging/entrypoint.sh
+++ b/packaging/entrypoint.sh
@@ -4,6 +4,8 @@ source /opt/ros/humble/setup.bash
 
 if [ "$1" == "sim_tcp_server" ] || [ "$PX4_SIM_USE_TCP_SERVER" != "" ]; then
     px4 -d "/px4_sitl_etc" -w sitl_${PX4_SIM_MODEL} -s /px4_sitl_etc/init.d-posix/rcS.sim_tcp_server
+elif [ "$1" == "sim_udp" ] || [ "$PX4_SIM_USE_UDP" != "" ]; then
+    px4 -d "/px4_sitl_etc" -w sitl_${PX4_SIM_MODEL} -s /px4_sitl_etc/init.d-posix/rcS.sim_udp
 else
     px4 -d "/px4_sitl_etc" -w sitl_${PX4_SIM_MODEL} -s /px4_sitl_etc/init.d-posix/rcS
 fi


### PR DESCRIPTION
Fix SITL gazebo connection type selection
In docker run command use --env to select connection type:

- `--env=PX4_SIM_USE_TCP_SERVER=1`     => PX4-sitl acts as TCP server 
- `--env=PX4_SIM_USE_UDP=1`     => PX4-sitl uses UDP
- default => PX4-sitl acts as TCP client (this is how upstream IRIS model works)