### PR TITLE
uORBDeviceNode: Fix race with _unregister_callback

### DIFF
--- a/platforms/common/uORB/uORBDeviceNode.cpp
+++ b/platforms/common/uORB/uORBDeviceNode.cpp
@@ -917,6 +917,15 @@ uORB::DeviceNode::_unregister_callback(uorb_cb_handle_t &cb_handle)
 		PX4_ERR("unregister fail\n");
 
 	} else {
+#ifndef CONFIG_BUILD_FLAT
+		EventWaitItem *item = callbacks.peek(cb_handle);
+
+		while (item->cb_triggered > 0) {
+			item->cb_triggered--;
+			Manager::lockThread(item->lock);
+		}
+
+#endif
 		callbacks.push_free(cb_handle);
 		cb_handle = UORB_INVALID_CB_HANDLE;
 	}


### PR DESCRIPTION
In case the callback has bee posted by DeviceNode::Write, but not yet handled by the callback thread, we must cancel the posts after removing the cb from the list of callbacks.

