### PR TITLE
DP-8235 bootloader_v2 compatible px_uploader.sh to px4 image container

### DIFF
--- a/Tools/px_uploader.Dockerfile
+++ b/Tools/px_uploader.Dockerfile
@@ -5,6 +5,7 @@ ARG saluki_v3_fpga_version
 FROM ghcr.io/tiiuae/saluki-pi-fpga:$saluki_pi_fpga_version AS SALUKI_PI
 FROM ghcr.io/tiiuae/saluki-pi-fpga:$saluki_v2_fpga_version AS SALUKI_V2
 FROM ghcr.io/tiiuae/saluki-pi-fpga:$saluki_v3_fpga_version AS SALUKI_V3
+FROM ghcr.io/tiiuae/saluki_bootloader_v2:master AS SALUKI_BOOTLOADER_v2
 
 FROM python:alpine3.14
 
@@ -25,9 +26,12 @@ FROM python:alpine3.14
 # ("/" above is relative to GH action runner home dir)
 # (see .github/workflows/tiiuae-pixhawk.yaml)
 
+# copy fpga files from separate saluki containers
 COPY --from=SALUKI_PI /firmware/saluki_pi-fpga /firmware/fpga/saluki_pi
 COPY --from=SALUKI_V2 /firmware/saluki_v2-fpga /firmware/fpga/saluki_v2
 COPY --from=SALUKI_V3 /firmware/saluki_v3-fpga /firmware/fpga/saluki_v3
+# copy px_uploader.py from saluki_bootloader_v2 container
+COPY --from=SALUKI_BOOTLOADER_v2 /firmware/bootloader_v2/px_uploader.py /firmware/px_uploader.py
 
 WORKDIR /firmware
 


### PR DESCRIPTION
The script is copied from
https://github.com/tiiuae/saluki_bootloader_v2/blob/master/tools/px_uploader.py
This is a short term fix. In the long we better have one script in one place