### PR TITLE
fix device serial number reading on user side

### DIFF
--- a/platforms/nuttx/src/px4/common/usr_mcu_version.cpp
+++ b/platforms/nuttx/src/px4/common/usr_mcu_version.cpp
@@ -203,7 +203,7 @@ int board_determine_hw_info(void)
 	orb_copy(ORB_ID(guid), guid_sub, &guid);
 	orb_unsubscribe(guid_sub);
 
-	memcpy(device_serial_number, &guid, min(sizeof(device_serial_number), sizeof(guid)));
+	memcpy(device_serial_number, guid.mfguid, min(sizeof(device_serial_number), sizeof(guid.mfguid)));
 
 	return 0;
 }


### PR DESCRIPTION
Matching change exists already on mpfs, this was probably accidentally not updated