### PR TITLE
nuttx/CMakeLists: Fix rule for renaming nsh -> init

### DIFF
--- a/platforms/nuttx/CMakeLists.txt
+++ b/platforms/nuttx/CMakeLists.txt
@@ -253,12 +253,13 @@ if (CONFIG_BUILD_KERNEL)
 	list(APPEND nuttx_userlibs nuttx_crt0)
 
 	# Create the initial boot ROMFS (which contains nsh)
-	add_custom_target(boot_bins
+	add_custom_command(OUTPUT ${PX4_BINARY_DIR}/boot
 		COMMAND mv ${PX4_BINARY_DIR}/bin/nsh ${PX4_BINARY_DIR}/init
 		COMMAND install -D ${PX4_BINARY_DIR}/init -t ${PX4_BINARY_DIR}/boot
 		COMMAND rm -f ${PX4_BINARY_DIR}/init
 		DEPENDS nuttx_app_bins
 	)
+	add_custom_target(boot_bins DEPENDS ${PX4_BINARY_DIR}/boot)
 
 	make_bin_romfs(
 		BINDIR ${PX4_BINARY_DIR}/boot


### PR DESCRIPTION
Only run the rule once i.e. if boot/init does not exist

