### PR TITLE
Commander: Failsafe: set clear condition for action Land like for RTL

### DIFF
--- a/src/modules/commander/failsafe/failsafe.cpp
+++ b/src/modules/commander/failsafe/failsafe.cpp
@@ -60,6 +60,7 @@ FailsafeBase::ActionOptions Failsafe::fromNavDllOrRclActParam(int param_value)
 
 	case gcs_connection_loss_failsafe_mode::Land_mode:
 		options.action = Action::Land;
+		options.clear_condition = ClearCondition::OnModeChangeOrDisarm;
 		break;
 
 	case gcs_connection_loss_failsafe_mode::Terminate:
@@ -113,6 +114,7 @@ FailsafeBase::ActionOptions Failsafe::fromGfActParam(int param_value)
 
 	case geofence_violation_action::Land_mode:
 		options.action = Action::Land;
+		options.clear_condition = ClearCondition::OnModeChangeOrDisarm;
 		break;
 
 	default:


### PR DESCRIPTION
This PR fetches the upstream changes introduced in this PR. ([#<span></span>23569](https://github.com/PX4/PX4-Autopilot/pull/23569))

In summary:
- When there is a failsafe condition such as RC loss with Land as failsafe action, the land operation is cleared once the RC signal is regained. This is not the same with the RTL, where it doesnt get cleared out. When the land failsafe action is cleared, it goes back to user intention nav state, which is not desirable.
- This PR prevent clearing the Land failsafe if the cause has been solved. Once it switches to Land failsafe, it will finalize that action unless mode changed manually or disarmed.

**_This change should be removed during the rebasing to a newer version of PX4-firmware._**
