### PR TITLE
uavcan: disable esc current report

### DIFF
--- a/src/drivers/uavcan/actuators/esc.cpp
+++ b/src/drivers/uavcan/actuators/esc.cpp
@@ -138,7 +138,8 @@ UavcanEscController::esc_status_sub_cb(const uavcan::ReceivedDataStructure<uavca
 		ref.timestamp       = hrt_absolute_time();
 		ref.esc_address = msg.getSrcNodeID().get();
 		ref.esc_voltage     = msg.voltage;
-		ref.esc_current     = fabs(msg.current);
+		//ref.esc_current     = fabs(msg.current);
+		ref.esc_current     = 0.0; // currently with Myxa ESC, the reported current is not reliable
 		ref.esc_temperature = msg.temperature;
 		ref.esc_rpm         = msg.rpm;
 		ref.esc_errorcount  = msg.error_count;


### PR DESCRIPTION
- Since the Myxa ESC current report is not correct, esc current should be set to 0 to disable the current probe in failure detector to avoid wrongly trigger of `Preflight Fail: Motor failure detected`