### PR TITLE
uxrce: add actuator_armed and estimator_gps_status topic publishers

### DIFF
--- a/src/modules/uxrce_dds_client/dds_topics.yaml
+++ b/src/modules/uxrce_dds_client/dds_topics.yaml
@@ -67,6 +67,12 @@ publications:
   - topic: /fmu/out/home_position
     type: px4_msgs::msg::HomePosition
 
+  - topic: /fmu/out/actuator_armed
+    type: px4_msgs::msg::ActuatorArmed
+
+  - topic: /fmu/out/estimator_gps_status
+    type: px4_msgs::msg::EstimatorGpsStatus
+
 subscriptions:
 
   - topic: /fmu/in/offboard_control_mode


### PR DESCRIPTION
## Changelog:

Add following topics to microxrce publishers. Both topics are low frequency, shouldn't add much load. If the usage gets problematic, we can drop `EstimatorGpsStatus` as it is only used for the diagnostic view.

- ActuatorArmed -> used for determining the kill switch status from `manual_lockdown` flag
- EstimatorGpsStatus -> used for gps diagnostics. Using `checks_passed` and `check_fail_gps_fix`.