### PR TITLE
remove extra line feed in ver all

### DIFF
--- a/src/systemcmds/ver/ver.cpp
+++ b/src/systemcmds/ver/ver.cpp
@@ -235,7 +235,7 @@ extern "C" __EXPORT int ver_main(int argc, char *argv[])
 
 			if (show_all || !strncmp(argv[1], sz_ver_bdate_str, sizeof(sz_ver_bdate_str))) {
 				time_t timestamp = px4_build_timestamp();
-				PX4_INFO_RAW("Build date: %s\n", asctime(gmtime(&timestamp)));
+				PX4_INFO_RAW("Build date: %s", asctime(gmtime(&timestamp)));
 				ret = 0;
 			}
 


### PR DESCRIPTION
Testing reported there is an extra line feed in ver all command:
```
OS version: Release 12.2.1 (201458175)
OS git-hash: d493bcdf064c25b0d145a5bd88f3a2af4cd8dd9f
Build date: Tue Jun  4 04:54:59 2024

Build uri: localhost
Build variant: default
```
appeared when timestamp was changed for ota update