### PR TITLE
Feature: failure detector hitl

### DIFF
--- a/src/modules/sensors/CMakeLists.txt
+++ b/src/modules/sensors/CMakeLists.txt
@@ -32,6 +32,7 @@
 ############################################################################
 
 add_subdirectory(data_validator)
+add_subdirectory(failure_detector_HITL)
 
 include_directories(${CMAKE_CURRENT_SOURCE_DIR})
 
@@ -79,6 +80,7 @@ px4_add_module(
 		mathlib
 		sensor_calibration
 		vehicle_imu
+		failure_detector_HITL
 	)
 
 if(CONFIG_SENSORS_VEHICLE_ACCELERATION)

--- a/src/modules/sensors/failure_detector_HITL/CMakeLists.txt
+++ b/src/modules/sensors/failure_detector_HITL/CMakeLists.txt
@@ -1,0 +1,3 @@
+px4_add_library(failure_detector_HITL
+	failure_detector_HITL.cpp
+)

--- a/src/modules/sensors/failure_detector_HITL/failure_detector_HITL.cpp
+++ b/src/modules/sensors/failure_detector_HITL/failure_detector_HITL.cpp
@@ -41,16 +41,18 @@
 
 #include <px4_platform_common/log.h>
 
-FailureDetectorHITL::FailureDetectorHITL(bool hil_enabled) {
+FailureDetectorHITL::FailureDetectorHITL(bool hil_enabled)
+{
 
-	if(!hil_enabled) {
+	if (!hil_enabled) {
 		_vehicle_command_sub.unsubscribe();
-	}
-	else {
+
+	} else {
 		PX4_INFO("RUN FailureDetectorHITL");
 	}
 }
-bool FailureDetectorHITL::update() {
+bool FailureDetectorHITL::update()
+{
 	vehicle_command_s vehicle_command{};
 	bool update = false;
 
@@ -66,66 +68,72 @@ bool FailureDetectorHITL::update() {
 		const int failure_type = static_cast<int>(vehicle_command.param2 + 0.5f);
 
 		PX4_INFO("Failure detector caught new injection");
-		switch (failure_unit)
-		{
+
+		switch (failure_unit) {
 		case vehicle_command_s::FAILURE_UNIT_SENSOR_GPS:
 #if defined(CONFIG_SENSORS_VEHICLE_GPS_POSITION)
 			handled = true;
+
 			if (failure_type == vehicle_command_s::FAILURE_TYPE_OK) {
 				PX4_INFO("CMD_INJECT_FAILURE, gps ok");
 				_gps = FailureStatus::ok;
 				supported = true;
 
-			}
-			else if (failure_type == vehicle_command_s::FAILURE_TYPE_OFF) {
+			} else if (failure_type == vehicle_command_s::FAILURE_TYPE_OFF) {
 				PX4_WARN("CMD_INJECT_FAILURE, gps off");
 				supported = true;
 				_gps = FailureStatus::off;
-			}
-			else if (failure_type == vehicle_command_s::FAILURE_TYPE_STUCK) {
+
+			} else if (failure_type == vehicle_command_s::FAILURE_TYPE_STUCK) {
 				PX4_WARN("CMD_INJECT_FAILURE, gps stuck");
 				_gps = FailureStatus::stuck;
 				supported = true;
 			}
+
 #endif // CONFIG_SENSORS_VEHICLE_GPS_POSITION
 			break;
 
 		case vehicle_command_s::FAILURE_UNIT_SENSOR_BARO:
 #if defined(CONFIG_SENSORS_VEHICLE_AIR_DATA)
 			handled = true;
+
 			if (failure_type == vehicle_command_s::FAILURE_TYPE_OK) {
 				PX4_INFO("CMD_INJECT_FAILURE, baro ok");
 				_baro = FailureStatus::ok;
 				supported = true;
-			}
-			else if (failure_type == vehicle_command_s::FAILURE_TYPE_OFF) {
+
+			} else if (failure_type == vehicle_command_s::FAILURE_TYPE_OFF) {
 				PX4_WARN("CMD_INJECT_FAILURE, baro off");
 				_baro = FailureStatus::off;
 				supported = true;
-			}
-			else if (failure_type == vehicle_command_s::FAILURE_TYPE_STUCK) {
+
+			} else if (failure_type == vehicle_command_s::FAILURE_TYPE_STUCK) {
 				PX4_WARN("CMD_INJECT_FAILURE, baro stuck");
 				_baro = FailureStatus::stuck;
 				supported = true;
 			}
+
 #endif // CONFIG_SENSORS_VEHICLE_AIR_DATA
 			break;
 
 		case vehicle_command_s::FAILURE_UNIT_SENSOR_MAG:
 #if defined(CONFIG_SENSORS_VEHICLE_MAGNETOMETER)
 			handled = true;
+
 			if (failure_type == vehicle_command_s::FAILURE_TYPE_OK) {
 				PX4_INFO("CMD_INJECT_FAILURE, mag ok");
 				_mag = FailureStatus::ok;
 				supported = true;
-			}
-			else if (failure_type == vehicle_command_s::FAILURE_TYPE_OFF) {
+
+			} else if (failure_type == vehicle_command_s::FAILURE_TYPE_OFF) {
 				PX4_WARN("CMD_INJECT_FAILURE, mag off");
 				_mag = FailureStatus::off;
 				supported = true;
 			}
+
 #endif // CONFIG_SENSORS_VEHICLE_MAGNETOMETER
 			break;
+
 		default:
 			break;
 		}
@@ -135,43 +143,51 @@ bool FailureDetectorHITL::update() {
 			ack.command = vehicle_command.command;
 			ack.from_external = false;
 			ack.result = supported ?
-				vehicle_command_ack_s::VEHICLE_CMD_RESULT_ACCEPTED :
-				vehicle_command_ack_s::VEHICLE_CMD_RESULT_UNSUPPORTED;
+				     vehicle_command_ack_s::VEHICLE_CMD_RESULT_ACCEPTED :
+				     vehicle_command_ack_s::VEHICLE_CMD_RESULT_UNSUPPORTED;
 			ack.timestamp = hrt_absolute_time();
 			_command_ack_pub.publish(ack);
 		}
+
 		update |= supported;
 	}
+
 	return update;
 }
 #if defined(CONFIG_SENSORS_VEHICLE_GPS_POSITION)
-bool FailureDetectorHITL::isGpsBlocked() const {
+bool FailureDetectorHITL::isGpsBlocked() const
+{
 	return FailureStatus::ok != _gps;
 }
 
-bool FailureDetectorHITL::isGpsStuck() const {
+bool FailureDetectorHITL::isGpsStuck() const
+{
 	return FailureStatus::stuck == _gps;
 }
 #endif // CONFIG_SENSORS_VEHICLE_GPS_POSITION
 
 #if defined(CONFIG_SENSORS_VEHICLE_AIR_DATA)
-bool FailureDetectorHITL::isBaroBlocked() const {
+bool FailureDetectorHITL::isBaroBlocked() const
+{
 	return FailureStatus::ok != _baro;
 }
 
-bool FailureDetectorHITL::isBaroStuck() const {
+bool FailureDetectorHITL::isBaroStuck() const
+{
 	return FailureStatus::stuck == _baro;
 }
 #endif // CONFIG_SENSORS_VEHICLE_AIR_DATA
 
 #if defined(CONFIG_SENSORS_VEHICLE_MAGNETOMETER)
-bool FailureDetectorHITL::isMagBlocked() const {
+bool FailureDetectorHITL::isMagBlocked() const
+{
 	return FailureStatus::ok != _mag;
 }
 #endif // CONFIG_SENSORS_VEHICLE_MAGNETOMETER
 
 
-FakeSensors::FakeSensors(bool hil_enabled) {
+FakeSensors::FakeSensors(bool hil_enabled)
+{
 	if (hil_enabled) {
 #if defined(CONFIG_SENSORS_VEHICLE_AIR_DATA)
 		_fake_baro_publisher.start();
@@ -183,7 +199,8 @@ FakeSensors::FakeSensors(bool hil_enabled) {
 	}
 }
 
-void FakeSensors::update(const FailureDetectorHITL& detector) {
+void FakeSensors::update(const FailureDetectorHITL &detector)
+{
 #if defined(CONFIG_SENSORS_VEHICLE_GPS_POSITION)
 	_fake_gps_publisher.setEnabled(detector.isGpsStuck());
 #endif // CONFIG_SENSORS_VEHICLE_GPS_POSITION

--- a/src/modules/sensors/failure_detector_HITL/failure_detector_HITL.cpp
+++ b/src/modules/sensors/failure_detector_HITL/failure_detector_HITL.cpp
@@ -1,0 +1,194 @@
+/****************************************************************************
+ *
+ *   Copyright (c) 2012-2024 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+/**
+ * @file failure_detector_HITL.cpp
+ *
+ * @author Ilia Loginov <ilia.loginov@tii.ae>
+ */
+
+#include "failure_detector_HITL.hpp"
+
+#include <px4_platform_common/log.h>
+
+FailureDetectorHITL::FailureDetectorHITL(bool hil_enabled) {
+
+	if(!hil_enabled) {
+		_vehicle_command_sub.unsubscribe();
+	}
+	else {
+		PX4_INFO("RUN FailureDetectorHITL");
+	}
+}
+bool FailureDetectorHITL::update() {
+	vehicle_command_s vehicle_command{};
+	bool update = false;
+
+	while (_vehicle_command_sub.update(&vehicle_command)) {
+		if (vehicle_command.command != vehicle_command_s::VEHICLE_CMD_INJECT_FAILURE) {
+			continue;
+		}
+
+		bool handled = false;
+		bool supported = false;
+
+		const int failure_unit = static_cast<int>(vehicle_command.param1 + 0.5f);
+		const int failure_type = static_cast<int>(vehicle_command.param2 + 0.5f);
+
+		PX4_INFO("Failure detector caught new injection");
+		switch (failure_unit)
+		{
+		case vehicle_command_s::FAILURE_UNIT_SENSOR_GPS:
+#if defined(CONFIG_SENSORS_VEHICLE_GPS_POSITION)
+			handled = true;
+			if (failure_type == vehicle_command_s::FAILURE_TYPE_OK) {
+				PX4_INFO("CMD_INJECT_FAILURE, gps ok");
+				_gps = FailureStatus::ok;
+				supported = true;
+
+			}
+			else if (failure_type == vehicle_command_s::FAILURE_TYPE_OFF) {
+				PX4_WARN("CMD_INJECT_FAILURE, gps off");
+				supported = true;
+				_gps = FailureStatus::off;
+			}
+			else if (failure_type == vehicle_command_s::FAILURE_TYPE_STUCK) {
+				PX4_WARN("CMD_INJECT_FAILURE, gps stuck");
+				_gps = FailureStatus::stuck;
+				supported = true;
+			}
+#endif // CONFIG_SENSORS_VEHICLE_GPS_POSITION
+			break;
+
+		case vehicle_command_s::FAILURE_UNIT_SENSOR_BARO:
+#if defined(CONFIG_SENSORS_VEHICLE_AIR_DATA)
+			handled = true;
+			if (failure_type == vehicle_command_s::FAILURE_TYPE_OK) {
+				PX4_INFO("CMD_INJECT_FAILURE, baro ok");
+				_baro = FailureStatus::ok;
+				supported = true;
+			}
+			else if (failure_type == vehicle_command_s::FAILURE_TYPE_OFF) {
+				PX4_WARN("CMD_INJECT_FAILURE, baro off");
+				_baro = FailureStatus::off;
+				supported = true;
+			}
+			else if (failure_type == vehicle_command_s::FAILURE_TYPE_STUCK) {
+				PX4_WARN("CMD_INJECT_FAILURE, baro stuck");
+				_baro = FailureStatus::stuck;
+				supported = true;
+			}
+#endif // CONFIG_SENSORS_VEHICLE_AIR_DATA
+			break;
+
+		case vehicle_command_s::FAILURE_UNIT_SENSOR_MAG:
+#if defined(CONFIG_SENSORS_VEHICLE_MAGNETOMETER)
+			handled = true;
+			if (failure_type == vehicle_command_s::FAILURE_TYPE_OK) {
+				PX4_INFO("CMD_INJECT_FAILURE, mag ok");
+				_mag = FailureStatus::ok;
+				supported = true;
+			}
+			else if (failure_type == vehicle_command_s::FAILURE_TYPE_OFF) {
+				PX4_WARN("CMD_INJECT_FAILURE, mag off");
+				_mag = FailureStatus::off;
+				supported = true;
+			}
+#endif // CONFIG_SENSORS_VEHICLE_MAGNETOMETER
+			break;
+		default:
+			break;
+		}
+
+		if (handled) {
+			vehicle_command_ack_s ack{};
+			ack.command = vehicle_command.command;
+			ack.from_external = false;
+			ack.result = supported ?
+				vehicle_command_ack_s::VEHICLE_CMD_RESULT_ACCEPTED :
+				vehicle_command_ack_s::VEHICLE_CMD_RESULT_UNSUPPORTED;
+			ack.timestamp = hrt_absolute_time();
+			_command_ack_pub.publish(ack);
+		}
+		update |= supported;
+	}
+	return update;
+}
+#if defined(CONFIG_SENSORS_VEHICLE_GPS_POSITION)
+bool FailureDetectorHITL::isGpsBlocked() const {
+	return FailureStatus::ok != _gps;
+}
+
+bool FailureDetectorHITL::isGpsStuck() const {
+	return FailureStatus::stuck == _gps;
+}
+#endif // CONFIG_SENSORS_VEHICLE_GPS_POSITION
+
+#if defined(CONFIG_SENSORS_VEHICLE_AIR_DATA)
+bool FailureDetectorHITL::isBaroBlocked() const {
+	return FailureStatus::ok != _baro;
+}
+
+bool FailureDetectorHITL::isBaroStuck() const {
+	return FailureStatus::stuck == _baro;
+}
+#endif // CONFIG_SENSORS_VEHICLE_AIR_DATA
+
+#if defined(CONFIG_SENSORS_VEHICLE_MAGNETOMETER)
+bool FailureDetectorHITL::isMagBlocked() const {
+	return FailureStatus::ok != _mag;
+}
+#endif // CONFIG_SENSORS_VEHICLE_MAGNETOMETER
+
+
+FakeSensors::FakeSensors(bool hil_enabled) {
+	if (hil_enabled) {
+#if defined(CONFIG_SENSORS_VEHICLE_AIR_DATA)
+		_fake_baro_publisher.start();
+#endif // CONFIG_SENSORS_VEHICLE_AIR_DATA
+
+#if defined(CONFIG_SENSORS_VEHICLE_GPS_POSITION)
+		_fake_gps_publisher.start();
+#endif // CONFIG_SENSORS_VEHICLE_GPS_POSITION
+	}
+}
+
+void FakeSensors::update(const FailureDetectorHITL& detector) {
+#if defined(CONFIG_SENSORS_VEHICLE_GPS_POSITION)
+	_fake_gps_publisher.setEnabled(detector.isGpsStuck());
+#endif // CONFIG_SENSORS_VEHICLE_GPS_POSITION
+
+#if defined(CONFIG_SENSORS_VEHICLE_AIR_DATA)
+	_fake_baro_publisher.setEnabled(detector.isBaroStuck());
+#endif // CONFIG_SENSORS_VEHICLE_AIR_DATA
+}

--- a/src/modules/sensors/failure_detector_HITL/failure_detector_HITL.cpp
+++ b/src/modules/sensors/failure_detector_HITL/failure_detector_HITL.cpp
@@ -1,6 +1,6 @@
 /****************************************************************************
  *
- *   Copyright (c) 2012-2024 PX4 Development Team. All rights reserved.
+ *   Copyright (c) 2024 Technology Innovation Institute. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -35,6 +35,7 @@
  * @file failure_detector_HITL.cpp
  *
  * @author Ilia Loginov <ilia.loginov@tii.ae>
+ * @author Hai To <hai.to@unikie.com>
  */
 
 #include "failure_detector_HITL.hpp"

--- a/src/modules/sensors/failure_detector_HITL/failure_detector_HITL.cpp
+++ b/src/modules/sensors/failure_detector_HITL/failure_detector_HITL.cpp
@@ -209,3 +209,14 @@ void FakeSensors::update(const FailureDetectorHITL &detector)
 	_fake_baro_publisher.setEnabled(detector.isBaroStuck());
 #endif // CONFIG_SENSORS_VEHICLE_AIR_DATA
 }
+
+void FakeSensors::turnOffAll()
+{
+#if defined(CONFIG_SENSORS_VEHICLE_GPS_POSITION)
+	_fake_gps_publisher.setEnabled(false);
+#endif // CONFIG_SENSORS_VEHICLE_GPS_POSITION
+
+#if defined(CONFIG_SENSORS_VEHICLE_AIR_DATA)
+	_fake_baro_publisher.setEnabled(false);
+#endif // CONFIG_SENSORS_VEHICLE_AIR_DATA
+}

--- a/src/modules/sensors/failure_detector_HITL/failure_detector_HITL.cpp
+++ b/src/modules/sensors/failure_detector_HITL/failure_detector_HITL.cpp
@@ -155,9 +155,14 @@ bool FailureDetectorHITL::update()
 	return update;
 }
 #if defined(CONFIG_SENSORS_VEHICLE_GPS_POSITION)
-bool FailureDetectorHITL::isGpsBlocked() const
+bool FailureDetectorHITL::isGpsOk() const
 {
-	return FailureStatus::ok != _gps;
+	return FailureStatus::ok == _gps;
+}
+
+bool FailureDetectorHITL::isGpsOff() const
+{
+	return FailureStatus::off == _gps;
 }
 
 bool FailureDetectorHITL::isGpsStuck() const
@@ -167,9 +172,14 @@ bool FailureDetectorHITL::isGpsStuck() const
 #endif // CONFIG_SENSORS_VEHICLE_GPS_POSITION
 
 #if defined(CONFIG_SENSORS_VEHICLE_AIR_DATA)
-bool FailureDetectorHITL::isBaroBlocked() const
+bool FailureDetectorHITL::isBaroOk() const
 {
-	return FailureStatus::ok != _baro;
+	return FailureStatus::ok == _baro;
+}
+
+bool FailureDetectorHITL::isBaroOff() const
+{
+	return FailureStatus::off == _baro;
 }
 
 bool FailureDetectorHITL::isBaroStuck() const
@@ -179,9 +189,14 @@ bool FailureDetectorHITL::isBaroStuck() const
 #endif // CONFIG_SENSORS_VEHICLE_AIR_DATA
 
 #if defined(CONFIG_SENSORS_VEHICLE_MAGNETOMETER)
-bool FailureDetectorHITL::isMagBlocked() const
+bool FailureDetectorHITL::isMagOk() const
 {
-	return FailureStatus::ok != _mag;
+	return FailureStatus::ok == _mag;
+}
+
+bool FailureDetectorHITL::isMagOff() const
+{
+	return FailureStatus::off == _mag;
 }
 #endif // CONFIG_SENSORS_VEHICLE_MAGNETOMETER
 
@@ -210,13 +225,3 @@ void FakeSensors::update(const FailureDetectorHITL &detector)
 #endif // CONFIG_SENSORS_VEHICLE_AIR_DATA
 }
 
-void FakeSensors::turnOffAll()
-{
-#if defined(CONFIG_SENSORS_VEHICLE_GPS_POSITION)
-	_fake_gps_publisher.setEnabled(false);
-#endif // CONFIG_SENSORS_VEHICLE_GPS_POSITION
-
-#if defined(CONFIG_SENSORS_VEHICLE_AIR_DATA)
-	_fake_baro_publisher.setEnabled(false);
-#endif // CONFIG_SENSORS_VEHICLE_AIR_DATA
-}

--- a/src/modules/sensors/failure_detector_HITL/failure_detector_HITL.hpp
+++ b/src/modules/sensors/failure_detector_HITL/failure_detector_HITL.hpp
@@ -1,6 +1,6 @@
 /****************************************************************************
  *
- *   Copyright (c) 2012-2024 PX4 Development Team. All rights reserved.
+ *   Copyright (c) 2024 Technology Innovation Institute. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -35,6 +35,7 @@
  * @file failure_detector_HITL.hpp
  *
  * @author Ilia Loginov <ilia.loginov@tii.ae>
+ * @author Hai To <hai.to@unikie.com>
  */
 
 #pragma once

--- a/src/modules/sensors/failure_detector_HITL/failure_detector_HITL.hpp
+++ b/src/modules/sensors/failure_detector_HITL/failure_detector_HITL.hpp
@@ -99,15 +99,15 @@ private:
 	uORB::Publication<vehicle_command_ack_s> _command_ack_pub{ORB_ID(vehicle_command_ack)};
 
 #if defined(CONFIG_SENSORS_VEHICLE_GPS_POSITION)
-	FailureStatus _gps{FailureStatus::ok};
+	FailureStatus _gps {FailureStatus::ok};
 #endif // CONFIG_SENSORS_VEHICLE_GPS_POSITION
 
 #if defined(CONFIG_SENSORS_VEHICLE_AIR_DATA)
-	FailureStatus _baro{FailureStatus::ok};
+	FailureStatus _baro {FailureStatus::ok};
 #endif // CONFIG_SENSORS_VEHICLE_AIR_DATA
 
 #if defined(CONFIG_SENSORS_VEHICLE_MAGNETOMETER)
-	FailureStatus _mag{FailureStatus::ok};
+	FailureStatus _mag {FailureStatus::ok};
 #endif // CONFIG_SENSORS_VEHICLE_MAGNETOMETER
 };
 
@@ -133,33 +133,39 @@ public:
 		ModuleParams(nullptr),
 		ScheduledWorkItem(MODULE_NAME, px4::wq_configurations::nav_and_controllers),
 		_sensor_pub(id),
-		_sensor_sub(id) {
+		_sensor_sub(id)
+	{
 		_sensor_pub.advertise();
 	}
 
-	~FakeStuckSensor() override {
+	~FakeStuckSensor() override
+	{
 		stop();
 		perf_free(_cycle_perf);
 	}
 
-	bool start() {
+	bool start()
+	{
 		ScheduleNow();
 		return true;
 	}
 
-	void stop() {
+	void stop()
+	{
 		Deinit();
 	}
 
-	void setEnabled(bool enable) {
+	void setEnabled(bool enable)
+	{
 		_enable = enable;
 	}
 private:
-	void Run() override {
+	void Run() override
+	{
 		perf_begin(_cycle_perf);
 
-		while (_sensor_sub.update(&_last_output)){
-			_first_init= true;
+		while (_sensor_sub.update(&_last_output)) {
+			_first_init = true;
 		}
 
 		if (_enable && _first_init) {
@@ -171,13 +177,13 @@ private:
 		perf_end(_cycle_perf);
 	}
 
-	uORB::Publication<sensorsData> _sensor_pub{};
-	uORB::Subscription _sensor_sub{};
+	uORB::Publication<sensorsData> _sensor_pub {};
+	uORB::Subscription _sensor_sub {};
 
-	bool _enable{};
-	bool _first_init{}; /**< Flag indicating whether the sensor has been initialized for the first time. */
-	sensorsData _last_output{};
-	perf_counter_t _cycle_perf{perf_alloc(PC_ELAPSED, MODULE_NAME": cycle")};
+	bool _enable {};
+	bool _first_init {}; /**< Flag indicating whether the sensor has been initialized for the first time. */
+	sensorsData _last_output {};
+	perf_counter_t _cycle_perf {perf_alloc(PC_ELAPSED, MODULE_NAME": cycle")};
 };
 
 }
@@ -188,21 +194,22 @@ private:
  * This class represents a collection of fake sensors used for simulation purposes.
  * It is expected to work only in HITL mode.
  */
-class FakeSensors final {
+class FakeSensors final
+{
 public:
 	FakeSensors(bool hil_enabled);
 
 	/**
 	 * @brief Updates states of the fake sensors with data from the failure detector.
 	 */
-	void update(const FailureDetectorHITL& detector);
+	void update(const FailureDetectorHITL &detector);
 private:
 
 #if defined(CONFIG_SENSORS_VEHICLE_AIR_DATA)
-	sensors::FakeStuckSensor<vehicle_air_data_s> _fake_baro_publisher{ORB_ID::vehicle_air_data};
+	sensors::FakeStuckSensor<vehicle_air_data_s> _fake_baro_publisher {ORB_ID::vehicle_air_data};
 #endif // CONFIG_SENSORS_VEHICLE_AIR_DATA
 
 #if defined(CONFIG_SENSORS_VEHICLE_GPS_POSITION)
-	sensors::FakeStuckSensor<sensor_gps_s> _fake_gps_publisher{ORB_ID::vehicle_gps_position};
+	sensors::FakeStuckSensor<sensor_gps_s> _fake_gps_publisher {ORB_ID::vehicle_gps_position};
 #endif // CONFIG_SENSORS_VEHICLE_GPS_POSITION
 };

--- a/src/modules/sensors/failure_detector_HITL/failure_detector_HITL.hpp
+++ b/src/modules/sensors/failure_detector_HITL/failure_detector_HITL.hpp
@@ -1,0 +1,208 @@
+/****************************************************************************
+ *
+ *   Copyright (c) 2012-2024 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+/**
+ * @file failure_detector_HITL.hpp
+ *
+ * @author Ilia Loginov <ilia.loginov@tii.ae>
+ */
+
+#pragma once
+
+#include <uORB/Publication.hpp>
+#include <uORB/Subscription.hpp>
+
+#include <uORB/topics/vehicle_command.h>
+#include <uORB/topics/vehicle_command_ack.h>
+
+#include <px4_platform_common/module_params.h>
+#include <px4_platform_common/px4_work_queue/ScheduledWorkItem.hpp>
+#include <uORB/topics/sensor_gps.h>
+#include <uORB/topics/vehicle_air_data.h>
+
+using namespace time_literals;
+
+/**
+ * @brief FailureDetectorHITL class
+ *
+ * This class tracks cmd vehicle command \ref VEHICLE_CMD_INJECT_FAILURE and provide information about current state.
+ * It is expected to work only in HITL mode.
+ *
+ * @note
+ * Supported message:
+ * \ref FAILURE_UNIT_SENSOR_GPS
+ * \ref FAILURE_UNIT_SENSOR_MAG
+ * \ref FAILURE_UNIT_SENSOR_BARO
+ *
+ * Supported commands:
+ * \ref FAILURE_TYPE_OK
+ * \ref FAILURE_TYPE_FAIL
+ * \ref FAILURE_TYPE_STUCK(only \ref FAILURE_UNIT_SENSOR_GPS and \ref FAILURE_UNIT_SENSOR_BARO)
+ */
+class FailureDetectorHITL final
+{
+public:
+	FailureDetectorHITL(bool hil_enabled);
+	bool update();
+
+#if defined(CONFIG_SENSORS_VEHICLE_GPS_POSITION)
+	bool isGpsBlocked() const;
+	bool isGpsStuck() const;
+#endif // CONFIG_SENSORS_VEHICLE_GPS_POSITION
+
+#if defined(CONFIG_SENSORS_VEHICLE_AIR_DATA)
+	bool isBaroBlocked() const;
+	bool isBaroStuck() const;
+#endif // CONFIG_SENSORS_VEHICLE_AIR_DATA
+
+#if defined(CONFIG_SENSORS_VEHICLE_MAGNETOMETER)
+	bool isMagBlocked() const;
+#endif // CONFIG_SENSORS_VEHICLE_MAGNETOMETER
+
+private:
+	enum class FailureStatus {
+		ok,
+		off,
+		stuck
+	};
+	uORB::Subscription _vehicle_command_sub{ORB_ID(vehicle_command)};
+	uORB::Publication<vehicle_command_ack_s> _command_ack_pub{ORB_ID(vehicle_command_ack)};
+
+#if defined(CONFIG_SENSORS_VEHICLE_GPS_POSITION)
+	FailureStatus _gps{FailureStatus::ok};
+#endif // CONFIG_SENSORS_VEHICLE_GPS_POSITION
+
+#if defined(CONFIG_SENSORS_VEHICLE_AIR_DATA)
+	FailureStatus _baro{FailureStatus::ok};
+#endif // CONFIG_SENSORS_VEHICLE_AIR_DATA
+
+#if defined(CONFIG_SENSORS_VEHICLE_MAGNETOMETER)
+	FailureStatus _mag{FailureStatus::ok};
+#endif // CONFIG_SENSORS_VEHICLE_MAGNETOMETER
+};
+
+
+namespace sensors
+{
+
+/**
+ * @brief FakeStuckSensor class
+ *
+ * This class implements the simulation of a sensor experiencing a "stuck" state,
+ * where the sensor's last recorded data is continuously published at regular intervals,
+ * mimicking a sensor that has stopped updating its readings.
+ * It is expected to work only in HITL mode.
+ *
+ * @tparam sensorsData Type of the sensor data to be published.
+ */
+template <typename sensorsData>
+class FakeStuckSensor final: public ModuleParams, public px4::ScheduledWorkItem
+{
+public:
+	FakeStuckSensor(ORB_ID id):
+		ModuleParams(nullptr),
+		ScheduledWorkItem(MODULE_NAME, px4::wq_configurations::nav_and_controllers),
+		_sensor_pub(id),
+		_sensor_sub(id) {
+		_sensor_pub.advertise();
+	}
+
+	~FakeStuckSensor() override {
+		stop();
+		perf_free(_cycle_perf);
+	}
+
+	bool start() {
+		ScheduleNow();
+		return true;
+	}
+
+	void stop() {
+		Deinit();
+	}
+
+	void setEnabled(bool enable) {
+		_enable = enable;
+	}
+private:
+	void Run() override {
+		perf_begin(_cycle_perf);
+
+		while (_sensor_sub.update(&_last_output)){
+			_first_init= true;
+		}
+
+		if (_enable && _first_init) {
+			_sensor_pub.publish(_last_output);
+		}
+
+		ScheduleDelayed(300_ms); // backup schedule
+
+		perf_end(_cycle_perf);
+	}
+
+	uORB::Publication<sensorsData> _sensor_pub{};
+	uORB::Subscription _sensor_sub{};
+
+	bool _enable{};
+	bool _first_init{}; /**< Flag indicating whether the sensor has been initialized for the first time. */
+	sensorsData _last_output{};
+	perf_counter_t _cycle_perf{perf_alloc(PC_ELAPSED, MODULE_NAME": cycle")};
+};
+
+}
+
+/**
+ * @brief FakeSensors class
+ *
+ * This class represents a collection of fake sensors used for simulation purposes.
+ * It is expected to work only in HITL mode.
+ */
+class FakeSensors final {
+public:
+	FakeSensors(bool hil_enabled);
+
+	/**
+	 * @brief Updates states of the fake sensors with data from the failure detector.
+	 */
+	void update(const FailureDetectorHITL& detector);
+private:
+
+#if defined(CONFIG_SENSORS_VEHICLE_AIR_DATA)
+	sensors::FakeStuckSensor<vehicle_air_data_s> _fake_baro_publisher{ORB_ID::vehicle_air_data};
+#endif // CONFIG_SENSORS_VEHICLE_AIR_DATA
+
+#if defined(CONFIG_SENSORS_VEHICLE_GPS_POSITION)
+	sensors::FakeStuckSensor<sensor_gps_s> _fake_gps_publisher{ORB_ID::vehicle_gps_position};
+#endif // CONFIG_SENSORS_VEHICLE_GPS_POSITION
+};

--- a/src/modules/sensors/sensors.cpp
+++ b/src/modules/sensors/sensors.cpp
@@ -161,11 +161,11 @@ bool Sensors::init()
 
 int Sensors::parameters_update()
 {
-	if (_armed && !_failure_detector_updated) {
+	if (_armed && !(_hil_enabled && _failure_detector_updated)) {
 		return 0;
 	}
 
-	if (_failure_detector_updated) {
+	if (_hil_enabled && _failure_detector_updated) {
 		_fakeSensors.update(_failureDetector);
 	}
 
@@ -435,11 +435,13 @@ void Sensors::InitializeVehicleAirData()
 			}
 
 		} else {
-			if (_failureDetector.isBaroOk()) {
-				_vehicle_air_data->Resume();
+			if (_hil_enabled) {
+				if (_failureDetector.isBaroOk()) {
+					_vehicle_air_data->Resume();
 
-			} else {
-				_vehicle_air_data->Pause();
+				} else {
+					_vehicle_air_data->Pause();
+				}
 			}
 		}
 	}
@@ -458,11 +460,13 @@ void Sensors::InitializeVehicleGPSPosition()
 			}
 
 		} else {
-			if (_failureDetector.isGpsOk()) {
-				_vehicle_gps_position->Resume();
+			if (_hil_enabled) {
+				if (_failureDetector.isGpsOk()) {
+					_vehicle_gps_position->Resume();
 
-			} else {
-				_vehicle_gps_position->Pause();
+				} else {
+					_vehicle_gps_position->Pause();
+				}
 			}
 		}
 	}
@@ -516,13 +520,16 @@ void Sensors::InitializeVehicleMagnetometer()
 			}
 
 		} else {
-			if (_failureDetector.isMagOk()) {
-				_vehicle_magnetometer->Resume();
+			if (_hil_enabled) {
+				if (_failureDetector.isMagOk()) {
+					_vehicle_magnetometer->Resume();
 
-			} else {
-				_vehicle_magnetometer->Pause();
+				} else {
+					_vehicle_magnetometer->Pause();
+				}
 			}
 		}
+
 	}
 }
 #endif // CONFIG_SENSORS_VEHICLE_MAGNETOMETER

--- a/src/modules/sensors/sensors.cpp
+++ b/src/modules/sensors/sensors.cpp
@@ -161,26 +161,12 @@ bool Sensors::init()
 
 int Sensors::parameters_update()
 {
-	if (_hil_enabled) {
-		_fakeSensors.turnOffAll();
-
-#if defined(CONFIG_SENSORS_VEHICLE_GPS_POSITION)
-		InitializeVehicleGPSPosition();
-#endif // CONFIG_SENSORS_VEHICLE_GPS_POSITION
-
-#if defined(CONFIG_SENSORS_VEHICLE_AIR_DATA)
-		InitializeVehicleAirData();
-#endif // CONFIG_SENSORS_VEHICLE_AIR_DATA
-
-#if defined(CONFIG_SENSORS_VEHICLE_MAGNETOMETER)
-		InitializeVehicleMagnetometer();
-#endif // CONFIG_SENSORS_VEHICLE_MAGNETOMETER
-
-		_fakeSensors.update(_failureDetector);
+	if (_armed && !_failure_detector_updated) {
+		return 0;
 	}
 
-	if (_armed) {
-		return 0;
+	if (_failure_detector_updated) {
+		_fakeSensors.update(_failureDetector);
 	}
 
 #if defined(CONFIG_SENSORS_VEHICLE_AIRSPEED)
@@ -441,19 +427,19 @@ void Sensors::adc_poll()
 void Sensors::InitializeVehicleAirData()
 {
 	if (_param_sys_has_baro.get()) {
-		if (_vehicle_air_data == nullptr && !_failureDetector.isBaroBlocked()) {
+		if (_vehicle_air_data == nullptr && _failureDetector.isBaroOk()) {
 			_vehicle_air_data = new VehicleAirData();
 
 			if (_vehicle_air_data) {
 				_vehicle_air_data->Start();
 			}
 		}
-	}
 
-	if (_vehicle_air_data && _failureDetector.isBaroBlocked()) {
-		_vehicle_air_data->Stop();
-		delete _vehicle_air_data;
-		_vehicle_air_data = nullptr;
+		if (_vehicle_air_data && !_failureDetector.isBaroOk()) {
+			_vehicle_air_data->Stop();
+			delete _vehicle_air_data;
+			_vehicle_air_data = nullptr;
+		}
 	}
 }
 #endif // CONFIG_SENSORS_VEHICLE_AIR_DATA
@@ -462,19 +448,19 @@ void Sensors::InitializeVehicleAirData()
 void Sensors::InitializeVehicleGPSPosition()
 {
 	if (_param_sys_has_gps.get()) {
-		if (_vehicle_gps_position == nullptr && !_failureDetector.isGpsBlocked()) {
+		if (_vehicle_gps_position == nullptr && _failureDetector.isGpsOk()) {
 			_vehicle_gps_position = new VehicleGPSPosition();
 
 			if (_vehicle_gps_position) {
 				_vehicle_gps_position->Start();
 			}
 		}
-	}
 
-	if (_vehicle_gps_position && _failureDetector.isGpsBlocked()) {
-		_vehicle_gps_position->Stop();
-		delete _vehicle_gps_position;
-		_vehicle_gps_position = nullptr;
+		if (_vehicle_gps_position && !_failureDetector.isGpsOk()) {
+			_vehicle_gps_position->Stop();
+			delete _vehicle_gps_position;
+			_vehicle_gps_position = nullptr;
+		}
 	}
 }
 #endif // CONFIG_SENSORS_VEHICLE_GPS_POSITION
@@ -518,19 +504,19 @@ void Sensors::InitializeVehicleIMU()
 void Sensors::InitializeVehicleMagnetometer()
 {
 	if (_param_sys_has_mag.get()) {
-		if (_vehicle_magnetometer == nullptr && !_failureDetector.isMagBlocked()) {
+		if (_vehicle_magnetometer == nullptr && _failureDetector.isMagOk()) {
 			_vehicle_magnetometer = new VehicleMagnetometer();
 
 			if (_vehicle_magnetometer) {
 				_vehicle_magnetometer->Start();
 			}
 		}
-	}
 
-	if (_vehicle_magnetometer && _failureDetector.isMagBlocked()) {
-		_vehicle_magnetometer->Stop();
-		delete _vehicle_magnetometer;
-		_vehicle_magnetometer = nullptr;
+		if (_vehicle_magnetometer && !_failureDetector.isMagOk()) {
+			_vehicle_magnetometer->Stop();
+			delete _vehicle_magnetometer;
+			_vehicle_magnetometer = nullptr;
+		}
 	}
 }
 #endif // CONFIG_SENSORS_VEHICLE_MAGNETOMETER
@@ -651,8 +637,13 @@ void Sensors::Run()
 		}
 	}
 
-	if (_hil_enabled && _failureDetector.update()) {
-		parameters_update();
+	if (_hil_enabled) {
+		_failure_detector_updated = _failureDetector.update();
+
+		if (_failure_detector_updated) {
+			parameters_update();
+			_failure_detector_updated = false;
+		}
 	}
 
 	_voted_sensors_update.sensorsPoll(_sensor_combined);

--- a/src/modules/sensors/sensors.cpp
+++ b/src/modules/sensors/sensors.cpp
@@ -162,6 +162,8 @@ bool Sensors::init()
 int Sensors::parameters_update()
 {
 	if (_hil_enabled) {
+		_fakeSensors.turnOffAll();
+
 #if defined(CONFIG_SENSORS_VEHICLE_GPS_POSITION)
 		InitializeVehicleGPSPosition();
 #endif // CONFIG_SENSORS_VEHICLE_GPS_POSITION

--- a/src/modules/sensors/sensors.cpp
+++ b/src/modules/sensors/sensors.cpp
@@ -161,19 +161,18 @@ bool Sensors::init()
 
 int Sensors::parameters_update()
 {
-	if (_hil_enabled)
-	{
-		#if defined(CONFIG_SENSORS_VEHICLE_GPS_POSITION)
-			InitializeVehicleGPSPosition();
-		#endif // CONFIG_SENSORS_VEHICLE_GPS_POSITION
+	if (_hil_enabled) {
+#if defined(CONFIG_SENSORS_VEHICLE_GPS_POSITION)
+		InitializeVehicleGPSPosition();
+#endif // CONFIG_SENSORS_VEHICLE_GPS_POSITION
 
-		#if defined(CONFIG_SENSORS_VEHICLE_AIR_DATA)
-			InitializeVehicleAirData();
-		#endif // CONFIG_SENSORS_VEHICLE_AIR_DATA
+#if defined(CONFIG_SENSORS_VEHICLE_AIR_DATA)
+		InitializeVehicleAirData();
+#endif // CONFIG_SENSORS_VEHICLE_AIR_DATA
 
-		#if defined(CONFIG_SENSORS_VEHICLE_MAGNETOMETER)
-			InitializeVehicleMagnetometer();
-		#endif // CONFIG_SENSORS_VEHICLE_MAGNETOMETER
+#if defined(CONFIG_SENSORS_VEHICLE_MAGNETOMETER)
+		InitializeVehicleMagnetometer();
+#endif // CONFIG_SENSORS_VEHICLE_MAGNETOMETER
 
 		_fakeSensors.update(_failureDetector);
 	}
@@ -650,7 +649,7 @@ void Sensors::Run()
 		}
 	}
 
-	if(_hil_enabled && _failureDetector.update()) {
+	if (_hil_enabled && _failureDetector.update()) {
 		parameters_update();
 	}
 

--- a/src/modules/sensors/sensors.cpp
+++ b/src/modules/sensors/sensors.cpp
@@ -427,18 +427,20 @@ void Sensors::adc_poll()
 void Sensors::InitializeVehicleAirData()
 {
 	if (_param_sys_has_baro.get()) {
-		if (_vehicle_air_data == nullptr && _failureDetector.isBaroOk()) {
+		if (_vehicle_air_data == nullptr) {
 			_vehicle_air_data = new VehicleAirData();
 
 			if (_vehicle_air_data) {
 				_vehicle_air_data->Start();
 			}
-		}
 
-		if (_vehicle_air_data && !_failureDetector.isBaroOk()) {
-			_vehicle_air_data->Stop();
-			delete _vehicle_air_data;
-			_vehicle_air_data = nullptr;
+		} else {
+			if (_failureDetector.isBaroOk()) {
+				_vehicle_air_data->Resume();
+
+			} else {
+				_vehicle_air_data->Pause();
+			}
 		}
 	}
 }
@@ -448,18 +450,20 @@ void Sensors::InitializeVehicleAirData()
 void Sensors::InitializeVehicleGPSPosition()
 {
 	if (_param_sys_has_gps.get()) {
-		if (_vehicle_gps_position == nullptr && _failureDetector.isGpsOk()) {
+		if (_vehicle_gps_position == nullptr) {
 			_vehicle_gps_position = new VehicleGPSPosition();
 
 			if (_vehicle_gps_position) {
 				_vehicle_gps_position->Start();
 			}
-		}
 
-		if (_vehicle_gps_position && !_failureDetector.isGpsOk()) {
-			_vehicle_gps_position->Stop();
-			delete _vehicle_gps_position;
-			_vehicle_gps_position = nullptr;
+		} else {
+			if (_failureDetector.isGpsOk()) {
+				_vehicle_gps_position->Resume();
+
+			} else {
+				_vehicle_gps_position->Pause();
+			}
 		}
 	}
 }
@@ -504,18 +508,20 @@ void Sensors::InitializeVehicleIMU()
 void Sensors::InitializeVehicleMagnetometer()
 {
 	if (_param_sys_has_mag.get()) {
-		if (_vehicle_magnetometer == nullptr && _failureDetector.isMagOk()) {
+		if (_vehicle_magnetometer == nullptr) {
 			_vehicle_magnetometer = new VehicleMagnetometer();
 
 			if (_vehicle_magnetometer) {
 				_vehicle_magnetometer->Start();
 			}
-		}
 
-		if (_vehicle_magnetometer && !_failureDetector.isMagOk()) {
-			_vehicle_magnetometer->Stop();
-			delete _vehicle_magnetometer;
-			_vehicle_magnetometer = nullptr;
+		} else {
+			if (_failureDetector.isMagOk()) {
+				_vehicle_magnetometer->Resume();
+
+			} else {
+				_vehicle_magnetometer->Pause();
+			}
 		}
 	}
 }

--- a/src/modules/sensors/sensors.hpp
+++ b/src/modules/sensors/sensors.hpp
@@ -135,6 +135,8 @@ private:
 
 	const bool _hil_enabled;	/**< if true, HIL is active */
 
+	bool _failure_detector_updated{};	/**< true if the failure detector has been updated */
+
 	perf_counter_t	_loop_perf;	/**< loop performance counter */
 
 	VehicleIMU *_vehicle_imu_list[MAX_SENSOR_COUNT] {};

--- a/src/modules/sensors/sensors.hpp
+++ b/src/modules/sensors/sensors.hpp
@@ -51,6 +51,7 @@
 #include <uORB/SubscriptionCallback.hpp>
 #include "voted_sensors_update.h"
 #include "vehicle_imu/VehicleIMU.hpp"
+#include "failure_detector_HITL/failure_detector_HITL.hpp"
 
 #if defined(CONFIG_SENSORS_VEHICLE_ACCELERATION)
 # include "vehicle_acceleration/VehicleAcceleration.hpp"
@@ -250,6 +251,9 @@ private:
 	VehicleOpticalFlow *_vehicle_optical_flow {nullptr};
 	uint8_t _n_optical_flow{0};
 #endif // CONFIG_SENSORS_VEHICLE_OPTICAL_FLOW
+
+	FailureDetectorHITL _failureDetector;
+	FakeSensors _fakeSensors;
 
 	DEFINE_PARAMETERS(
 #if defined(CONFIG_SENSORS_VEHICLE_AIR_DATA)

--- a/src/modules/sensors/vehicle_air_data/VehicleAirData.cpp
+++ b/src/modules/sensors/vehicle_air_data/VehicleAirData.cpp
@@ -131,6 +131,10 @@ bool VehicleAirData::ParametersUpdate(bool force)
 
 void VehicleAirData::Run()
 {
+	if (_paused) {
+		return;
+	}
+
 	perf_begin(_cycle_perf);
 
 	const hrt_abstime time_now_us = hrt_absolute_time();

--- a/src/modules/sensors/vehicle_air_data/VehicleAirData.hpp
+++ b/src/modules/sensors/vehicle_air_data/VehicleAirData.hpp
@@ -68,6 +68,8 @@ public:
 
 	bool Start();
 	void Stop();
+	void Pause() { _paused = true; }
+	void Resume() { _paused = false; }
 
 	void PrintStatus();
 
@@ -124,6 +126,8 @@ private:
 	int8_t _selected_sensor_sub_index{-1};
 
 	float _air_temperature_celsius{20.f}; // initialize with typical 20degC ambient temperature
+
+	bool _paused{false};
 
 	DEFINE_PARAMETERS(
 		(ParamFloat<px4::params::SENS_BARO_QNH>) _param_sens_baro_qnh,

--- a/src/modules/sensors/vehicle_gps_position/VehicleGPSPosition.cpp
+++ b/src/modules/sensors/vehicle_gps_position/VehicleGPSPosition.cpp
@@ -101,6 +101,10 @@ void VehicleGPSPosition::ParametersUpdate(bool force)
 
 void VehicleGPSPosition::Run()
 {
+	if (_paused) {
+		return;
+	}
+
 	perf_begin(_cycle_perf);
 	ParametersUpdate();
 

--- a/src/modules/sensors/vehicle_gps_position/VehicleGPSPosition.hpp
+++ b/src/modules/sensors/vehicle_gps_position/VehicleGPSPosition.hpp
@@ -61,6 +61,8 @@ public:
 
 	bool Start();
 	void Stop();
+	void Pause() { _paused = true; }
+	void Resume() { _paused = false; }
 
 	void PrintStatus();
 
@@ -91,6 +93,8 @@ private:
 	perf_counter_t _cycle_perf{perf_alloc(PC_ELAPSED, MODULE_NAME": cycle")};
 
 	GpsBlending _gps_blending;
+
+	bool _paused{false};
 
 	DEFINE_PARAMETERS(
 		(ParamInt<px4::params::SENS_GPS_MASK>) _param_sens_gps_mask,

--- a/src/modules/sensors/vehicle_magnetometer/VehicleMagnetometer.cpp
+++ b/src/modules/sensors/vehicle_magnetometer/VehicleMagnetometer.cpp
@@ -397,6 +397,10 @@ void VehicleMagnetometer::UpdatePowerCompensation()
 
 void VehicleMagnetometer::Run()
 {
+	if (_paused) {
+		return;
+	}
+
 	perf_begin(_cycle_perf);
 
 	const hrt_abstime time_now_us = hrt_absolute_time();

--- a/src/modules/sensors/vehicle_magnetometer/VehicleMagnetometer.hpp
+++ b/src/modules/sensors/vehicle_magnetometer/VehicleMagnetometer.hpp
@@ -74,6 +74,8 @@ public:
 
 	bool Start();
 	void Stop();
+	void Pause() { _paused = true; }
+	void Resume() { _paused = false; }
 
 	void PrintStatus();
 
@@ -172,6 +174,8 @@ private:
 	int8_t _selected_sensor_sub_index{-1};
 
 	bool _armed{false};
+
+	bool _paused{false};
 
 	DEFINE_PARAMETERS(
 		(ParamInt<px4::params::CAL_MAG_COMP_TYP>) _param_mag_comp_typ,


### PR DESCRIPTION
Component: Introduced failure_detector_hitl module, integrating three classes for handling failure injection messages(FailureDetectorHITL),

simulating sensors that have ceased to update (FakeStuckSensor), and a component managing a collection of these simulated sensors (FakeSensors).

This module is a combination of three classes: FailureDetectorHITL for detecting failure injection messages, FakeStuckSensor for simulating sensors whose readings have become stuck, and FakeSensors, a component that aggregates a collection of such simulated sensors.

Additionally, the handling of the sensors module has been extended to support disabling sensors during flight.

Designed exclusively for operation in HITL (Hardware-In-The-Loop) mode, this module does not interfere with normal operational mode.

Reported-by: Ilia Loginov ilia.loginov@tii.ae

On branch FEATURE_FAILURE_INJECTION_HITL
Changes to be committed:
	modified:   src/modules/sensors/CMakeLists.txt
	new file:   src/modules/sensors/failure_detector_HITL/CMakeLists.txt
	new file:   src/modules/sensors/failure_detector_HITL/failure_detector_HITL.cpp
	new file:   src/modules/sensors/failure_detector_HITL/failure_detector_HITL.hpp
	modified:   src/modules/sensors/sensors.cpp
	modified:   src/modules/sensors/sensors.hpp
	
	
Tested on Pixhawk and Saluki v3 HITL mode