### PR TITLE
Gz sim simulation improvements

### DIFF
--- a/src/modules/mavlink/mavlink_params.c
+++ b/src/modules/mavlink/mavlink_params.c
@@ -157,6 +157,15 @@ PARAM_DEFINE_INT32(MAV_HB_FORW_EN, 1);
 PARAM_DEFINE_INT32(MAV_RADIO_TOUT, 5);
 
 /**
+ * mavlink receiver HITL use simulated origin (home) position
+ *
+ * @boolean
+ * @reboot_required true
+ * @group MAVLink
+ */
+PARAM_DEFINE_INT32(MAV_HITL_SHOME, 1);
+
+/**
  * mavlink receiver HITL simulated origin latitude
  *
  * @unit deg

--- a/src/modules/mavlink/mavlink_receiver.h
+++ b/src/modules/mavlink/mavlink_receiver.h
@@ -377,6 +377,11 @@ private:
 	matrix::Vector3f _hil_euler_prev{};
 	MapProjection _hil_pos_ref{};
 
+	uint64_t _hitl_sim_gps_time_usec{0};
+	double _hitl_sim_home_lat{0.0};
+	double _hitl_sim_home_lon{0.0};
+	double _hitl_sim_home_alt{0.0};
+
 	// Allocated if needed.
 	TunePublisher *_tune_publisher{nullptr};
 
@@ -401,12 +406,13 @@ private:
 	hrt_abstime _heartbeat_component_uart_bridge{0};
 
 	DEFINE_PARAMETERS(
-		(ParamFloat<px4::params::BAT_CRIT_THR>)     _param_bat_crit_thr,
-		(ParamFloat<px4::params::BAT_EMERGEN_THR>)  _param_bat_emergen_thr,
-		(ParamFloat<px4::params::BAT_LOW_THR>)      _param_bat_low_thr,
-		(ParamFloat<px4::params::MAV_HITL_LAT>) _param_hil_home_lat,
-		(ParamFloat<px4::params::MAV_HITL_LON>) _param_hil_home_lon,
-		(ParamFloat<px4::params::MAV_HITL_ALT>) _param_hil_home_alt
+		(ParamFloat<px4::params::BAT_CRIT_THR>) _param_bat_crit_thr,
+		(ParamFloat<px4::params::BAT_EMERGEN_THR>) _param_bat_emergen_thr,
+		(ParamFloat<px4::params::BAT_LOW_THR>) _param_bat_low_thr,
+		(ParamBool<px4::params::MAV_HITL_SHOME>) _param_hitl_use_sim_home,
+		(ParamFloat<px4::params::MAV_HITL_LAT>) _param_hitl_home_lat,
+		(ParamFloat<px4::params::MAV_HITL_LON>) _param_hitl_home_lon,
+		(ParamFloat<px4::params::MAV_HITL_ALT>) _param_hitl_home_alt
 	);
 
 	// Disallow copy construction and move assignment.

--- a/src/modules/mavlink/streams/HIL_ACTUATOR_CONTROLS.hpp
+++ b/src/modules/mavlink/streams/HIL_ACTUATOR_CONTROLS.hpp
@@ -63,6 +63,7 @@ private:
 	{
 		_act_sub = uORB::Subscription{ORB_ID(actuator_outputs_sim)};
 		mavlink->register_orb_poll(get_id_static(), _orbs, arraySize(_orbs));
+
 		for (int i = 0; i < actuator_outputs_s::NUM_ACTUATOR_OUTPUTS; ++i) {
 			char param_name[17];
 			snprintf(param_name, sizeof(param_name), "%s_%s%d", "PWM_MAIN", "FUNC", i + 1);

--- a/src/modules/simulation/gz_bridge/GZBridge.hpp
+++ b/src/modules/simulation/gz_bridge/GZBridge.hpp
@@ -109,6 +109,7 @@ private:
 	void barometerCallback(const gz::msgs::FluidPressure &air_pressure);
 	void imuCallback(const gz::msgs::IMU &imu);
 	void poseInfoCallback(const gz::msgs::Pose_V &pose);
+	void navSatCallback(const gz::msgs::NavSat &nav_sat);
 	void odometryCallback(const gz::msgs::OdometryWithCovariance &odometry);
 
 	/**
@@ -163,11 +164,20 @@ private:
 
 	float _temperature{288.15};  // 15 degrees
 
+	uint64_t _gz_sim_gps_time_usec{0};
+
+	double _gz_home_lat{0.0};
+
+	double _gz_home_lon{0.0};
+
+	double _gz_home_alt{0.0};
+
 	gz::transport::Node::Publisher _cmd_vel_pub;
 
 	gz::transport::Node _node;
 
 	DEFINE_PARAMETERS(
+		(ParamBool<px4::params::SIM_GZ_SHOME>) _param_use_sim_home,
 		(ParamFloat<px4::params::SIM_GZ_HOME_LAT>) _param_sim_home_lat,
 		(ParamFloat<px4::params::SIM_GZ_HOME_LON>) _param_sim_home_lon,
 		(ParamFloat<px4::params::SIM_GZ_HOME_ALT>) _param_sim_home_alt

--- a/src/modules/simulation/gz_bridge/parameters.c
+++ b/src/modules/simulation/gz_bridge/parameters.c
@@ -50,6 +50,15 @@ PARAM_DEFINE_INT32(SIM_GZ_EN, 0);
 PARAM_DEFINE_INT32(SIM_GZ_RUN_GZSIM, 1);
 
 /**
+ * use simulator origin (home) position
+ *
+ * @boolean
+ * @reboot_required true
+ * @group Simulator
+ */
+PARAM_DEFINE_INT32(SIM_GZ_SHOME, 1);
+
+/**
  * simulator origin latitude
  *
  * @unit deg


### PR DESCRIPTION
- Add support for esc_status uorb msg in HITL mode. It will be needed for tests that requires failure injection
- Add support for receiving home GPS position and option to use it instead of default px4 home GPS coordinates

Tested in SITL and HITL