### PR TITLE
Dependabot updates

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -31,7 +31,7 @@ jobs:
       image: px4io/px4-dev-nuttx-focal:2021-09-08
       options: --privileged --ulimit core=-1 --security-opt seccomp=unconfined
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v4
       with:
         token: ${{ secrets.ACCESS_TOKEN }}
 

--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     container: px4io/px4-dev-clang:2021-09-08
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v4
       with:
         token: ${{secrets.ACCESS_TOKEN}}
 

--- a/.github/workflows/compile_linux.yml
+++ b/.github/workflows/compile_linux.yml
@@ -21,7 +21,7 @@ jobs:
           scumaker_pilotpi_default,
           ]
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v4
       with:
         token: ${{secrets.ACCESS_TOKEN}}
 

--- a/.github/workflows/compile_linux_arm64.yml
+++ b/.github/workflows/compile_linux_arm64.yml
@@ -18,7 +18,7 @@ jobs:
           scumaker_pilotpi_arm64,
           ]
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v4
       with:
         token: ${{secrets.ACCESS_TOKEN}}
 

--- a/.github/workflows/compile_macos.yml
+++ b/.github/workflows/compile_macos.yml
@@ -19,7 +19,7 @@ jobs:
           #tests, # includes px4_sitl
           ]
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v4
       with:
         token: ${{secrets.ACCESS_TOKEN}}
 

--- a/.github/workflows/compile_nuttx.yml
+++ b/.github/workflows/compile_nuttx.yml
@@ -73,7 +73,7 @@ jobs:
           uvify_core
           ]
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v4
       with:
         token: ${{secrets.ACCESS_TOKEN}}
 

--- a/.github/workflows/deploy_all.yml
+++ b/.github/workflows/deploy_all.yml
@@ -14,7 +14,7 @@ jobs:
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v4
       with:
         token: ${{secrets.ACCESS_TOKEN}}
     - id: set-matrix
@@ -26,7 +26,7 @@ jobs:
       matrix: ${{fromJson(needs.enumerate_targets.outputs.matrix)}}
     container: px4io/px4-dev-${{ matrix.container }}:2021-09-08
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v4
       with:
         token: ${{secrets.ACCESS_TOKEN}}
 

--- a/.github/workflows/ekf_functional_change_indicator.yml
+++ b/.github/workflows/ekf_functional_change_indicator.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     container: px4io/px4-dev-base-focal:2021-09-08
     steps:
-    - uses: actions/checkout@v2.3.1
+    - uses: actions/checkout@v4
       with:
         fetch-depth: 0
     - name: checkout newest version of branch

--- a/.github/workflows/ekf_update_change_indicator.yml
+++ b/.github/workflows/ekf_update_change_indicator.yml
@@ -10,7 +10,7 @@ jobs:
       GIT_COMMITTER_EMAIL: bot@px4.io
       GIT_COMMITTER_NAME: PX4BuildBot
     steps:
-    - uses: actions/checkout@v2.3.1
+    - uses: actions/checkout@v4
       with:
         fetch-depth: 0
     - name: main test updates change indication files

--- a/.github/workflows/mavros_mission_tests.yml
+++ b/.github/workflows/mavros_mission_tests.yml
@@ -28,7 +28,7 @@ jobs:
       image: px4io/px4-dev-ros-melodic:2021-09-08
       options: --privileged --ulimit core=-1 --security-opt seccomp=unconfined
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v4
       with:
         token: ${{ secrets.ACCESS_TOKEN }}
 

--- a/.github/workflows/mavros_offboard_tests.yml
+++ b/.github/workflows/mavros_offboard_tests.yml
@@ -23,7 +23,7 @@ jobs:
       image: px4io/px4-dev-ros-melodic:2021-09-08
       options: --privileged --ulimit core=-1 --security-opt seccomp=unconfined
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v4
       with:
         token: ${{ secrets.ACCESS_TOKEN }}
 

--- a/.github/workflows/metadata.yml
+++ b/.github/workflows/metadata.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     container: px4io/px4-dev-base-focal:2021-09-08
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v4
       with:
         token: ${{ secrets.ACCESS_TOKEN }}
 
@@ -39,7 +39,7 @@ jobs:
     runs-on: ubuntu-latest
     container: px4io/px4-dev-base-focal:2021-09-08
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v4
       with:
         token: ${{ secrets.ACCESS_TOKEN }}
 
@@ -54,7 +54,7 @@ jobs:
     runs-on: ubuntu-latest
     container: px4io/px4-dev-base-focal:2021-09-08
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v4
       with:
         token: ${{ secrets.ACCESS_TOKEN }}
 
@@ -78,7 +78,7 @@ jobs:
     runs-on: ubuntu-latest
     container: px4io/px4-dev-base-focal:2021-09-08
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v4
       with:
         token: ${{ secrets.ACCESS_TOKEN }}
 
@@ -105,7 +105,7 @@ jobs:
     runs-on: ubuntu-latest
     container: px4io/px4-dev-nuttx-focal:2021-09-08
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v4
       with:
         token: ${{ secrets.ACCESS_TOKEN }}
 
@@ -120,7 +120,7 @@ jobs:
     runs-on: ubuntu-latest
     container: px4io/px4-dev-base-focal:2021-09-08
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v4
       with:
         token: ${{ secrets.ACCESS_TOKEN }}
 

--- a/.github/workflows/python_checks.yml
+++ b/.github/workflows/python_checks.yml
@@ -12,7 +12,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v4
       with:
         token: ${{ secrets.ACCESS_TOKEN }}
     - name: Install Python3

--- a/.github/workflows/sitl_tests.yml
+++ b/.github/workflows/sitl_tests.yml
@@ -24,7 +24,7 @@ jobs:
       image: px4io/px4-dev-simulation-focal:2021-09-08
       options: --privileged --ulimit core=-1 --security-opt seccomp=unconfined
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v4
       with:
         token: ${{ secrets.ACCESS_TOKEN }}
 

--- a/.github/workflows/tiiuae-check-format.yml
+++ b/.github/workflows/tiiuae-check-format.yml
@@ -10,7 +10,7 @@ jobs:
     name: Validate testfile
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Lint
       run:  |

--- a/.github/workflows/tiiuae-coverity-scan-image.yaml
+++ b/.github/workflows/tiiuae-coverity-scan-image.yaml
@@ -14,13 +14,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout px4-firmware
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           path: px4-firmware
           fetch-depth: 0
       - name: Docker meta
         id: meta
-        uses: docker/metadata-action@v4
+        uses: docker/metadata-action@v5
         with:
           images: ghcr.io/tiiuae/px4-coverity-scan-image
           tags: |
@@ -33,7 +33,7 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Build and push coverity scan image
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@v5
         with:
           context: .
           file: ./px4-firmware/packaging/Dockerfile.coverity

--- a/.github/workflows/tiiuae-coverity-scan.yaml
+++ b/.github/workflows/tiiuae-coverity-scan.yaml
@@ -9,7 +9,7 @@ jobs:
     runs-on: px4-self-hosted-coverity
     steps:
       - name: Checkout px4-firmware
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           token: ${{ secrets.GH_REPO_TOKEN }}
           submodules: 'recursive'

--- a/.github/workflows/tiiuae-pixhawk-and-saluki-builder.yaml
+++ b/.github/workflows/tiiuae-pixhawk-and-saluki-builder.yaml
@@ -20,7 +20,7 @@ jobs:
     if: ${{ inputs.enabled }}
     steps:
       - name: Checkout px4-firmware
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           token: ${{ secrets.GH_REPO_TOKEN }}
           # if we clone_public, then do not clone submodules, otherwise 'recursive'

--- a/.github/workflows/tiiuae-pixhawk-and-saluki.yaml
+++ b/.github/workflows/tiiuae-pixhawk-and-saluki.yaml
@@ -108,7 +108,7 @@ jobs:
       - fc_matrix
     steps:
       - name: Checkout px4-firmware
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           path: px4-firmware
           fetch-depth: 0
@@ -140,7 +140,7 @@ jobs:
       - variables
     steps:
       - name: Checkout px4-firmware
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           path: px4-firmware
           fetch-depth: 0
@@ -151,7 +151,7 @@ jobs:
           path: bin
       - name: Firmware flasher - Container metadata
         id: containermeta # referenced from later step
-        uses: docker/metadata-action@v4
+        uses: docker/metadata-action@v5
         with:
           images: ghcr.io/tiiuae/px4-firmware
           tags: |
@@ -166,7 +166,7 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Firmware flasher - Build and push
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@v5
         with:
           push: true
           context: .
@@ -275,7 +275,7 @@ jobs:
       - variables
     steps:
       - name: Checkout px4-firmware
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           path: px4-firmware
           fetch-depth: 0
@@ -286,7 +286,7 @@ jobs:
           path: bin
       - name: Firmware flasher - Container metadata
         id: containermeta # referenced from later step
-        uses: docker/metadata-action@v4
+        uses: docker/metadata-action@v5
         with:
           images: artifactory.ssrcdevops.tii.ae/tiiuae/px4-firmware
           tags: |
@@ -308,7 +308,7 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Firmware flasher - Build and push
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@v5
         with:
           push: true
           context: .

--- a/.github/workflows/tiiuae-sitl-tests.yml
+++ b/.github/workflows/tiiuae-sitl-tests.yml
@@ -26,7 +26,7 @@ jobs:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         token: ${{ secrets.GH_REPO_TOKEN }}
         fetch-depth: 0

--- a/.github/workflows/tiiuae-sitl.yaml
+++ b/.github/workflows/tiiuae-sitl.yaml
@@ -20,7 +20,7 @@ jobs:
     steps:
 
       - name: Checkout px4-firmware
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           path: px4-firmware
           fetch-depth: 0
@@ -44,7 +44,7 @@ jobs:
 
       - name: Docker meta
         id: meta
-        uses: docker/metadata-action@v4
+        uses: docker/metadata-action@v5
         with:
           images: ghcr.io/tiiuae/tii-px4-sitl
           tags: |
@@ -62,7 +62,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build tii-px4-sitl image and push
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@v5
         with:
           context: .
           file: ./px4-firmware/packaging/Dockerfile.sitl


### PR DESCRIPTION
Bundles 3 dependabot updates to one PR:
- bump docker/metadata-action from 4 to 5
- bump docker/build-push-action from 3 to 5
- bump actions/checkout from 1 to 4
