### PR TITLE
rgbled_is31fl3195: Change default I2C frequency to 400kHz

### DIFF
--- a/src/drivers/lights/rgbled_is31fl3195/rgbled_is31fl3195.cpp
+++ b/src/drivers/lights/rgbled_is31fl3195/rgbled_is31fl3195.cpp
@@ -413,7 +413,7 @@ extern "C" __EXPORT int rgbled_is31fl3195_main(int argc, char *argv[])
 	int ch;
 	using ThisDriver = RGBLED_IS31FL3195;
 	BusCLIArguments cli{true, false};
-	cli.default_i2c_frequency = 100000;
+	cli.default_i2c_frequency = 400000;
 	cli.i2c_address = ADDR;
 	cli.custom1 = 123;
 	cli.custom2 = CURRENT_BAND_CB_P5;


### PR DESCRIPTION
This enables the newer GPS stick on salukis, which don't support 100kHz i2c