### PR TITLE
build/bin: Remove nsh from the final ROMFS

### DIFF
--- a/platforms/nuttx/CMakeLists.txt
+++ b/platforms/nuttx/CMakeLists.txt
@@ -254,7 +254,7 @@ if (CONFIG_BUILD_KERNEL)
 
 	# Create the initial boot ROMFS (which contains nsh)
 	add_custom_target(boot_bins
-		COMMAND cp ${PX4_BINARY_DIR}/bin/nsh ${PX4_BINARY_DIR}/init
+		COMMAND mv ${PX4_BINARY_DIR}/bin/nsh ${PX4_BINARY_DIR}/init
 		COMMAND install -D ${PX4_BINARY_DIR}/init -t ${PX4_BINARY_DIR}/boot
 		COMMAND rm -f ${PX4_BINARY_DIR}/init
 		DEPENDS nuttx_app_bins


### PR DESCRIPTION
nsh is the init process, which resides in sbin/init. The user should not have rights to execute nsh.
