### PR TITLE
Fix logger crash

### DIFF
--- a/platforms/nuttx/src/px4/nxp/imx9/version/board_mcu_version.c
+++ b/platforms/nuttx/src/px4/nxp/imx9/version/board_mcu_version.c
@@ -217,9 +217,17 @@ int board_mcu_version(char *rev, const char **revstr, const char **errata)
 	unsigned len = sizeof(hw_version_table) / sizeof(hw_version_table[0]);
 
 	if (hw_version < len) {
-		*rev = hw_version_table[hw_version].rev;
-		*revstr = hw_version_table[hw_version].revstr;
-		*errata = hw_version_table[hw_version].errata;
+		if (rev) {
+			*rev = hw_version_table[hw_version].rev;
+		}
+
+		if (revstr) {
+			*revstr = hw_version_table[hw_version].revstr;
+		}
+
+		if (errata) {
+			*errata = hw_version_table[hw_version].errata;
+		}
 	}
 
 	return hw_version;


### PR DESCRIPTION
This was one of the reason for sequential crashes in "flat" builds. Logger calls the version library with null errata pointer when logging in started. This may happen also during the boot depending on the parameters.