### PR TITLE
Fix uorb again

### DIFF
--- a/platforms/common/uORB/uORBDeviceNode.cpp
+++ b/platforms/common/uORB/uORBDeviceNode.cpp
@@ -917,15 +917,6 @@ uORB::DeviceNode::_unregister_callback(uorb_cb_handle_t &cb_handle)
 		PX4_ERR("unregister fail\n");
 
 	} else {
-#ifndef CONFIG_BUILD_FLAT
-		EventWaitItem *item = callbacks.peek(cb_handle);
-
-		while (item->cb_triggered > 0) {
-			item->cb_triggered--;
-			Manager::lockThread(item->lock);
-		}
-
-#endif
 		callbacks.push_free(cb_handle);
 		cb_handle = UORB_INVALID_CB_HANDLE;
 	}

--- a/platforms/common/uORB/uORBDeviceNode.hpp
+++ b/platforms/common/uORB/uORBDeviceNode.hpp
@@ -224,7 +224,7 @@ public:
 		return node(node_handle)->_register_callback(callback_sub, poll_lock, last_update, interval_us, cb_handle);
 	}
 
-	static bool unregister_callback(orb_advert_t &node_handle, uorb_cb_handle_t &cb_handle)
+	static int unregister_callback(orb_advert_t &node_handle, uorb_cb_handle_t &cb_handle)
 	{
 		return node(node_handle)->_unregister_callback(cb_handle);
 	}
@@ -346,7 +346,7 @@ private:
 
 	bool _register_callback(SubscriptionCallback *callback_sub, int8_t poll_lock, hrt_abstime last_update,
 				uint32_t interval_us, uorb_cb_handle_t &cb_handle);
-	bool _unregister_callback(uorb_cb_handle_t &cb_handle);
+	int _unregister_callback(uorb_cb_handle_t &cb_handle);
 
 #ifdef CONFIG_BUILD_FLAT
 	char *_devname;


### PR DESCRIPTION
Try to fix the original problem in a preper way;

Only take the synhcronizing semaphore in the callback thread; just take into account how many times the callback has been triggered but not handled.

This seems to work correctly in SITL: not tested on the hw so far

The original fix had a huge regression; the publisher thread was getting blocked by the semaphore. Now try the fix the same issue in the way that only place where the snchronizing semaphore is taken is actually the callback thread