### PR TITLE
uORB: Fix uORB callback register/unregister issues

### DIFF
--- a/platforms/common/uORB/uORBManager.cpp
+++ b/platforms/common/uORB/uORBManager.cpp
@@ -557,7 +557,8 @@ uORB::Manager::registerCallback(orb_advert_t &node_handle, SubscriptionCallback 
 
 		lock_cb_list();
 		per_process_cb_list.add(callback_sub);
-		unlock_cb_list();
+
+		// keep the cb list locked; this prevents the callback thread from trying to access the callback item before it is registered to the device node
 #endif
 		ret = uORB::DeviceNode::register_callback(node_handle, callback_sub, cb_lock, last_update,
 
@@ -566,11 +567,10 @@ uORB::Manager::registerCallback(orb_advert_t &node_handle, SubscriptionCallback 
 	}
 
 	if (!ret) {
-		lock_cb_list();
 		per_process_cb_list.remove(callback_sub);
-		unlock_cb_list();
 	}
 
+	unlock_cb_list();
 #endif
 
 	return ret;


### PR DESCRIPTION
In memory protected modes there were the following issues:
1. It is wrong to self-unregister the callback in uORBDeviceNode. The device node can't assume that the callback thread is killed if the callbacks haven't been handled timely. It might also be temporarily blocked e.g. during boot. If the device node unregisters the callback and the callback thread gets executed later, the cb_handle would point to an item within the device node that is not any more in use.
2. While registering a callback, it has to be registered to both callback thread and the device node before letting callback thread handle them.

Fix these issues as follows:
1. Don't let the device node unregister the callback by itself
2. Keep the callback list locked for the full registration of the callback

In addition, make a minor clean up for the uORB::DeviceNode::_unregister_callback. Get a pointer to the callback item before removing it from the node's cb list. The original code happened to work since the callback handle is just an idex to statically allocated items, but it looked weird.

