### PR TITLE
px4_init.cpp: Define __cxa_atexit() here

### DIFF
--- a/platforms/nuttx/src/px4/common/px4_init.cpp
+++ b/platforms/nuttx/src/px4/common/px4_init.cpp
@@ -98,6 +98,12 @@ static void cxx_initialize(void)
 		}
 	}
 }
+
+int __cxa_atexit(CODE void (*func)(FAR void *), FAR void *arg,
+		 FAR void *dso_handle)
+{
+	return -ENOTSUP;
+}
 #endif
 
 int px4_platform_init()


### PR DESCRIPTION
Like __dso_handle, this symbol must NOT be pulled from the user libc. The __cxa_atexitatexit() functions in kernel are no-ops as we don't support shared library destructors.

This fixes uavcan for kernel mode