### PR TITLE
run codeql on push to main branch

### DIFF
--- a/.github/workflows/tiiuae-codeql.yaml
+++ b/.github/workflows/tiiuae-codeql.yaml
@@ -1,6 +1,8 @@
 name: "CodeQL"
 
 on:
+  push:
+    branches: [main]
   pull_request:
     branches: [main]
   workflow_dispatch:


### PR DESCRIPTION
CodeQL needs to be ran on push to main. Otherwise the github status page stays out of sync