### PR TITLE
mavlink_ulog: always update ulog_stream_acked uorb 

### DIFF
--- a/src/modules/mavlink/mavlink_ulog.cpp
+++ b/src/modules/mavlink/mavlink_ulog.cpp
@@ -180,31 +180,33 @@ int MavlinkULog::handle_update(mavlink_channel_t channel)
 			++_current_num_msgs;
 		}
 
-		if (check_for_updates && _ulog_stream_acked_sub.updated()) {
+		if (_ulog_stream_acked_sub.updated()) {
 			_ulog_stream_acked_sub.update();
 
-			const ulog_stream_s &ulog_data = _ulog_stream_acked_sub.get();
+			if (check_for_updates) {
+				const ulog_stream_s &ulog_data = _ulog_stream_acked_sub.get();
 
-			if (ulog_data.timestamp > 0) {
-				_sent_tries = 1;
-				_last_sent_time = hrt_absolute_time();
-				lock();
-				_wait_for_ack_sequence = ulog_data.msg_sequence;
-				_ack_received = false;
-				unlock();
+				if (ulog_data.timestamp > 0) {
+					_sent_tries = 1;
+					_last_sent_time = hrt_absolute_time();
+					lock();
+					_wait_for_ack_sequence = ulog_data.msg_sequence;
+					_ack_received = false;
+					unlock();
 
-				mavlink_logging_data_acked_t msg;
-				msg.sequence = ulog_data.msg_sequence;
-				msg.length = ulog_data.length;
-				msg.first_message_offset = ulog_data.first_message_offset;
-				msg.target_system = _target_system;
-				msg.target_component = _target_component;
-				memcpy(msg.data, ulog_data.data, sizeof(msg.data));
-				mavlink_msg_logging_data_acked_send_struct(channel, &msg);
+					mavlink_logging_data_acked_t msg;
+					msg.sequence = ulog_data.msg_sequence;
+					msg.length = ulog_data.length;
+					msg.first_message_offset = ulog_data.first_message_offset;
+					msg.target_system = _target_system;
+					msg.target_component = _target_component;
+					memcpy(msg.data, ulog_data.data, sizeof(msg.data));
+					mavlink_msg_logging_data_acked_send_struct(channel, &msg);
 
+				}
+
+				++_current_num_msgs;
 			}
-
-			++_current_num_msgs;
 		}
 	}
 


### PR DESCRIPTION
ulog_stream_acked uorb shall be synced with update() call even check_for_updates not set.
If update not called, it may lead to infinite loop in case check_for_updates not set and there are new messages in ulog_stream_acked uorb.

