### PR TITLE
perf counter: add support for multi-instance counters

### DIFF
--- a/src/lib/perf/perf_counter.cpp
+++ b/src/lib/perf/perf_counter.cpp
@@ -281,7 +281,7 @@ perf_free(perf_counter_t handle)
 		char shmname[PERF_SHMNAME_MAX];
 
 		/* should not fail, if object creation succeeded ? */
-		if (perf_shmname(shmname, handle->name, sizeof(shmname) >= 0)) {
+		if (perf_shmname(shmname, handle->name, sizeof(shmname)) >= 0) {
 			shm_unlink(shmname);
 		}
 


### PR DESCRIPTION
Adding multiple instance support for performance counters.

Instance number is added to shared memory filename
```
saluki> ls /var/shm
...
 _perf_bmp388: comms errors_0
 _perf_bmp388: comms errors_1
 _perf_bmp388: measure_0
 _perf_bmp388: measure_1
 _perf_bmp388: read_0
 _perf_bmp388: read_1
```

Driver status output
```
saluki> bmp388 status
INFO  [SPI_I2C] Running on I2C Bus 1, Address 0x77
chip id:  0x60 rev id:  0x01
0: bmp388: read: 1965 events, 553165us elapsed, 281.51us avg, min 263us max 417us 17.823us rms
0: bmp388: measure: 1967 events, 674518us elapsed, 342.92us avg, min 308us max 12234us 269.558us rms
0: bmp388: comms errors: 1 events
measurement interval:  43300 us 
INFO  [SPI_I2C] Running on I2C Bus 2, Address 0x76
chip id:  0x60 rev id:  0x01
1: bmp388: read: 1963 events, 557289us elapsed, 283.90us avg, min 263us max 414us 18.843us rms
1: bmp388: measure: 1965 events, 671906us elapsed, 341.94us avg, min 311us max 505us 29.296us rms
1: bmp388: comms errors: 0 events
measurement interval:  43300 us 
```

Perf command output
```
saluki> perf
...
0: bmp388: comms errors: 0 events
1: bmp388: comms errors: 0 events
0: bmp388: measure: 440 events, 150143us elapsed, 341.23us avg, min 308us max 521us 28.983us rms
1: bmp388: measure: 437 events, 150859us elapsed, 345.22us avg, min 311us max 505us 31.142us rms
0: bmp388: read: 439 events, 124787us elapsed, 284.25us avg, min 264us max 417us 20.915us rms
1: bmp388: read: 436 events, 125514us elapsed, 287.88us avg, min 266us max 414us 20.775us rms
...
```

Tested with default and flat build in FMU2.


