### PR TITLE
Mavlink logging refactor

### DIFF
--- a/src/modules/logger/log_writer.cpp
+++ b/src/modules/logger/log_writer.cpp
@@ -158,7 +158,7 @@ void LogWriter::thread_stop()
 	}
 }
 
-int LogWriter::write_message(LogType type, void *ptr, size_t size, uint64_t dropout_start, bool reliable, bool wait)
+int LogWriter::write_message(LogType type, void *ptr, size_t size, uint64_t dropout_start, ULogWriteType wrtype)
 {
 	int ret_file = 0, ret_mavlink = 0;
 
@@ -169,8 +169,8 @@ int LogWriter::write_message(LogType type, void *ptr, size_t size, uint64_t drop
 	if (_log_writer_mavlink_for_write && type == LogType::Full) {
 #ifdef LOGGER_PARALLEL_LOGGING
 
-		if (reliable) {
-			ret_mavlink = _log_writer_mavlink_for_write->write_reliable_message(ptr, size, wait);
+		if (wrtype != ULogWriteType::BEST_EFFORT) {
+			ret_mavlink = _log_writer_mavlink_for_write->write_reliable_message(ptr, size, wrtype);
 
 		} else
 #endif

--- a/src/modules/logger/log_writer.h
+++ b/src/modules/logger/log_writer.h
@@ -35,6 +35,7 @@
 
 #include "log_writer_file.h"
 #include "log_writer_mavlink.h"
+#include "messages.h"
 
 namespace px4
 {
@@ -74,10 +75,19 @@ public:
 	void stop_log_mavlink();
 
 #ifdef LOGGER_PARALLEL_LOGGING
+
+	void allow_delayed_sending()
+	{
+		if (_log_writer_mavlink) { _log_writer_mavlink->allow_delayed_sending(); }
+	}
+	void stop_log_mavlink_req()
+	{
+		if (_log_writer_mavlink) { _log_writer_mavlink->stop_log_req(); }
+	}
 	void wait_fifo_empty()
 	{
 		if (_log_writer_mavlink) {
-			_log_writer_mavlink->wait_fifo_count(0);
+			_log_writer_mavlink->wait_fifos_empty();
 
 			while (_log_writer_mavlink->reliable_fifo_is_sending()) {
 				usleep(10000);
@@ -103,8 +113,8 @@ public:
 	 *         -1 if not enough space in the buffer left (file backend), -2 mavlink backend failed
 	 *  add type -> pass through, but not to mavlink if mission log
 	 */
-	int write_message(LogType type, void *ptr, size_t size, uint64_t dropout_start = 0, bool reliable = false,
-			  bool wait = false);
+	int write_message(LogType type, void *ptr, size_t size, uint64_t dropout_start = 0,
+			  ULogWriteType wrtype = ULogWriteType::BEST_EFFORT);
 
 	/**
 	 * Select a backend, so that future calls to write_message() only write to the selected

--- a/src/modules/logger/logger.h
+++ b/src/modules/logger/logger.h
@@ -71,7 +71,7 @@ namespace logger
 
 #ifdef LOGGER_PARALLEL_LOGGING
 typedef struct thread_data {
-	bool wait_for_ack{false};
+	ULogWriteType write_type{ULogWriteType::RELIABLE_TOPIC_DATA};
 } thread_data_t;
 
 pthread_key_t pthread_data_key;
@@ -228,6 +228,7 @@ private:
 	void start_log_mavlink();
 
 	void stop_log_mavlink();
+	void do_stop_log_mavlink();
 
 #ifdef LOGGER_PARALLEL_LOGGING
 	/**
@@ -237,6 +238,8 @@ private:
 
 	static void *mav_start_steps_helper(void *);
 
+	bool _mavlink_log_stop_req = false;
+	bool _mavlink_log_start_steps_sent = false;
 #endif
 
 	/** check if mavlink logging can be started */
@@ -308,7 +311,7 @@ private:
 	 * Must be called with _writer.lock() held.
 	 * @return true if data written, false otherwise (on overflow)
 	 */
-	bool write_message(LogType type, void *ptr, size_t size, bool reliable = false, bool wait = false);
+	bool write_message(LogType type, void *ptr, size_t size, ULogWriteType wrtype = ULogWriteType::BEST_EFFORT);
 
 	/**
 	 * Add topic subscriptions from SD file if it exists, otherwise add topics based on the configured profile.

--- a/src/modules/logger/messages.h
+++ b/src/modules/logger/messages.h
@@ -51,6 +51,11 @@ enum class ULogMessageType : uint8_t {
 	FLAG_BITS = 'B',
 };
 
+enum class ULogWriteType : uint8_t {
+	BEST_EFFORT = 0,
+	RELIABLE_START_STEPS = 1,
+	RELIABLE_TOPIC_DATA = 2,
+};
 
 /* declare message data structs with byte alignment (no padding) */
 #pragma pack(push, 1)

--- a/src/modules/mavlink/mavlink_main.cpp
+++ b/src/modules/mavlink/mavlink_main.cpp
@@ -2541,7 +2541,8 @@ Mavlink::task_main(int argc, char *argv[])
 
 		/* check for ulog streaming messages */
 		if (_mavlink_ulog) {
-			if (cmd_logging_stop_acknowledgement) {
+			if (cmd_logging_stop_acknowledgement && _mavlink_ulog->is_idle()) {
+				PX4_INFO("[mavlink_ulog] stop");
 				_mavlink_ulog->stop();
 				_mavlink_ulog = nullptr;
 

--- a/src/modules/mavlink/mavlink_ulog.h
+++ b/src/modules/mavlink/mavlink_ulog.h
@@ -101,6 +101,8 @@ public:
 	float current_data_rate() const { return _current_rate_factor; }
 	float maximum_data_rate() const { return _max_rate_factor; }
 
+	bool is_idle();
+
 private:
 
 	MavlinkULog(int datarate, float max_rate_factor, uint8_t target_system, uint8_t target_component);
@@ -141,6 +143,8 @@ private:
 	float _current_rate_factor; ///< currently used rate percentage
 	int _current_num_msgs = 0;  ///< number of messages sent within the current time interval
 	hrt_abstime _next_rate_check; ///< next timestamp at which to update the rate
+	uint32_t _num_cumulative_messages = 0;
+	uint32_t _prev_num_cumulative_messages = 0;
 
 	perf_counter_t _msg_missed_ulog_stream_perf{perf_alloc(PC_COUNT, MODULE_NAME": ulog_stream messages missed")};
 


### PR DESCRIPTION
This contains the code from mavlink-logging-ack-timeout-increased branch. Commits are squashed and cherry-picked on top of latest main.
Functionality verified: https://ssrc.atlassian.net/wiki/spaces/DRON/pages/811761775/Indoor+Test+Memo#14.3.2024-Misc-Testing
