### PR TITLE
Increase max uorbs

### DIFF
--- a/Tools/msg/templates/uorb/msg.cpp.em
+++ b/Tools/msg/templates/uorb/msg.cpp.em
@@ -77,7 +77,7 @@ topic_fields = ["%s %s" % (convert_type(field.type, True), field.name) for field
 constexpr char __orb_@(name_snake_case)_fields[] = "@( ";".join(topic_fields) );";
 
 @[for topic in topics]@
-ORB_DEFINE(@topic, struct @uorb_struct, @(struct_size-padding_end_size), __orb_@(name_snake_case)_fields, static_cast<uint8_t>(ORB_ID::@topic));
+ORB_DEFINE(@topic, struct @uorb_struct, @(struct_size-padding_end_size), __orb_@(name_snake_case)_fields, static_cast<orb_id_size_t>(ORB_ID::@topic));
 @[end for]
 
 void print_message(const orb_metadata *meta, const @uorb_struct& message)

--- a/Tools/msg/templates/uorb/uORBTopics.cpp.em
+++ b/Tools/msg/templates/uorb/uORBTopics.cpp.em
@@ -76,5 +76,5 @@ const struct orb_metadata *get_orb_meta(ORB_ID id)
 		return nullptr;
 	}
 
-	return uorb_topics_list[static_cast<uint8_t>(id)];
+	return uorb_topics_list[static_cast<orb_id_size_t>(id)];
 }

--- a/Tools/msg/templates/uorb/uORBTopics.hpp.em
+++ b/Tools/msg/templates/uorb/uORBTopics.hpp.em
@@ -62,7 +62,7 @@ static constexpr size_t orb_topics_count() { return ORB_TOPICS_COUNT; }
  */
 extern const struct orb_metadata *const *orb_get_topics() __EXPORT;
 
-enum class ORB_ID : uint8_t {
+enum class ORB_ID : orb_id_size_t {
 @[for idx, topic_name in enumerate(topic_names_all)]@
 	@(topic_name) = @(idx),
 @[end for]

--- a/platforms/common/uORB/uORB.h
+++ b/platforms/common/uORB/uORB.h
@@ -42,16 +42,17 @@
 #include <stdint.h>
 #include <stdbool.h>
 
+typedef uint16_t orb_id_size_t;
 
 /**
  * Object metadata.
  */
 struct orb_metadata {
-	const char *o_name;		/**< unique object name */
-	const uint16_t o_size;		/**< object size */
-	const uint16_t o_size_no_padding;	/**< object size w/o padding at the end (for logger) */
-	const char *o_fields;		/**< semicolon separated list of fields (with type) */
-	uint8_t o_id;			/**< ORB_ID enum */
+	const char    *o_name;              /**< unique object name */
+	const uint16_t o_size;              /**< object size */
+	const uint16_t o_size_no_padding;   /**< object size w/o padding at the end (for logger) */
+	const char    *o_fields;            /**< semicolon separated list of fields (with type) */
+	orb_id_size_t  o_id;                /**< ORB_ID enum */
 };
 
 typedef const struct orb_metadata *orb_id_t;

--- a/platforms/common/uORB/uORBDeviceNode.cpp
+++ b/platforms/common/uORB/uORBDeviceNode.cpp
@@ -643,7 +643,7 @@ uORB::DeviceNode::publish(const orb_metadata *meta, orb_advert_t &handle, const 
 	}
 
 	/* check if the orb meta data matches the publication */
-	if (static_cast<uint8_t>(devnode->id()) != meta->o_id) {
+	if (static_cast<orb_id_size_t>(devnode->id()) != meta->o_id) {
 		errno = EINVAL;
 		return PX4_ERROR;
 	}

--- a/platforms/common/uORB/uORBManager.hpp
+++ b/platforms/common/uORB/uORBManager.hpp
@@ -399,7 +399,7 @@ public:
 
 	static bool has_publisher(ORB_ID orb_id, uint8_t instance)
 	{
-		return (get_instance()->g_has_publisher[static_cast<uint8_t>(orb_id)] & (1 << instance)) != 0;
+		return (get_instance()->g_has_publisher[static_cast<orb_id_size_t>(orb_id)] & (1 << instance)) != 0;
 	}
 
 #ifdef CONFIG_ORB_COMMUNICATOR
@@ -600,13 +600,13 @@ private: //class methods
 	void set_has_publisher(ORB_ID orb_id, uint8_t instance)
 	{
 		static_assert(sizeof(g_has_publisher[0]) * 8 >= ORB_MULTI_MAX_INSTANCES);
-		g_has_publisher[static_cast<uint8_t>(orb_id)] |= (1 << instance);
+		g_has_publisher[static_cast<orb_id_size_t>(orb_id)] |= (1 << instance);
 	}
 
 	void unset_has_publisher(ORB_ID orb_id, uint8_t instance)
 	{
 		static_assert(sizeof(g_has_publisher[0]) * 8 >= ORB_MULTI_MAX_INSTANCES);
-		g_has_publisher[static_cast<uint8_t>(orb_id)] &= ~(1 << instance);
+		g_has_publisher[static_cast<orb_id_size_t>(orb_id)] &= ~(1 << instance);
 	}
 
 	// Global cache for advertised uORB node instances

--- a/src/modules/logger/logged_topics.h
+++ b/src/modules/logger/logged_topics.h
@@ -88,7 +88,7 @@ public:
 		RequestedSubscription sub[MAX_TOPICS_NUM];
 		int count{0};
 
-		uint8_t excluded_optional_topic_ids[MAX_EXCLUDED_OPTIONAL_TOPICS_NUM];
+		orb_id_size_t excluded_optional_topic_ids[MAX_EXCLUDED_OPTIONAL_TOPICS_NUM];
 		int num_excluded_optional_topic_ids{0};
 	};
 

--- a/src/modules/logger/logger.h
+++ b/src/modules/logger/logger.h
@@ -390,7 +390,7 @@ private:
 	uint16_t 					_event_sequence_offset{0}; ///< event sequence offset to account for skipped (not logged) messages
 	uint16_t 					_event_sequence_offset_mission{0};
 
-	uint8_t						_excluded_optional_topic_ids[LoggedTopics::MAX_EXCLUDED_OPTIONAL_TOPICS_NUM];
+	orb_id_size_t  					_excluded_optional_topic_ids[LoggedTopics::MAX_EXCLUDED_OPTIONAL_TOPICS_NUM];
 	int						_num_excluded_optional_topic_ids{0};
 
 	LogWriter					_writer;

--- a/src/modules/uxrce_dds_client/dds_topics.h.em
+++ b/src/modules/uxrce_dds_client/dds_topics.h.em
@@ -132,7 +132,7 @@ static void on_topic_update(uxrSession *session, uxrObjectId object_id, uint16_t
 
 	switch (object_id.id) {
 @[    for idx, sub in enumerate(subscriptions)]@
-	case @(idx)+1000: {
+	case @(idx)+ (65535U / 32U) + 1: {
 			@(sub['simple_base_type'])_s data;
 
 			if (ucdr_deserialize_@(sub['simple_base_type'])(*ub, data, time_offset_us)) {

--- a/src/modules/uxrce_dds_client/utilities.hpp
+++ b/src/modules/uxrce_dds_client/utilities.hpp
@@ -10,8 +10,16 @@
 
 uxrObjectId topic_id_from_orb(ORB_ID orb_id, uint8_t instance = 0)
 {
-	if (orb_id != ORB_ID::INVALID) {
-		uint16_t id = static_cast<uint8_t>(orb_id) + (instance * UINT8_MAX);
+	// Note that the uxrObjectId.id is a uint16_t so we need to cap the ID.
+	// orb_id_size_t is currently uint16_t (MAX = 65535) and a max # of instances as either 4 or 10.
+	// We want to use half of the available id's for writers and half for readers,
+	// so this works as long as orb_id < 3276.
+	// Unfortunately, limits does not appear to be available. So hard-coding for uint16_t.
+	if (orb_id != ORB_ID::INVALID &&
+	    //(orb_id_size_t) orb_id < (std::numeric_limits<orb_id_size_t> / (2*ORB_MULTI_MAX_INSTANCES) )
+	    (orb_id_size_t) orb_id < (65535U / (2U * (uint16_t)ORB_MULTI_MAX_INSTANCES))
+	   ) {
+		uint16_t id = static_cast<orb_id_size_t>(orb_id) + (instance * ORB_TOPICS_COUNT);
 		uxrObjectId topic_id = uxr_object_id(id, UXR_TOPIC_ID);
 		return topic_id;
 	}
@@ -110,8 +118,9 @@ static bool create_data_reader(uxrSession *session, uxrStreamId reliable_out_str
 		return false;
 	}
 
-	uint16_t id = index + 1000;
-
+	// Use the second half of the available ID space.
+	// Add 1 so that we get a nice hex starting number: 0x8000 instead of 0x7fff.
+	uint16_t id = index + (65535U / 2U) + 1;
 
 	uxrObjectId topic_id = uxr_object_id(id, UXR_TOPIC_ID);
 	uint16_t topic_req = uxr_buffer_create_topic_bin(session, reliable_out_stream_id, topic_id, participant_id, topic_name,

--- a/src/modules/uxrce_dds_client/utilities.hpp
+++ b/src/modules/uxrce_dds_client/utilities.hpp
@@ -10,17 +10,13 @@
 
 uxrObjectId topic_id_from_orb(ORB_ID orb_id, uint8_t instance = 0)
 {
-	// Note that the uxrObjectId.id is a uint16_t so we need to cap the ID.
-	// orb_id_size_t is currently uint16_t (MAX = 65535) and a max # of instances as either 4 or 10.
-	// We want to use half of the available id's for writers and half for readers,
-	// so this works as long as orb_id < 3276.
-	// Unfortunately, limits does not appear to be available. So hard-coding for uint16_t.
-	if (orb_id != ORB_ID::INVALID &&
-	    //(orb_id_size_t) orb_id < (std::numeric_limits<orb_id_size_t> / (2*ORB_MULTI_MAX_INSTANCES) )
-	    (orb_id_size_t) orb_id < (65535U / (2U * (uint16_t)ORB_MULTI_MAX_INSTANCES))
-	   ) {
-		uint16_t id = static_cast<orb_id_size_t>(orb_id) + (instance * ORB_TOPICS_COUNT);
-		uxrObjectId topic_id = uxr_object_id(id, UXR_TOPIC_ID);
+	// Note that the uxrObjectId.id is a uint16_t so we need to cap the ID,
+	// and urx does not allow us to use the upper 4 bits.
+	const unsigned max_id = 65535U / 32U;
+	const unsigned id = static_cast<unsigned>(orb_id) + (instance * ORB_TOPICS_COUNT);
+
+	if (orb_id != ORB_ID::INVALID && id < max_id) {
+		uxrObjectId topic_id = uxr_object_id(static_cast<uint16_t>(id), UXR_TOPIC_ID);
 		return topic_id;
 	}
 
@@ -119,8 +115,8 @@ static bool create_data_reader(uxrSession *session, uxrStreamId reliable_out_str
 	}
 
 	// Use the second half of the available ID space.
-	// Add 1 so that we get a nice hex starting number: 0x8000 instead of 0x7fff.
-	uint16_t id = index + (65535U / 2U) + 1;
+	// Add 1 so that we get a nice hex starting number: 0x800 instead of 0x7ff.
+	uint16_t id = index + (65535U / 32U) + 1;
 
 	uxrObjectId topic_id = uxr_object_id(id, UXR_TOPIC_ID);
 	uint16_t topic_req = uxr_buffer_create_topic_bin(session, reliable_out_stream_id, topic_id, participant_id, topic_name,


### PR DESCRIPTION
These are cherry-picks from PX4 mainline, with some modifications to uORB (as we have an own version of that library).

The change is needed in order to support more than 255 uORB ID:s. We are very close to the limit, and currently it is not possbile to add new ones - which is needed by our own development (e.g. redundancy topics) and most likely by the customer as well.