### PR TITLE
nuttx/Make.defs.in: Support for ARM64

### DIFF
--- a/platforms/nuttx/NuttX/Make.defs.in
+++ b/platforms/nuttx/NuttX/Make.defs.in
@@ -129,6 +129,11 @@ ifeq ($(CONFIG_ARMV7M_STACKCHECK),y)
 	FLAGS += -finstrument-functions -ffixed-r10
 endif
 
+# don't warn about attributes
+ifeq ($(CONFIG_ARCH_ARM64),y)
+	FLAGS += -Wno-attributes
+endif
+
 ARCHCFLAGS = -std=gnu11 \
 	$(FLAGS) \
 	-Wno-bad-function-cast \
@@ -183,7 +188,7 @@ define ASSEMBLE
 endef
 
 define ARCHIVE
-    $(AR) $1 $(2)
+	$(AR) $1 $(2)
 endef
 
 # ELF module definitions
@@ -198,5 +203,9 @@ LDENDGROUP   = --end-group
 LDLIBPATH = $(foreach PATH, $(USERLIBS), $(addprefix -L, $(dir $(PATH))))
 LDLIBFILES = $(foreach PATH, $(USERLIBS), $(notdir $(PATH)))
 LDLIBS = $(patsubst %.a,%,$(patsubst lib%,-l%,$(LDLIBFILES)))
-LDELFFLAGS = -r -e _start -Bstatic
+LDELFFLAGS = -e _start -Bstatic
 LDELFFLAGS += $(addprefix -T, $(ELFLDNAME))
+
+ifeq ($(CONFIG_BINFMT_ELF_RELOCATABLE),y)
+	LDELFFLAGS += -r
+endif


### PR DESCRIPTION
The aarch64 compiler does not like some attributes used by NuttX, so suppress the warning.

The flag is used in upstream as well.