### PR TITLE
Build epoch time

### DIFF
--- a/Tools/px_uploader.Dockerfile
+++ b/Tools/px_uploader.Dockerfile
@@ -1,4 +1,4 @@
-FROM python:alpine3.14
+FROM alpine:3.20
 
 ARG saluki_fpga_directory
 ARG SALUKI_FILE_INFO_JSON=saluki_file_info.json
@@ -14,10 +14,6 @@ ENTRYPOINT ["/entrypoint.sh"]
 # tools needed to extract binaries from px4 files
 RUN apk add pigz jq
 
-# dependency of px_uploader.py
-RUN pip3 install --user pyserial
-
-ADD px4-firmware/Tools/px_uploader.py /bin/
 ADD px4-firmware/Tools/px_uploader.entrypoint /entrypoint.sh
 
 # copy /bin/* -> /firmware/*

--- a/Tools/px_uploader.entrypoint
+++ b/Tools/px_uploader.entrypoint
@@ -20,11 +20,8 @@ extract_bin_from_px4() {
     # as base64 encoded and gzipped
     cat ${px4_file} | jq -r '.image' | base64 -d | pigz -d > $target
 
-    # px4 build timestamp is included in px4 file
-    build_timestamp=$(cat ${px4_file} | jq -r '.build_time')
-
     validation_file=${target_dir}/$(basename ${px4_file%.px4}).val
-    generate_metadata ${px4_file} ${validation_file} ${build_timestamp}
+    generate_metadata ${px4_file} ${validation_file}
 }
 
 # generate validation files for the extracted px4 files
@@ -32,7 +29,6 @@ extract_bin_from_px4() {
 function generate_metadata() {
     local px4_filename=${1}
     local validation_file=${2}
-    local timestamp=${3}
     echo "generating validation file for ${px4_filename} to ${validation_file}"
 
     # get the file info from the SALUKI_FILE_INFO_JSON.json
@@ -44,11 +40,6 @@ function generate_metadata() {
         jq -c '.files[] | select (.filename | contains("'${px4_filename}'")) |
         .filename = "'${px4_bin_filename}'" |
         .type = "px4-bin"')
-
-    # Add the build timestamp
-    saluki_file_info=$(echo ${saluki_file_info} |
-        jq -c 'select (.filename | contains("'${px4_bin_filename}'"))' |
-        jq '. += {"build_time":"'${timestamp}'"}')
     echo ${saluki_file_info} > ${validation_file}
 
     # append file info to temporary file

--- a/build.sh
+++ b/build.sh
@@ -77,82 +77,108 @@ case $target in
     $build_cmd_fw ssrc_saluki-v2_default
     cp ${script_dir}/build/ssrc_saluki-v2_default/ssrc_saluki-v2_default.px4 ${dest_dir}/ssrc_saluki-v2_default-${version}.px4
     cp ${script_dir}/build/ssrc_saluki-v2_default/ssrc_saluki-v2_default_kernel.elf ${dest_dir}/ssrc_saluki-v2_default_kernel-${version}.elf
-    json_output+="\"filename\":\"ssrc_saluki-v2_default-${version}.px4\"}"
+    json_output+="\"filename\":\"ssrc_saluki-v2_default-${version}.px4\","
+    px4_build_time=$(grep px4_build_time ${script_dir}/build/ssrc_saluki-v2_default/src/lib/version/build_git_version.h|awk '{print $3}')
+    json_output+="\"px4_build_time\":\"${px4_build_time}\"}"
     ;;
   "saluki-v2_amp")
     $build_cmd_fw ssrc_saluki-v2_amp
     cp ${script_dir}/build/ssrc_saluki-v2_amp/ssrc_saluki-v2_amp.bin ${dest_dir}/ssrc_saluki-v2_amp-${version}.bin
     cp ${script_dir}/build/ssrc_saluki-v2_amp/ssrc_saluki-v2_amp_kernel.elf ${dest_dir}/ssrc_saluki-v2_amp_kernel-${version}.elf
-    json_output+="\"filename\":\"ssrc_saluki-v2_amp-${version}.bin\"}"
+    json_output+="\"filename\":\"ssrc_saluki-v2_amp-${version}.bin\","
+    px4_build_time=$(grep px4_build_time ${script_dir}/build/ssrc_saluki-v2_amp/src/lib/version/build_git_version.h|awk '{print $3}')
+    json_output+="\"px4_build_time\":\"${px4_build_time}\"}"
     ;;
   "saluki-v2_flat")
     $build_cmd_fw ssrc_saluki-v2_flat
     cp ${script_dir}/build/ssrc_saluki-v2_flat/ssrc_saluki-v2_flat.px4 ${dest_dir}/ssrc_saluki-v2_flat-${version}.px4
     cp ${script_dir}/build/ssrc_saluki-v2_flat/ssrc_saluki-v2_flat.elf ${dest_dir}/ssrc_saluki-v2_flat-${version}.elf
-    json_output+="\"filename\":\"ssrc_saluki-v2_flat-${version}.px4\"}"
+    json_output+="\"filename\":\"ssrc_saluki-v2_flat-${version}.px4\","
+    px4_build_time=$(grep px4_build_time ${script_dir}/build/ssrc_saluki-v2_flat/src/lib/version/build_git_version.h|awk '{print $3}')
+    json_output+="\"px4_build_time\":\"${px4_build_time}\"}"
     ;;
   "saluki-v2_custom_keys")
     # on custom keys case we build _default target but SIGNING_ARGS env variable is set above in build_cmd_fw
     $build_cmd_fw ssrc_saluki-v2_default
     cp ${script_dir}/build/ssrc_saluki-v2_default/ssrc_saluki-v2_default.px4 ${dest_dir}/ssrc_saluki-v2_custom_keys-${version}.px4
     cp ${script_dir}/build/ssrc_saluki-v2_default/ssrc_saluki-v2_default_kernel.elf ${dest_dir}/ssrc_saluki-v2_custom_keys_kernel-${version}.elf
-    json_output+="\"filename\":\"ssrc_saluki-v2_custom_keys-${version}.px4\"}"
+    json_output+="\"filename\":\"ssrc_saluki-v2_custom_keys-${version}.px4\","
+    px4_build_time=$(grep px4_build_time ${script_dir}/build/ssrc_saluki-v2_default/src/lib/version/build_git_version.h|awk '{print $3}')
+    json_output+="\"px4_build_time\":\"${px4_build_time}\"}"
     ;;
   "saluki-v3_default")
     $build_cmd_fw ssrc_saluki-v3_default
     cp ${script_dir}/build/ssrc_saluki-v3_default/ssrc_saluki-v3_default.px4 ${dest_dir}/ssrc_saluki-v3_default-${version}.px4
     cp ${script_dir}/build/ssrc_saluki-v3_default/ssrc_saluki-v3_default_kernel.elf ${dest_dir}/ssrc_saluki-v3_default_kernel-${version}.elf
-    json_output+="\"filename\":\"ssrc_saluki-v3_default-${version}.px4\"}"
+    json_output+="\"filename\":\"ssrc_saluki-v3_default-${version}.px4\","
+    px4_build_time=$(grep px4_build_time ${script_dir}/build/ssrc_saluki-v3_default/src/lib/version/build_git_version.h|awk '{print $3}')
+    json_output+="\"px4_build_time\":\"${px4_build_time}\"}"
     ;;
   "saluki-v3_amp")
     $build_cmd_fw ssrc_saluki-v3_amp
     cp ${script_dir}/build/ssrc_saluki-v3_amp/ssrc_saluki-v3_amp.px4 ${dest_dir}/ssrc_saluki-v3_amp-${version}.px4
     cp ${script_dir}/build/ssrc_saluki-v3_amp/ssrc_saluki-v3_amp_kernel.elf ${dest_dir}/ssrc_saluki-v3_amp_kernel-${version}.elf
-    json_output+="\"filename\":\"ssrc_saluki-v3_amp-${version}.px4\"}"
+    json_output+="\"filename\":\"ssrc_saluki-v3_amp-${version}.px4\","
+    px4_build_time=$(grep px4_build_time ${script_dir}/build/ssrc_saluki-v3_amp/src/lib/version/build_git_version.h|awk '{print $3}')
+    json_output+="\"px4_build_time\":\"${px4_build_time}\"}"
     ;;
   "saluki-v3_flat")
     $build_cmd_fw ssrc_saluki-v3_flat
     cp ${script_dir}/build/ssrc_saluki-v3_flat/ssrc_saluki-v3_flat.px4 ${dest_dir}/ssrc_saluki-v3_flat-${version}.px4
     cp ${script_dir}/build/ssrc_saluki-v3_flat/ssrc_saluki-v3_flat.elf ${dest_dir}/ssrc_saluki-v3_flat-${version}.elf
-    json_output+="\"filename\":\"ssrc_saluki-v3_flat-${version}.px4\"}"
+    json_output+="\"filename\":\"ssrc_saluki-v3_flat-${version}.px4\","
+    px4_build_time=$(grep px4_build_time ${script_dir}/build/ssrc_saluki-v3_flat/src/lib/version/build_git_version.h|awk '{print $3}')
+    json_output+="\"px4_build_time\":\"${px4_build_time}\"}"
     ;;
   "saluki-v3_custom_keys")
     # on custom keys case we build _default target but SIGNING_ARGS env variable is set above in build_cmd_fw
     $build_cmd_fw ssrc_saluki-v3_default
     cp ${script_dir}/build/ssrc_saluki-v3_default/ssrc_saluki-v3_default.px4 ${dest_dir}/ssrc_saluki-v3_custom_keys-${version}.px4
     cp ${script_dir}/build/ssrc_saluki-v3_default/ssrc_saluki-v3_default_kernel.elf ${dest_dir}/ssrc_saluki-v3_custom_keys_kernel-${version}.elf
-    json_output+="\"filename\":\"ssrc_saluki-v3_custom_keys-${version}.px4\"}"
+    json_output+="\"filename\":\"ssrc_saluki-v3_custom_keys-${version}.px4\","
+    px4_build_time=$(grep px4_build_time ${script_dir}/build/ssrc_saluki-v3_default/src/lib/version/build_git_version.h|awk '{print $3}')
+    json_output+="\"px4_build_time\":\"${px4_build_time}\"}"
     ;;
   "saluki-pi_default")
     $build_cmd_fw ssrc_saluki-pi_default
     cp ${script_dir}/build/ssrc_saluki-pi_default/ssrc_saluki-pi_default.px4 ${dest_dir}/ssrc_saluki-pi_default-${version}.px4
     cp ${script_dir}/build/ssrc_saluki-pi_default/ssrc_saluki-pi_default_kernel.elf ${dest_dir}/ssrc_saluki-pi_default_kernel-${version}.elf
-    json_output+="\"filename\":\"ssrc_saluki-pi_default-${version}.px4\"}"
+    json_output+="\"filename\":\"ssrc_saluki-pi_default-${version}.px4\","
+    px4_build_time=$(grep px4_build_time ${script_dir}/build/ssrc_saluki-pi_default/src/lib/version/build_git_version.h|awk '{print $3}')
+    json_output+="\"px4_build_time\":\"${px4_build_time}\"}"
     ;;
   "saluki-pi_amp")
     $build_cmd_fw ssrc_saluki-pi_amp
     cp ${script_dir}/build/ssrc_saluki-pi_amp/ssrc_saluki-pi_amp.px4 ${dest_dir}/ssrc_saluki-pi_amp-${version}.px4
     cp ${script_dir}/build/ssrc_saluki-pi_amp/ssrc_saluki-pi_amp_kernel.elf ${dest_dir}/ssrc_saluki-pi_amp_kernel-${version}.elf
-    json_output+="\"filename\":\"ssrc_saluki-pi_amp-${version}.px4\"}"
+    json_output+="\"filename\":\"ssrc_saluki-pi_amp-${version}.px4\","
+    px4_build_time=$(grep px4_build_time ${script_dir}/build/ssrc_saluki-pi_amp/src/lib/version/build_git_version.h|awk '{print $3}')
+    json_output+="\"px4_build_time\":\"${px4_build_time}\"}"
     ;;
   "saluki-pi_flat")
     $build_cmd_fw ssrc_saluki-pi_flat
     cp ${script_dir}/build/ssrc_saluki-pi_flat/ssrc_saluki-pi_flat.px4 ${dest_dir}/ssrc_saluki-pi_flat-${version}.px4
     cp ${script_dir}/build/ssrc_saluki-pi_flat/ssrc_saluki-pi_flat.elf ${dest_dir}/ssrc_saluki-pi_flat-${version}.elf
-    json_output+="\"filename\":\"ssrc_saluki-pi_flat-${version}.px4\"}"
+    json_output+="\"filename\":\"ssrc_saluki-pi_flat-${version}.px4\","
+    px4_build_time=$(grep px4_build_time ${script_dir}/build/ssrc_saluki-pi_flat/src/lib/version/build_git_version.h|awk '{print $3}')
+    json_output+="\"px4_build_time\":\"${px4_build_time}\"}"
     ;;
   "saluki-pi_custom_keys")
     # on custom keys case we build _default target but SIGNING_ARGS env variable is set above in build_cmd_fw
     $build_cmd_fw ssrc_saluki-pi_default
     cp ${script_dir}/build/ssrc_saluki-pi_default/ssrc_saluki-pi_default.px4 ${dest_dir}/ssrc_saluki-pi_custom_keys-${version}.px4
     cp ${script_dir}/build/ssrc_saluki-pi_default/ssrc_saluki-pi_default_kernel.elf ${dest_dir}/ssrc_saluki-pi_custom_keys_kernel-${version}.elf
-    json_output+="\"filename\":\"ssrc_saluki-pi_custom_keys-${version}.px4\"}"
+    json_output+="\"filename\":\"ssrc_saluki-pi_custom_keys-${version}.px4\","
+    px4_build_time=$(grep px4_build_time ${script_dir}/build/ssrc_saluki-pi_default/src/lib/version/build_git_version.h|awk '{print $3}')
+    json_output+="\"px4_build_time\":\"${px4_build_time}\"}"
     ;;
   "saluki-nxp93_flat")
     $build_cmd_fw ssrc_saluki-nxp93_flat
     cp ${script_dir}/build/ssrc_saluki-nxp93_flat/ssrc_saluki-nxp93_flat.px4 ${dest_dir}/ssrc_saluki-nxp93_flat-${version}.px4
     cp ${script_dir}/build/ssrc_saluki-nxp93_flat/ssrc_saluki-nxp93_flat.elf ${dest_dir}/ssrc_saluki-nxp93_flat-${version}.elf
-    json_output+="\"filename\":\"ssrc_saluki-nxp93_flat-${version}.px4\"}"
+    json_output+="\"filename\":\"ssrc_saluki-nxp93_flat-${version}.px4\","
+    px4_build_time=$(grep px4_build_time ${script_dir}/build/ssrc_saluki-nxp93_flat/src/lib/version/build_git_version.h|awk '{print $3}')
+    json_output+="\"px4_build_time\":\"${px4_build_time}\"}"
     ;;
   *)
     usage

--- a/build.sh
+++ b/build.sh
@@ -13,12 +13,15 @@ usage() {
   echo "     saluki-v2_default"
   echo "     saluki-v2_amp"
   echo "     saluki-v2_flat"
+  echo "     saluki-v2_custom_keys"
   echo "     saluki-pi_default"
   echo "     saluki-pi_amp"
   echo "     saluki-pi_flat"
+  echo "     saluki-pi_custom_keys"
   echo "     saluki-v3_default"
   echo "     saluki-v3_amp"
   echo "     saluki-v3_flat"
+  echo "     saluki-v3_custom_keys"
   echo "     saluki-nxp93_flat"
   echo
   exit 1
@@ -56,128 +59,48 @@ fi
 json_output="{\"type\":\"px4-firmware\",\
               \"hw\":\"${target}\","
 case $target in
-  "px4fwupdater")
+  px4fwupdater)
     $build_cmd_px4fwupdater
     ;;
-  "pixhawk")
+  pixhawk)
     $build_cmd_fw px4_fmu-v5x_ssrc
     cp ${script_dir}/build/px4_fmu-v5x_ssrc/px4_fmu-v5x_ssrc.px4 ${dest_dir}/px4_fmu-v5x_ssrc-${version}.px4
     ;;
-  "fmu-v6xrt")
+  fmu-v6xrt)
     $build_cmd_fw px4_fmu-v6xrt_bootloader
     $build_cmd_fw px4_fmu-v6xrt_ssrc
     cp ${script_dir}/build/px4_fmu-v6xrt_bootloader/px4_fmu-v6xrt_bootloader.elf ${dest_dir}/px4_fmu-v6xrt_bootloader-${version}.elf
     cp ${script_dir}/build/px4_fmu-v6xrt_ssrc/px4_fmu-v6xrt_ssrc.px4 ${dest_dir}/px4_fmu-v6xrt_ssrc-${version}.px4
     ;;
-  "saluki-v1_default")
-    $build_cmd_fw ssrc_saluki-v1_default
-    cp ${script_dir}/build/ssrc_saluki-v1_default/ssrc_saluki-v1_default.px4 ${dest_dir}/ssrc_saluki-v1_default-${version}.px4
-    ;;
-  "saluki-v2_default")
-    $build_cmd_fw ssrc_saluki-v2_default
-    cp ${script_dir}/build/ssrc_saluki-v2_default/ssrc_saluki-v2_default.px4 ${dest_dir}/ssrc_saluki-v2_default-${version}.px4
-    cp ${script_dir}/build/ssrc_saluki-v2_default/ssrc_saluki-v2_default_kernel.elf ${dest_dir}/ssrc_saluki-v2_default_kernel-${version}.elf
-    json_output+="\"filename\":\"ssrc_saluki-v2_default-${version}.px4\","
-    px4_build_time=$(grep px4_build_time ${script_dir}/build/ssrc_saluki-v2_default/src/lib/version/build_git_version.h|awk '{print $3}')
+  # on custom keys case we build _default target but SIGNING_ARGS env variable is set above in build_cmd_fw
+  *_custom_keys)
+    #set build target to match the output name of the targe
+    build_target="ssrc_${target}"
+    # as the targets has to be built with default names, we need to have separate env target name for build scripts
+    build_target_env=$(echo ${build_target}|sed 's/custom_keys/default/g')
+
+    $build_cmd_fw ${build_target_env}
+    cp ${script_dir}/build/${build_target_env}/${build_target_env}.px4 ${dest_dir}/${build_target}-${version}.px4
+    cp ${script_dir}/build/${build_target_env}/${build_target_env}_kernel.elf ${dest_dir}/${build_target}_kernel-${version}.elf
+    json_output+="\"filename\":\"${build_target}-${version}.px4\","
+    px4_build_time=$(grep PX4_BUILD_TIME ${script_dir}/build/${build_target_env}/src/lib/version/build_git_version.h|awk '{print $3}')
     json_output+="\"px4_build_time\":\"${px4_build_time}\"}"
     ;;
-  "saluki-v2_amp")
-    $build_cmd_fw ssrc_saluki-v2_amp
-    cp ${script_dir}/build/ssrc_saluki-v2_amp/ssrc_saluki-v2_amp.bin ${dest_dir}/ssrc_saluki-v2_amp-${version}.bin
-    cp ${script_dir}/build/ssrc_saluki-v2_amp/ssrc_saluki-v2_amp_kernel.elf ${dest_dir}/ssrc_saluki-v2_amp_kernel-${version}.elf
-    json_output+="\"filename\":\"ssrc_saluki-v2_amp-${version}.bin\","
-    px4_build_time=$(grep px4_build_time ${script_dir}/build/ssrc_saluki-v2_amp/src/lib/version/build_git_version.h|awk '{print $3}')
-    json_output+="\"px4_build_time\":\"${px4_build_time}\"}"
-    ;;
-  "saluki-v2_flat")
-    $build_cmd_fw ssrc_saluki-v2_flat
-    cp ${script_dir}/build/ssrc_saluki-v2_flat/ssrc_saluki-v2_flat.px4 ${dest_dir}/ssrc_saluki-v2_flat-${version}.px4
-    cp ${script_dir}/build/ssrc_saluki-v2_flat/ssrc_saluki-v2_flat.elf ${dest_dir}/ssrc_saluki-v2_flat-${version}.elf
-    json_output+="\"filename\":\"ssrc_saluki-v2_flat-${version}.px4\","
-    px4_build_time=$(grep px4_build_time ${script_dir}/build/ssrc_saluki-v2_flat/src/lib/version/build_git_version.h|awk '{print $3}')
-    json_output+="\"px4_build_time\":\"${px4_build_time}\"}"
-    ;;
-  "saluki-v2_custom_keys")
-    # on custom keys case we build _default target but SIGNING_ARGS env variable is set above in build_cmd_fw
-    $build_cmd_fw ssrc_saluki-v2_default
-    cp ${script_dir}/build/ssrc_saluki-v2_default/ssrc_saluki-v2_default.px4 ${dest_dir}/ssrc_saluki-v2_custom_keys-${version}.px4
-    cp ${script_dir}/build/ssrc_saluki-v2_default/ssrc_saluki-v2_default_kernel.elf ${dest_dir}/ssrc_saluki-v2_custom_keys_kernel-${version}.elf
-    json_output+="\"filename\":\"ssrc_saluki-v2_custom_keys-${version}.px4\","
-    px4_build_time=$(grep px4_build_time ${script_dir}/build/ssrc_saluki-v2_default/src/lib/version/build_git_version.h|awk '{print $3}')
-    json_output+="\"px4_build_time\":\"${px4_build_time}\"}"
-    ;;
-  "saluki-v3_default")
-    $build_cmd_fw ssrc_saluki-v3_default
-    cp ${script_dir}/build/ssrc_saluki-v3_default/ssrc_saluki-v3_default.px4 ${dest_dir}/ssrc_saluki-v3_default-${version}.px4
-    cp ${script_dir}/build/ssrc_saluki-v3_default/ssrc_saluki-v3_default_kernel.elf ${dest_dir}/ssrc_saluki-v3_default_kernel-${version}.elf
-    json_output+="\"filename\":\"ssrc_saluki-v3_default-${version}.px4\","
-    px4_build_time=$(grep px4_build_time ${script_dir}/build/ssrc_saluki-v3_default/src/lib/version/build_git_version.h|awk '{print $3}')
-    json_output+="\"px4_build_time\":\"${px4_build_time}\"}"
-    ;;
-  "saluki-v3_amp")
-    $build_cmd_fw ssrc_saluki-v3_amp
-    cp ${script_dir}/build/ssrc_saluki-v3_amp/ssrc_saluki-v3_amp.px4 ${dest_dir}/ssrc_saluki-v3_amp-${version}.px4
-    cp ${script_dir}/build/ssrc_saluki-v3_amp/ssrc_saluki-v3_amp_kernel.elf ${dest_dir}/ssrc_saluki-v3_amp_kernel-${version}.elf
-    json_output+="\"filename\":\"ssrc_saluki-v3_amp-${version}.px4\","
-    px4_build_time=$(grep px4_build_time ${script_dir}/build/ssrc_saluki-v3_amp/src/lib/version/build_git_version.h|awk '{print $3}')
-    json_output+="\"px4_build_time\":\"${px4_build_time}\"}"
-    ;;
-  "saluki-v3_flat")
-    $build_cmd_fw ssrc_saluki-v3_flat
-    cp ${script_dir}/build/ssrc_saluki-v3_flat/ssrc_saluki-v3_flat.px4 ${dest_dir}/ssrc_saluki-v3_flat-${version}.px4
-    cp ${script_dir}/build/ssrc_saluki-v3_flat/ssrc_saluki-v3_flat.elf ${dest_dir}/ssrc_saluki-v3_flat-${version}.elf
-    json_output+="\"filename\":\"ssrc_saluki-v3_flat-${version}.px4\","
-    px4_build_time=$(grep px4_build_time ${script_dir}/build/ssrc_saluki-v3_flat/src/lib/version/build_git_version.h|awk '{print $3}')
-    json_output+="\"px4_build_time\":\"${px4_build_time}\"}"
-    ;;
-  "saluki-v3_custom_keys")
-    # on custom keys case we build _default target but SIGNING_ARGS env variable is set above in build_cmd_fw
-    $build_cmd_fw ssrc_saluki-v3_default
-    cp ${script_dir}/build/ssrc_saluki-v3_default/ssrc_saluki-v3_default.px4 ${dest_dir}/ssrc_saluki-v3_custom_keys-${version}.px4
-    cp ${script_dir}/build/ssrc_saluki-v3_default/ssrc_saluki-v3_default_kernel.elf ${dest_dir}/ssrc_saluki-v3_custom_keys_kernel-${version}.elf
-    json_output+="\"filename\":\"ssrc_saluki-v3_custom_keys-${version}.px4\","
-    px4_build_time=$(grep px4_build_time ${script_dir}/build/ssrc_saluki-v3_default/src/lib/version/build_git_version.h|awk '{print $3}')
-    json_output+="\"px4_build_time\":\"${px4_build_time}\"}"
-    ;;
-  "saluki-pi_default")
-    $build_cmd_fw ssrc_saluki-pi_default
-    cp ${script_dir}/build/ssrc_saluki-pi_default/ssrc_saluki-pi_default.px4 ${dest_dir}/ssrc_saluki-pi_default-${version}.px4
-    cp ${script_dir}/build/ssrc_saluki-pi_default/ssrc_saluki-pi_default_kernel.elf ${dest_dir}/ssrc_saluki-pi_default_kernel-${version}.elf
-    json_output+="\"filename\":\"ssrc_saluki-pi_default-${version}.px4\","
-    px4_build_time=$(grep px4_build_time ${script_dir}/build/ssrc_saluki-pi_default/src/lib/version/build_git_version.h|awk '{print $3}')
-    json_output+="\"px4_build_time\":\"${px4_build_time}\"}"
-    ;;
-  "saluki-pi_amp")
-    $build_cmd_fw ssrc_saluki-pi_amp
-    cp ${script_dir}/build/ssrc_saluki-pi_amp/ssrc_saluki-pi_amp.px4 ${dest_dir}/ssrc_saluki-pi_amp-${version}.px4
-    cp ${script_dir}/build/ssrc_saluki-pi_amp/ssrc_saluki-pi_amp_kernel.elf ${dest_dir}/ssrc_saluki-pi_amp_kernel-${version}.elf
-    json_output+="\"filename\":\"ssrc_saluki-pi_amp-${version}.px4\","
-    px4_build_time=$(grep px4_build_time ${script_dir}/build/ssrc_saluki-pi_amp/src/lib/version/build_git_version.h|awk '{print $3}')
-    json_output+="\"px4_build_time\":\"${px4_build_time}\"}"
-    ;;
-  "saluki-pi_flat")
-    $build_cmd_fw ssrc_saluki-pi_flat
-    cp ${script_dir}/build/ssrc_saluki-pi_flat/ssrc_saluki-pi_flat.px4 ${dest_dir}/ssrc_saluki-pi_flat-${version}.px4
-    cp ${script_dir}/build/ssrc_saluki-pi_flat/ssrc_saluki-pi_flat.elf ${dest_dir}/ssrc_saluki-pi_flat-${version}.elf
-    json_output+="\"filename\":\"ssrc_saluki-pi_flat-${version}.px4\","
-    px4_build_time=$(grep px4_build_time ${script_dir}/build/ssrc_saluki-pi_flat/src/lib/version/build_git_version.h|awk '{print $3}')
-    json_output+="\"px4_build_time\":\"${px4_build_time}\"}"
-    ;;
-  "saluki-pi_custom_keys")
-    # on custom keys case we build _default target but SIGNING_ARGS env variable is set above in build_cmd_fw
-    $build_cmd_fw ssrc_saluki-pi_default
-    cp ${script_dir}/build/ssrc_saluki-pi_default/ssrc_saluki-pi_default.px4 ${dest_dir}/ssrc_saluki-pi_custom_keys-${version}.px4
-    cp ${script_dir}/build/ssrc_saluki-pi_default/ssrc_saluki-pi_default_kernel.elf ${dest_dir}/ssrc_saluki-pi_custom_keys_kernel-${version}.elf
-    json_output+="\"filename\":\"ssrc_saluki-pi_custom_keys-${version}.px4\","
-    px4_build_time=$(grep px4_build_time ${script_dir}/build/ssrc_saluki-pi_default/src/lib/version/build_git_version.h|awk '{print $3}')
-    json_output+="\"px4_build_time\":\"${px4_build_time}\"}"
-    ;;
-  "saluki-nxp93_flat")
-    $build_cmd_fw ssrc_saluki-nxp93_flat
-    cp ${script_dir}/build/ssrc_saluki-nxp93_flat/ssrc_saluki-nxp93_flat.px4 ${dest_dir}/ssrc_saluki-nxp93_flat-${version}.px4
-    cp ${script_dir}/build/ssrc_saluki-nxp93_flat/ssrc_saluki-nxp93_flat.elf ${dest_dir}/ssrc_saluki-nxp93_flat-${version}.elf
-    json_output+="\"filename\":\"ssrc_saluki-nxp93_flat-${version}.px4\","
-    px4_build_time=$(grep px4_build_time ${script_dir}/build/ssrc_saluki-nxp93_flat/src/lib/version/build_git_version.h|awk '{print $3}')
+  # handle all normal ssrc targets
+  saluki-*)
+    build_target="ssrc_${target}"
+    $build_cmd_fw ${build_target}
+
+    elf_target=${build_target}_kernel.elf
+    # in flat builds kernel.elf has a different name
+    if [[ ${build_target} == *flat ]]; then
+      elf_target=${build_target}.elf
+    fi
+
+    cp ${script_dir}/build/${build_target}/${build_target}.px4 ${dest_dir}/${build_target}-${version}.px4
+    cp ${script_dir}/build/${build_target}/${elf_target} ${dest_dir}/${build_target}_kernel-${version}.elf
+    json_output+="\"filename\":\"${build_target}-${version}.px4\","
+    px4_build_time=$(grep PX4_BUILD_TIME ${script_dir}/build/${build_target}/src/lib/version/build_git_version.h|awk '{print $3}')
     json_output+="\"px4_build_time\":\"${px4_build_time}\"}"
     ;;
   *)

--- a/src/lib/version/px_update_git_header.py
+++ b/src/lib/version/px_update_git_header.py
@@ -107,6 +107,9 @@ if tag_or_branch is None:
     if not tag_or_branch.startswith('release-'):
         tag_or_branch = 'master'
 
+# build timestamp in epoch format
+build_timestamp = subprocess.check_output('date -u +%s'.split(),
+                                          stderr=subprocess.STDOUT).decode('utf-8').strip()
 header += f"""
 #define PX4_GIT_VERSION_STR "{git_version}"
 #define PX4_GIT_VERSION_BINARY 0x{git_version_short}
@@ -116,6 +119,7 @@ header += f"""
 #define PX4_GIT_OEM_VERSION_STR  "{oem_tag}"
 
 #define PX4_GIT_TAG_OR_BRANCH_NAME "{tag_or_branch}" // special variable: git tag, release or master branch
+#define PX4_BUILD_TIME {build_timestamp}
 """
 
 

--- a/src/lib/version/version.c
+++ b/src/lib/version/version.c
@@ -247,6 +247,11 @@ const char *px4_firmware_git_branch(void)
 	return PX4_GIT_BRANCH_NAME;
 }
 
+time_t px4_build_timestamp(void)
+{
+	return PX4_BUILD_TIME;
+}
+
 uint32_t px4_board_version(void)
 {
 #if defined(__PX4_NUTTX)

--- a/src/lib/version/version.h
+++ b/src/lib/version/version.h
@@ -185,6 +185,11 @@ __EXPORT const char *px4_firmware_version_string(void);
 __EXPORT const char *px4_firmware_git_branch(void);
 
 /**
+ * get the epoch timestamp when the build was compiled
+ */
+__EXPORT time_t px4_build_timestamp(void);
+
+/**
  * Firmware version in binary form (first part of the git tag)
  */
 __EXPORT uint64_t px4_firmware_version_binary(void);

--- a/src/systemcmds/ver/ver.cpp
+++ b/src/systemcmds/ver/ver.cpp
@@ -234,9 +234,9 @@ extern "C" __EXPORT int ver_main(int argc, char *argv[])
 			}
 
 			if (show_all || !strncmp(argv[1], sz_ver_bdate_str, sizeof(sz_ver_bdate_str))) {
-				PX4_INFO_RAW("Build datetime: %s %s\n", __DATE__, __TIME__);
+				time_t timestamp = px4_build_timestamp();
+				PX4_INFO_RAW("Build date: %s\n", asctime(gmtime(&timestamp)));
 				ret = 0;
-
 			}
 
 			if (show_all || !strncmp(argv[1], sz_ver_buri_str, sizeof(sz_ver_buri_str))) {


### PR DESCRIPTION
- include build time to generated build_git_version.h. This is done to get the build timestamp to docker container saluki_file_info.json file and it will match to px4 version library. It can then be used to ota update to know if the image is newer or older. 
- Also to reduce container size changed the px4 container so it doesn't have python anymore as it is not needed.
- build.sh had 14 almost equal switch cases so that is now redone to be more generic