### PR TITLE
DP-7925 remove user input poll

### DIFF
--- a/src/systemcmds/topic_listener/listener_main.cpp
+++ b/src/systemcmds/topic_listener/listener_main.cpp
@@ -114,21 +114,6 @@ void listener(const orb_id_t &id, unsigned num_msgs, int topic_instance,
 		int time = 0;
 
 		while (msgs_received < num_msgs) {
-
-			char c = 0;
-			int ret = read(0, &c, 1);
-
-			if (ret) {
-
-				switch (c) {
-				case 0x03: // ctrl-c
-				case 0x1b: // esc
-				case 'q':
-					return;
-					/* not reached */
-				}
-			}
-
 			if (px4_poll(&fds[0], 1, 50) > 0) {
 				// Received message from subscription
 
@@ -137,7 +122,7 @@ void listener(const orb_id_t &id, unsigned num_msgs, int topic_instance,
 
 					PX4_INFO_RAW("\nTOPIC: %s instance %d #%d\n", id->o_name, topic_instance, msgs_received);
 
-					ret = listener_print_topic(id, sub);
+					int ret = listener_print_topic(id, sub);
 
 					if (ret != PX4_OK) {
 						PX4_ERR("listener callback failed (%i)", ret);


### PR DESCRIPTION
earlier commit removed user input poll but it still tries to read user input
https://github.com/tiiuae/px4-firmware/commit/0b603183c025282a36f5d9f01639af98d99eee63#diff-95ea6d47bf95b7f58b56e2f57e462a07eee1d497fa4c1ff7f019f8e704470db6L118
now the control stays there is `read` which never returns unless user gives some input