### PR TITLE
uORB: Fix the remaining race conditions from callback unregistration

### DIFF
--- a/platforms/common/uORB/uORBDeviceNode.cpp
+++ b/platforms/common/uORB/uORBDeviceNode.cpp
@@ -622,7 +622,7 @@ uORB::DeviceNode::write(const char *buffer, const orb_metadata *meta, orb_advert
 #else
 
 			// Release poll waiters and callback threads
-			if (Manager::isThreadAlive(item->lock)) {
+			if (item->cb_triggered < CB_ALIVE_MAX_VALUE) {
 				__atomic_fetch_add(&item->cb_triggered, 1, __ATOMIC_SEQ_CST);
 				Manager::unlockThread(item->lock);
 

--- a/platforms/common/uORB/uORBDeviceNode.hpp
+++ b/platforms/common/uORB/uORBDeviceNode.hpp
@@ -65,6 +65,7 @@ typedef void *uorb_cb_handle_t;
 #define UORB_INVALID_CB_HANDLE -1
 typedef int8_t uorb_cb_handle_t;
 #define uorb_cb_handle_valid(x) ((x) >= 0)
+#define CB_ALIVE_MAX_VALUE 50
 #endif
 
 #define CB_LIST_T struct EventWaitItem, uorb_cb_handle_t, MAX_EVENT_WAITERS

--- a/platforms/common/uORB/uORBManager.hpp
+++ b/platforms/common/uORB/uORBManager.hpp
@@ -371,7 +371,15 @@ public:
 #ifndef CONFIG_BUILD_FLAT
 	static uint8_t getCallbackLock()
 	{
-		return per_process_lock >= 0 ? per_process_lock : launchCallbackThread();
+		int8_t ret = per_process_lock;
+
+		if (ret < 0) {
+			_Instance->lock();
+			ret = per_process_lock >= 0 ? per_process_lock : launchCallbackThread();
+			_Instance->unlock();
+		}
+
+		return ret;
 	}
 #endif
 

--- a/platforms/common/uORB/uORBManager.hpp
+++ b/platforms/common/uORB/uORBManager.hpp
@@ -51,7 +51,6 @@
 #endif /* CONFIG_ORB_COMMUNICATOR */
 
 #define NUM_GLOBAL_SEMS 40
-#define SUB_ALIVE_SEM_MAX_VALUE 100
 
 namespace uORB
 {
@@ -452,12 +451,6 @@ public:
 	static void freeThreadLock(int i) {_Instance->g_sem_pool.free(i);}
 
 	static int8_t getThreadLock() {return _Instance->g_sem_pool.reserve();}
-
-	static bool isThreadAlive(int idx)
-	{
-		int value = _Instance->g_sem_pool.value(idx);
-		return value <= SUB_ALIVE_SEM_MAX_VALUE;
-	}
 
 private: // class methods
 	inline static uORB::DeviceNode *node(orb_advert_t handle) {return static_cast<uORB::DeviceNode *>(handle.node);}


### PR DESCRIPTION
This is another fix for the previous issue. It tries to remove the remaining race conditions from the callback counter handling.

A simpler fix obviously would be to remove the whole counter, but that would cause the callback loop spinning a lot more, and taking the mutexes inside are rather heavy. I measured this to eat ~2pp of CPU on a "standard configuration", so trying to keep the counter in.

