### PR TITLE
console_buffer: Implement console_buffer_usr

### DIFF
--- a/platforms/nuttx/src/px4/common/px4_userspace_init.cpp
+++ b/platforms/nuttx/src/px4/common/px4_userspace_init.cpp
@@ -38,6 +38,7 @@
  */
 
 #include <drivers/drv_hrt.h>
+#include <px4_platform_common/console_buffer.h>
 #include <px4_platform_common/px4_work_queue/WorkQueueManager.hpp>
 #include <px4_platform_common/spi.h>
 #include <px4_platform_common/log.h>
@@ -57,6 +58,8 @@ extern "C" void px4_userspace_init(void)
 #endif
 
 	px4_log_initialize();
+
+	px4_console_buffer_init();
 
 #if defined(CONFIG_SYSTEM_CDCACM) && defined(CONFIG_BUILD_PROTECTED)
 	cdcacm_init();


### PR DESCRIPTION
Implements user space version of buffered console. Uses the /dev/console device.

This fixes SD card flight logs in kernel mode.