### PR TITLE
cpuload: Fix wrong idle thread load

### DIFF
--- a/src/modules/logger/logger.cpp
+++ b/src/modules/logger/logger.cpp
@@ -1688,6 +1688,11 @@ void Logger::print_load_callback(void *user)
 
 void Logger::initialize_load_output(PrintLoadReason reason)
 {
+	// If already in progress, don't try to start again
+	if (_next_load_print != 0) {
+		return;
+	}
+
 	init_print_load(&_load);
 
 	if (reason == PrintLoadReason::Watchdog) {


### PR DESCRIPTION
This is a cherry-pick from upstream px4, fixing https://ssrc.atlassian.net/browse/DP-8252

-----------------------

When the CPU load monitor is started while already running, then the idle thread last_times[0] is reset to the last 1 second, rather than since when the CPU load monitor was last started. The remaining threads are not impacted, since their last_times[i] is reset to zero here.

This results in the idle thread having a lower than real CPU load, with the remaining CPU time being wrongly attributed as scheduler load.
