### PR TITLE
Add HITL support for fw, vtol and rover

### DIFF
--- a/ROMFS/px4fmu_common/init.d-posix/airframes/4404_gz_ssrc_standard_vtol
+++ b/ROMFS/px4fmu_common/init.d-posix/airframes/4404_gz_ssrc_standard_vtol
@@ -82,7 +82,6 @@ param set-default CA_SV_CS1_TRQ_R 0.5
 param set-default CA_SV_CS2_TYPE 3
 param set-default CA_SV_CS2_TRQ_P 1.0
 
-param set-default FW_L1_PERIOD 12
 param set-default FW_PR_FF 0.2
 param set-default FW_PR_P 0.9
 param set-default FW_PSP_OFF 2

--- a/ROMFS/px4fmu_common/init.d-posix/airframes/4430_gz_ssrc_strivermini
+++ b/ROMFS/px4fmu_common/init.d-posix/airframes/4430_gz_ssrc_strivermini
@@ -24,7 +24,12 @@ PX4_GZ_WORLD=${PX4_GZ_WORLD:=default}
 PX4_SIM_MODEL=${PX4_SIM_MODEL:=strivermini}
 
 param set-default SIM_GZ_EN 1
-param set-default SIM_GZ_RUN_GZSIM 0
+param set-default SIM_GZ_SHOME 1
+if [ "$PX4_RUN_GZSIM" = "0" ]; then
+  param set-default SIM_GZ_RUN_GZSIM 0
+else
+  param set-default SIM_GZ_RUN_GZSIM 1
+fi
 
 param set-default SENS_EN_GPSSIM 1
 param set-default SENS_EN_BAROSIM 1
@@ -142,7 +147,7 @@ param set-default VT_F_TRANS_DUR 6.0
 param set-default VT_F_TRANS_THR 1.0
 
 # VTOL takeoff
-param set-default VTO_LOITER_ALT 20
+param set-default VTO_LOITER_ALT 20.0
 
 param set-default MC_AIRMODE 0
 param set-default MC_ROLLRATE_P 0.14

--- a/ROMFS/px4fmu_common/init.d/airframes/4400_ssrc_fog_x
+++ b/ROMFS/px4fmu_common/init.d/airframes/4400_ssrc_fog_x
@@ -49,12 +49,6 @@ param set-default PWM_MAIN_MIN2 1050
 param set-default PWM_MAIN_MIN3 1050
 param set-default PWM_MAIN_MIN4 1050
 
-# HITL PWM functions
-param set-default HIL_ACT_FUNC1 101
-param set-default HIL_ACT_FUNC2 102
-param set-default HIL_ACT_FUNC3 103
-param set-default HIL_ACT_FUNC4 104
-
 # UAVCAN_EC functions
 param set-default UAVCAN_EC_FUNC1 101
 param set-default UAVCAN_EC_FUNC2 102

--- a/src/modules/mavlink/mavlink_receiver.cpp
+++ b/src/modules/mavlink/mavlink_receiver.cpp
@@ -40,7 +40,6 @@
  * @author Thomas Gubler <thomas@px4.io>
  */
 
-#include <lib/airspeed/airspeed.h>
 #include <lib/conversion/rotation.h>
 #include <lib/systemlib/px4_macros.h>
 
@@ -2660,15 +2659,6 @@ MavlinkReceiver::handle_message_hil_state_quaternion(mavlink_message_t *msg)
 
 	const double dt = math::constrain((timestamp_sample - _hil_timestamp_prev) * 1e-6, 0.001, 0.1);
 	_hil_timestamp_prev = timestamp_sample;
-
-	/* airspeed */
-	airspeed_s airspeed{};
-	airspeed.timestamp_sample = timestamp_sample;
-	airspeed.indicated_airspeed_m_s = hil_state.ind_airspeed * 1e-2f;
-	airspeed.true_airspeed_m_s = hil_state.true_airspeed * 1e-2f;
-	airspeed.air_temperature_celsius = 15.f;
-	airspeed.timestamp = hrt_absolute_time();
-	_airspeed_pub.publish(airspeed);
 
 	/* Receive attitude quaternion from gz-sim and publish vehicle attitude
 	 * groundtruth and angular velocity ground truth

--- a/src/modules/mavlink/mavlink_receiver.h
+++ b/src/modules/mavlink/mavlink_receiver.h
@@ -62,7 +62,6 @@
 #include <uORB/SubscriptionInterval.hpp>
 #include <uORB/topics/actuator_armed.h>
 #include <uORB/topics/actuator_outputs.h>
-#include <uORB/topics/airspeed.h>
 #include <uORB/topics/autotune_attitude_control_status.h>
 #include <uORB/topics/battery_status.h>
 #include <uORB/topics/camera_status.h>
@@ -288,7 +287,6 @@ private:
 	uint16_t _mavlink_status_last_packet_rx_drop_count{0};
 
 	// ORB publications
-	uORB::Publication<airspeed_s>				_airspeed_pub{ORB_ID(airspeed)};
 	uORB::Publication<battery_status_s>			_battery_pub{ORB_ID(battery_status)};
 	uORB::Publication<camera_status_s>			_camera_status_pub{ORB_ID(camera_status)};
 	uORB::Publication<cellular_status_s>			_cellular_status_pub{ORB_ID(cellular_status)};

--- a/src/modules/simulation/pwm_out_sim/PWMSim.hpp
+++ b/src/modules/simulation/pwm_out_sim/PWMSim.hpp
@@ -76,10 +76,9 @@ public:
 private:
 	void Run() override;
 
-	static constexpr uint16_t PWM_SIM_DISARMED_MAGIC = 900;
-	static constexpr uint16_t PWM_SIM_FAILSAFE_MAGIC = 600;
-	static constexpr uint16_t PWM_SIM_PWM_MIN_MAGIC = 1000;
-	static constexpr uint16_t PWM_SIM_PWM_MAX_MAGIC = 2000;
+	int32_t _pwm_min[MAX_ACTUATORS] {};
+	int32_t _pwm_max[MAX_ACTUATORS] {};
+	int32_t _pwm_disarmed[MAX_ACTUATORS] {};
 
 	MixingOutput _mixing_output{PARAM_PREFIX, MAX_ACTUATORS, *this, MixingOutput::SchedulingPolicy::Auto, false, false};
 	uORB::SubscriptionInterval _parameter_update_sub{ORB_ID(parameter_update), 1_s};

--- a/src/modules/simulation/pwm_out_sim/module_hil.yaml
+++ b/src/modules/simulation/pwm_out_sim/module_hil.yaml
@@ -5,4 +5,9 @@ actuator_output:
   output_groups:
     - param_prefix: HIL_ACT
       channel_label: Channel
+      standard_params:
+        disarmed: { min: 0, max: 1000, default: 0 }
+        min: { min: 0, max: 1000, default: 0 }
+        max: { min: 0, max: 1000, default: 1000 }
+        failsafe: { min: 0, max: 1000 }
       num_channels: 16

--- a/src/modules/simulation/sensor_airspeed_sim/SensorAirspeedSim.cpp
+++ b/src/modules/simulation/sensor_airspeed_sim/SensorAirspeedSim.cpp
@@ -195,7 +195,7 @@ int SensorAirspeedSim::print_usage(const char *reason)
 
 )DESCR_STR");
 
-	PRINT_MODULE_USAGE_NAME("sensor_arispeed_sim", "system");
+	PRINT_MODULE_USAGE_NAME("sensor_airspeed_sim", "system");
 	PRINT_MODULE_USAGE_COMMAND("start");
 	PRINT_MODULE_USAGE_DEFAULT_COMMANDS();
 

--- a/src/modules/simulation/sensor_airspeed_sim/SensorAirspeedSim.hpp
+++ b/src/modules/simulation/sensor_airspeed_sim/SensorAirspeedSim.hpp
@@ -82,7 +82,7 @@ private:
 	matrix::Vector3f noiseGauss3f(float stdx, float stdy, float stdz) { return matrix::Vector3f(generate_wgn() * stdx, generate_wgn() * stdy, generate_wgn() * stdz); }
 
 	uORB::SubscriptionInterval _parameter_update_sub{ORB_ID(parameter_update), 1_s};
-	uORB::Subscription _vehicle_attitude_sub{ORB_ID(vehicle_attitude)};
+	uORB::Subscription _vehicle_attitude_sub{ORB_ID(vehicle_attitude_groundtruth)};
 	uORB::Subscription _vehicle_global_position_sub{ORB_ID(vehicle_global_position_groundtruth)};
 	uORB::Subscription _vehicle_local_position_sub{ORB_ID(vehicle_local_position_groundtruth)};
 

--- a/ssrc_config/config_hitl_eth_gzsim.txt
+++ b/ssrc_config/config_hitl_eth_gzsim.txt
@@ -1,4 +1,5 @@
 # Default parameter set for HITL with ethernet Gazebo Sim connection (partly derived from indoor flying parameters)
+# Currently this is used for FC only HITL with ssrc holybro x500 airframe
 # [ type: hitl_eth_gzsim ]
 
 #####################################

--- a/ssrc_config/config_hitl_eth_gzsim_fw.txt
+++ b/ssrc_config/config_hitl_eth_gzsim_fw.txt
@@ -1,0 +1,107 @@
+# Default parameter set for HITL with ethernet Gazebo Sim connection on Skywalker X8 FW
+# [ type: hitl_eth_gzsim ]
+
+param set SYS_AUTOSTART 4421
+param set SYS_AUTOCONFIG 0
+
+####################################
+# general HITL configuration
+####################################
+
+# Set HITL related flag
+param set SYS_HITL 1
+param set MAV_HITL_SHOME 1
+param set SENS_EN_GPSSIM 1
+param set SENS_EN_BAROSIM 1
+param set SENS_EN_MAGSIM 1
+param set SENS_EN_ARSPDSIM 1
+
+# Disable safety switch
+param set COM_PREARM_MODE 0
+param set CBRK_IO_SAFETY 22027
+
+# Disable RC loss failsafe check
+param set NAV_RCL_ACT 0
+
+# Disable RC input requirement
+param set COM_RC_IN_MODE 1
+
+# EKF2
+param set EKF2_MULTI_IMU 1
+
+####################################
+# specific fw HITL configuration
+####################################
+
+# Override airframe defaults
+param set ASPD_DO_CHECKS 7
+param set FW_LAUN_DETCN_ON 0
+
+# HITL PWM functions
+param set HIL_ACT_FUNC1 201
+param set HIL_ACT_DIS1 500
+param set HIL_ACT_FUNC2 202
+param set HIL_ACT_DIS2 500
+param set HIL_ACT_FUNC4 101
+param set HIL_ACT_MIN4 150
+param set HIL_ACT_MAX4 3000
+
+# Control allocator parameters
+param set CA_AIRFRAME 1
+param set CA_ROTOR_COUNT 1
+param set CA_SV_CS_COUNT 2
+param set CA_SV_CS0_TYPE 5
+param set CA_SV_CS0_TRQ_P 0.5
+param set CA_SV_CS0_TRQ_R -0.5
+param set CA_SV_CS1_TYPE 6
+param set CA_SV_CS1_TRQ_P 0.5
+param set CA_SV_CS1_TRQ_R 0.5
+
+# Airspeed parameters
+param set ASPD_PRIMARY 1
+
+# Maximum landing slope angle in deg
+param set FW_LND_ANG 8.0
+
+# RC loss failsafe to HOLD mode
+param set COM_RC_IN_MODE 1
+
+# Maximum manual roll angle
+param set FW_MAN_R_MAX 60.0
+
+# Fixed wing control
+# Pitch rate
+param set FW_PR_P 0.9
+param set FW_PR_FF 0.5
+param set FW_PR_I 0.5
+param set TRIM_PITCH -0.15
+# Pitch angle in deg
+param set FW_PSP_OFF 0.0
+param set FW_P_LIM_MIN -15.0
+# Roll rate
+param set FW_RR_FF 0.5
+param set FW_RR_P 0.3
+param set FW_RR_I 0.5
+# Yaw rate
+param set FW_YR_FF 0.5
+param set FW_YR_P 0.6
+param set FW_YR_I 0.5
+#Throttle limit
+param set FW_THR_MAX 0.6
+param set FW_THR_MIN 0.05
+param set FW_THR_TRIM 0.25
+# Climb and sink rate
+param set FW_T_CLMB_MAX 8.0
+param set FW_T_SINK_MAX 2.7
+param set FW_T_SINK_MIN 2.2
+
+# Navigation
+param set NAV_ACC_RAD 15.0
+param set NAV_DLL_ACT 2
+
+# Misc
+param set RTL_RETURN_ALT 30.0
+param set RTL_DESCEND_ALT 30.0
+param set FW_LND_USETER 0
+param set RWTO_TKOFF 1
+param set FD_ESCS_EN 0

--- a/ssrc_config/config_hitl_eth_gzsim_mc.txt
+++ b/ssrc_config/config_hitl_eth_gzsim_mc.txt
@@ -1,0 +1,72 @@
+# Default parameter set for HITL with ethernet Gazebo Sim connection on Holybro X500 MC
+# [ type: hitl_eth_gzsim ]
+
+param set SYS_AUTOSTART 4400
+param set SYS_AUTOCONFIG 0
+
+####################################
+# general HITL configuration
+####################################
+
+# Set HITL related flag
+param set SYS_HITL 1
+param set MAV_HITL_SHOME 1
+param set SENS_EN_GPSSIM 1
+param set SENS_EN_BAROSIM 1
+param set SENS_EN_MAGSIM 1
+
+# Disable safety switch
+param set COM_PREARM_MODE 0
+param set CBRK_IO_SAFETY 22027
+
+# Disable RC loss failsafe check
+param set NAV_RCL_ACT 0
+
+# Disable RC input requirement
+param set COM_RC_IN_MODE 1
+
+# EKF2
+param set EKF2_MULTI_IMU 1
+
+####################################
+# specific mc HITL configuration
+####################################
+
+# HITL PWM functions
+param set-default HIL_ACT_FUNC1 101
+param set-default HIL_ACT_FUNC2 102
+param set-default HIL_ACT_FUNC3 103
+param set-default HIL_ACT_FUNC4 104
+
+param set-default CA_ROTOR0_PX 0.175
+param set-default CA_ROTOR0_PY 0.175
+param set-default CA_ROTOR0_KM  0.05
+
+param set-default CA_ROTOR1_PX -0.175
+param set-default CA_ROTOR1_PY -0.175
+param set-default CA_ROTOR1_KM  0.05
+
+param set-default CA_ROTOR2_PX 0.175
+param set-default CA_ROTOR2_PY -0.175
+param set-default CA_ROTOR2_KM -0.05
+
+param set-default CA_ROTOR3_PX -0.175
+param set-default CA_ROTOR3_PY 0.175
+param set-default CA_ROTOR3_KM -0.05
+
+# extra
+param set-default MPC_THR_HOVER 0.60
+param set COM_RCL_EXCEPT 4
+param set NAV_DLL_ACT 0
+param set NAV_RCL_ACT 0
+param set MAV_0_BROADCAST 1
+param set IMU_GYRO_CUTOFF 60
+param set IMU_DGYRO_CUTOFF 30
+param set MC_ROLLRATE_P 0.14
+param set MC_PITCHRATE_P 0.14
+param set MC_ROLLRATE_I 0.3
+param set MC_PITCHRATE_I 0.3
+param set MC_ROLLRATE_D 0.004
+param set MC_PITCHRATE_D 0.004
+param set BAT_N_CELLS 4
+param set SDLOG_MODE 0

--- a/ssrc_config/config_hitl_eth_gzsim_rover.txt
+++ b/ssrc_config/config_hitl_eth_gzsim_rover.txt
@@ -1,0 +1,83 @@
+# Default parameter set for HITL with ethernet Gazebo Sim connection on scout mini rover
+# [ type: hitl_eth_gzsim ]
+
+param set SYS_AUTOSTART 50005
+param set SYS_AUTOCONFIG 0
+
+####################################
+# general HITL configuration
+####################################
+
+# Set HITL related flag
+param set SYS_HITL 1
+param set MAV_HITL_SHOME 1
+param set SENS_EN_GPSSIM 1
+param set SENS_EN_BAROSIM 1
+param set SENS_EN_MAGSIM 1
+
+# Disable safety switch
+param set COM_PREARM_MODE 0
+param set CBRK_IO_SAFETY 22027
+
+# Disable RC loss failsafe check
+param set NAV_RCL_ACT 0
+
+# Disable RC input requirement
+param set COM_RC_IN_MODE 1
+
+# EKF2
+param set EKF2_MULTI_IMU 1
+
+####################################
+# specific rover HITL configuration
+####################################
+
+param set IMU_GYRO_CUTOFF 60.0
+param set IMU_DGYRO_CUTOFF 30.0
+
+param set SYS_HAS_BARO 0
+
+param set BAT1_N_CELLS 4
+
+param set MIS_TAKEOFF_ALT 0.01
+
+param set NAV_ACC_RAD 0.5     # reached when within 0.5m of waypoint
+
+# Enable Airspeed check circuit breaker because Rovers will have no airspeed sensor
+param set CBRK_AIRSPD_CHK 162128
+
+# EKF2
+param set EKF2_GBIAS_INIT 0.01
+param set EKF2_ANGERR_INIT 0.01
+param set EKF2_MAG_TYPE 1
+param set EKF2_REQ_SACC 1.0
+param set EKF2_REQ_VDRIFT 0.4
+param set EKF2_REQ_HDRIFT 0.2
+
+
+# Rover Position Control Module
+param set GND_SP_CTRL_MODE 1
+param set GND_L1_DIST 5.0
+param set GND_L1_PERIOD 3.0
+param set GND_THR_CRUISE 1.0
+param set GND_THR_MAX 1.0
+
+# Because this is differential drive, it can make a turn with radius 0.
+# This corresponds to a turn angle of pi radians.
+# If a special case is made for differential-drive, this will need to change.
+param set GND_MAX_ANG 3.142
+param set GND_WHEEL_BASE 0.45
+
+# TODO: Set to -1.0, to allow reversing. This will require many changes in the codebase
+# to support negative throttle.
+param set GND_THR_MIN 0.0
+param set GND_SPEED_P 0.4
+param set GND_SPEED_I 1.0
+param set GND_SPEED_D 0.001
+param set GND_SPEED_MAX 3.0
+param set GND_SPEED_TRIM 3.0
+param set GND_SPEED_THR_SC 1.0
+param set GND_VEL_CTRL 1
+param set GND_ANG_VEL_CTRL 1
+param set GND_ACC_LIMIT 10.0
+param set GND_DEC_LIMIT 50.0

--- a/ssrc_config/config_hitl_eth_gzsim_vtol_sm.txt
+++ b/ssrc_config/config_hitl_eth_gzsim_vtol_sm.txt
@@ -1,0 +1,176 @@
+# Default parameter set for HITL with ethernet Gazebo Sim connection on Striver Mini VTOL
+# [ type: hitl_eth_gzsim ]
+
+param set SYS_AUTOSTART 4430
+param set SYS_AUTOCONFIG 0
+
+####################################
+# general HITL configuration
+####################################
+
+# Set HITL related flag
+param set SYS_HITL 1
+param set MAV_HITL_SHOME 1
+param set SENS_EN_GPSSIM 1
+param set SENS_EN_BAROSIM 1
+param set SENS_EN_MAGSIM 1
+param set SENS_EN_ARSPDSIM 1
+
+# Disable safety switch
+param set COM_PREARM_MODE 0
+param set CBRK_IO_SAFETY 22027
+
+# Disable RC loss failsafe check
+param set NAV_RCL_ACT 0
+
+# Disable RC input requirement
+param set COM_RC_IN_MODE 1
+
+# EKF2
+param set EKF2_MULTI_IMU 1
+
+####################################
+# specific vtol HITL configuration
+####################################
+
+# HITL PWM functions
+param set HIL_ACT_FUNC1 101
+param set HIL_ACT_MIN1 10
+param set HIL_ACT_MAX1 1500
+param set HIL_ACT_FUNC2 102
+param set HIL_ACT_MIN2 10
+param set HIL_ACT_MAX2 1500
+param set HIL_ACT_FUNC3 103
+param set HIL_ACT_MIN3 10
+param set HIL_ACT_MAX3 1500
+param set HIL_ACT_FUNC4 104
+param set HIL_ACT_MIN4 10
+param set HIL_ACT_MAX4 1500
+param set HIL_ACT_FUNC5 201
+param set HIL_ACT_DIS5 500
+param set HIL_ACT_FUNC6 202
+param set HIL_ACT_DIS6 500
+param set HIL_ACT_FUNC7 203
+param set HIL_ACT_DIS7 500
+param set HIL_ACT_FUNC8 204
+param set HIL_ACT_DIS8 500
+param set HIL_ACT_FUNC9 205
+param set HIL_ACT_DIS9 500
+param set HIL_ACT_FUNC10 105
+param set HIL_ACT_MIN10 0
+param set HIL_ACT_MAX10 3500
+
+# Control allocator parameters
+param set CA_AIRFRAME 2
+param set CA_ROTOR_COUNT 5
+param set CA_ROTOR0_PX 0.37
+param set CA_ROTOR0_PY 0.42
+param set CA_ROTOR1_PX -0.41
+param set CA_ROTOR1_PY -0.42
+param set CA_ROTOR2_PX 0.37
+param set CA_ROTOR2_PY -0.42
+param set CA_ROTOR2_KM -0.05
+param set CA_ROTOR3_PX -0.41
+param set CA_ROTOR3_PY 0.42
+param set CA_ROTOR3_KM -0.05
+param set CA_ROTOR4_AX 1.0
+param set CA_ROTOR4_AZ 0.0
+param set CA_ROTOR4_PX 0.0
+param set CA_ROTOR4_KM 0.05
+
+param set CA_SV_CS_COUNT 5
+param set CA_SV_CS0_TYPE 1
+param set CA_SV_CS0_TRQ_R -0.5
+param set CA_SV_CS1_TYPE 2
+param set CA_SV_CS1_TRQ_R 0.5
+param set CA_SV_CS2_TYPE 3
+param set CA_SV_CS2_TRQ_P 1.0
+param set CA_SV_CS2_TRIM 0.1
+param set CA_SV_CS3_TYPE 3
+param set CA_SV_CS3_TRQ_P 1.0
+param set CA_SV_CS3_TRIM 0.1
+param set CA_SV_CS4_TYPE 4
+param set CA_SV_CS4_TRQ_Y 1.0
+
+# Fixed wing specific
+param set FW_RR_IMAX 0.4000
+param set FW_YR_IMAX 0.4000
+
+param set FW_YR_P 0.2
+param set FW_YR_I 0.01
+
+param set FW_RR_FF 0.5
+param set FW_RR_P 0.05
+param set FW_RR_I 0.1
+param set FW_RR_IMAX 0.4
+
+param set FW_R_LIM 50.0
+param set FW_R_RMAX 70.0
+param set FW_R_TC 0.4
+
+param set FW_PR_FF 0.5
+param set FW_PR_I 0.1
+param set FW_PR_IMAX 0.4
+
+param set FW_P_LIM_MAX 30.0
+param set FW_P_LIM_MIN -30.0
+
+# Airspeed parameters
+param set ASPD_PRIMARY 1
+param set FW_AIRSPD_MAX 25.0
+param set FW_AIRSPD_MIN 15.0
+param set FW_AIRSPD_STALL 12.0
+param set FW_AIRSPD_TRIM 18.0
+
+# VTOL specific
+# VTOL type
+param set VT_TYPE 2
+
+# Airspeed at which we can start blending both fw and mc controls.
+param set VT_ARSP_BLEND 8.0
+
+# Airspeed at which we can switch to fw mode
+param set VT_ARSP_TRANS 14.0
+
+# Back-transition duration
+param set VT_B_TRANS_DUR 10.0
+param set VT_B_TRANS_RAMP 3.0
+
+# Transition duration
+param set VT_F_TRANS_DUR 6.0
+param set VT_F_TRANS_THR 1.0
+
+# VTOL takeoff
+param set MIS_TAKEOFF_ALT 10.0
+param set VTO_LOITER_ALT 10.0
+
+param set MC_AIRMODE 0
+param set MC_ROLLRATE_P 0.14
+param set MC_ROLLRATE_I 0.2
+param set MC_PITCHRATE_P 0.14
+param set MC_PITCHRATE_I 0.2
+param set MC_YAW_P 2.0
+param set MC_YAW_WEIGHT 0.5
+param set MC_YAWRATE_P 0.2
+param set MC_YAWRATE_I 0.1
+param set MC_YAWRATE_MAX 120.0
+
+param set MPC_XY_P 0.95
+param set MPC_XY_VEL_P_ACC 1.8
+param set MPC_XY_VEL_I_ACC 0.4
+param set MPC_XY_VEL_D_ACC 0.2
+param set MPC_YAW_MODE 4
+
+param set NAV_ACC_RAD 10.0
+
+# QuadChute altitude (transition to quad mode as a failsafe)
+param set VT_FW_MIN_ALT 5.0
+
+# QuadChute angle limits
+param set VT_FW_QC_P 35
+param set VT_FW_QC_R 60
+
+# Others
+param set FD_ACT_EN 0
+param set FD_ACT_MOT_TOUT 500
+param set FD_ESCS_EN 0

--- a/ssrc_config/config_hitl_eth_gzsim_vtol_sv.txt
+++ b/ssrc_config/config_hitl_eth_gzsim_vtol_sv.txt
@@ -1,0 +1,120 @@
+# Default parameter set for HITL with ethernet Gazebo Sim connection on standard VTOL
+# [ type: hitl_eth_gzsim ]
+
+param set SYS_AUTOSTART 13000
+param set SYS_AUTOCONFIG 0
+
+####################################
+# general HITL configuration
+####################################
+
+# Set HITL related flag
+param set SYS_HITL 1
+param set MAV_HITL_SHOME 1
+param set SENS_EN_GPSSIM 1
+param set SENS_EN_BAROSIM 1
+param set SENS_EN_MAGSIM 1
+param set SENS_EN_ARSPDSIM 1
+
+# Disable safety switch
+param set COM_PREARM_MODE 0
+param set CBRK_IO_SAFETY 22027
+
+# Disable RC loss failsafe check
+param set NAV_RCL_ACT 0
+
+# Disable RC input requirement
+param set COM_RC_IN_MODE 1
+
+# EKF2
+param set EKF2_MULTI_IMU 1
+
+####################################
+# specific vtol HITL configuration
+####################################
+
+# HITL PWM functions
+param set HIL_ACT_FUNC1 101
+param set HIL_ACT_MIN1 10
+param set HIL_ACT_MAX1 1500
+param set HIL_ACT_FUNC2 102
+param set HIL_ACT_MIN2 10
+param set HIL_ACT_MAX2 1500
+param set HIL_ACT_FUNC3 103
+param set HIL_ACT_MIN3 10
+param set HIL_ACT_MAX3 1500
+param set HIL_ACT_FUNC4 104
+param set HIL_ACT_MIN4 10
+param set HIL_ACT_MAX4 1500
+param set HIL_ACT_FUNC5 105
+param set HIL_ACT_MIN5 0
+param set HIL_ACT_MAX5 3500
+param set HIL_ACT_FUNC6 201
+param set HIL_ACT_DIS6 500
+param set HIL_ACT_FUNC7 202
+param set HIL_ACT_DIS7 500
+param set HIL_ACT_FUNC8 203
+param set HIL_ACT_DIS8 500
+
+
+# Control allocator parameters
+param set CA_ROTOR_COUNT 5
+param set CA_ROTOR0_PX 0.1515
+param set CA_ROTOR0_PY 0.245
+param set CA_ROTOR0_KM 0.05
+param set CA_ROTOR1_PX -0.1515
+param set CA_ROTOR1_PY -0.1875
+param set CA_ROTOR1_KM 0.05
+param set CA_ROTOR2_PX 0.1515
+param set CA_ROTOR2_PY -0.245
+param set CA_ROTOR2_KM -0.05
+param set CA_ROTOR3_PX -0.1515
+param set CA_ROTOR3_PY 0.1875
+param set CA_ROTOR3_KM -0.05
+param set CA_ROTOR4_AX 1.0
+param set CA_ROTOR4_AZ 0.0
+param set CA_ROTOR4_PX 0.2
+
+param set CA_SV_CS_COUNT 3
+param set CA_SV_CS0_TYPE 1
+param set CA_SV_CS0_TRQ_R -0.5
+param set CA_SV_CS1_TYPE 2
+param set CA_SV_CS1_TRQ_R 0.5
+param set CA_SV_CS2_TYPE 3
+param set CA_SV_CS2_TRQ_P 1.0
+param set CA_SV_CS3_TRQ_Y 0.0
+param set CA_SV_CS3_TYPE 0
+
+# Airspeed parameters
+param set ASPD_PRIMARY 1
+
+param set FW_PR_FF 0.2
+param set FW_PR_P 0.9
+param set FW_PSP_OFF 2.0
+param set FW_P_LIM_MIN -15.0
+param set FW_RR_FF 0.1
+param set FW_RR_P 0.3
+param set FW_THR_TRIM 0.25
+param set FW_THR_MAX 0.6
+param set FW_THR_MIN 0.05
+param set FW_T_CLMB_MAX 8.0
+param set FW_T_SINK_MAX 2.7
+param set FW_T_SINK_MIN 2.2
+
+param set MC_AIRMODE 1
+param set MC_ROLLRATE_P 0.3
+param set MC_YAW_P 1.6
+
+param set MIS_TAKEOFF_ALT 10.0
+
+param set MPC_XY_P 0.8
+param set MPC_XY_VEL_P_ACC 3.0
+param set MPC_XY_VEL_I_ACC 4.0
+param set MPC_XY_VEL_D_ACC 0.1
+
+param set NAV_ACC_RAD 5.0
+
+param set VT_FWD_THRUST_EN 4
+param set VT_F_TRANS_THR 0.75
+param set VT_TYPE 2
+param set FD_ESCS_EN 0


### PR DESCRIPTION
- Add HITL support for FW (tested with Skywalker_x8 model)
- Add HITL support for VTOL (tested with standard_vtol and striver_mini models)
- Add HITL support for Rover (tested with scout_mini model)
- Mavlink receiver: remove unused Airspeed data reception from Gz (use sensor_airspeed_sim instead)

Related PR https://github.com/tiiuae/px4-gzsim-plugins/pull/9, https://github.com/tiiuae/gz-models/pull/4