### PR TITLE
uORBDeviceNode.cpp: Use semaphore as node lock, instead of critical s…

### DIFF
--- a/platforms/common/uORB/uORBDeviceNode.hpp
+++ b/platforms/common/uORB/uORBDeviceNode.hpp
@@ -351,11 +351,6 @@ private:
 				uint32_t interval_us, uorb_cb_handle_t &cb_handle);
 	int _unregister_callback(uorb_cb_handle_t &cb_handle);
 
-#ifdef CONFIG_BUILD_FLAT
-	char *_devname;
-	void *_data{nullptr};
-#else
-
 	/**
 	 * Mutex for protecting node's internal data
 	 */
@@ -364,6 +359,10 @@ private:
 	void		unlock() { px4_sem_post(&_lock); }
 	px4_sem_t	_lock; /**< lock to protect access to all class members */
 
+#ifdef CONFIG_BUILD_FLAT
+	char *_devname;
+	void *_data{nullptr};
+#else
 	char _devname[NAME_MAX + 1];
 #endif
 };


### PR DESCRIPTION
…ection

A critical section is not a lock, it cannot be used to lock the device node as if the task that needs to lock the node yields, interrupts can get re-enabled which means the node is not locked anymore.

