### PR TITLE
Remove bson test for kernel-mode build

### DIFF
--- a/src/systemcmds/tests/CMakeLists.txt
+++ b/src/systemcmds/tests/CMakeLists.txt
@@ -35,7 +35,6 @@ set(srcs
 	test_atomic_bitset.cpp
 	test_bezierQuad.cpp
 	test_bitset.cpp
-	test_bson.cpp
 	test_dataman.cpp
 	test_file.c
 	test_file2.c
@@ -65,6 +64,12 @@ set(srcs
 	test_cli.c
 	tests_main.c
 	)
+
+if(CONFIG_BUILD_FLAT)
+	list(APPEND srcs
+		test_bson.cpp
+		)
+endif()
 
 if(${PX4_PLATFORM} STREQUAL "nuttx")
 	list(APPEND srcs

--- a/src/systemcmds/tests/tests_main.c
+++ b/src/systemcmds/tests/tests_main.c
@@ -81,7 +81,9 @@ const struct {
 	{"atomic_bitset",	test_atomic_bitset,	0},
 	{"bezier",		test_bezierQuad,	0},
 	{"bitset",		test_bitset,		0},
+#ifdef CONFIG_BUILD_FLAT
 	{"bson",		test_bson,		0},
+#endif
 	{"dataman",		test_dataman,	OPT_NOJIGTEST | OPT_NOALLTEST},
 	{"file2",		test_file2,		OPT_NOJIGTEST},
 	{"float",		test_float,		0},


### PR DESCRIPTION
Remove bson test from kernel-mode build.
Tinybson lib is located in kernel space and can't be accessed from user side tests app

Removal can be selected with config flag CONFIG_TESTS_KERNEL_MODE_COMPATIBLE 
to separate it out from kernel-mode builds only
