### PR TITLE
uORBManager.cpp: Fix issue with registerCallback

### DIFF
--- a/platforms/common/uORB/uORBManager.cpp
+++ b/platforms/common/uORB/uORBManager.cpp
@@ -567,16 +567,16 @@ uORB::Manager::registerCallback(orb_advert_t &node_handle, SubscriptionCallback 
 		// keep the cb list locked; this prevents the callback thread from trying to access the callback item before it is registered to the device node
 #endif
 		ret = uORB::DeviceNode::register_callback(node_handle, callback_sub, cb_lock, last_update,
-
 				interval_us, cb_handle);
 #ifndef CONFIG_BUILD_FLAT
+
+		if (!ret) {
+			per_process_cb_list.remove(callback_sub);
+		}
+
+		unlock_cb_list();
 	}
 
-	if (!ret) {
-		per_process_cb_list.remove(callback_sub);
-	}
-
-	unlock_cb_list();
 #endif
 
 	return ret;


### PR DESCRIPTION
A curly brace was misplaced, calls to unlock_cb_list() etc belong within the statement

if (cb_lock >= 0) {

}

