### PR TITLE
mavlink: enable partner ip status print

### DIFF
--- a/src/modules/mavlink/mavlink_main.cpp
+++ b/src/modules/mavlink/mavlink_main.cpp
@@ -3042,13 +3042,11 @@ Mavlink::display_status()
 		       broadcast_enabled() ? "YES" : "NO");
 		printf("\tMulticast enabled: %s\n",
 		       multicast_enabled() ? "YES" : "NO");
-#ifdef __PX4_POSIX
 
 		if (get_client_source_initialized()) {
 			printf("\tpartner IP: %s\n", inet_ntoa(get_client_source_address().sin_addr));
 		}
 
-#endif
 		break;
 #endif // MAVLINK_UDP
 


### PR DESCRIPTION
Enable **partner IP** to be printed in mavlink status output also other than POSIX (SITL) build

Example:
```
instance #1:
        mavlink chan: #1
        type:           GENERIC LINK OR RADIO
        flow control: OFF
        rates:
          tx: 1246.4 B/s
          txerr: 0.0 B/s
          tx rate mult: 1.000
          tx rate max: 1000000 B/s
          rx: 0.0 B/s
          rx loss: 0.0%
        FTP enabled: YES, TX enabled: YES
        mode: Normal
        Forwarding: Off
        MAVLink version: 1
        transport protocol: UDP (14541, remote port: 12345)
        Broadcast enabled: NO
        Multicast enabled: NO
        partner IP: 192.168.200.100
saluki>
```