### PR TITLE
Fix missing incdir tool error which came with latest NuttX

### DIFF
--- a/platforms/nuttx/cmake/init.cmake
+++ b/platforms/nuttx/cmake/init.cmake
@@ -60,6 +60,11 @@ set(NUTTX_SRC_DIR  ${PX4_SOURCE_DIR}/platforms/nuttx/NuttX)
 set(NUTTX_DIR      ${PX4_SOURCE_DIR}/platforms/nuttx/NuttX/nuttx CACHE FILEPATH "NuttX directory" FORCE)
 set(NUTTX_APPS_DIR ${PX4_SOURCE_DIR}/platforms/nuttx/NuttX/apps CACHE FILEPATH "NuttX apps directory" FORCE)
 
+execute_process(
+  COMMAND make --no-print-directory --silent tools/incdir
+  WORKING_DIRECTORY ${NUTTX_DIR}
+)
+
 px4_add_git_submodule(TARGET git_nuttx PATH "${NUTTX_SRC_DIR}/nuttx")
 px4_add_git_submodule(TARGET git_nuttx_apps PATH "${NUTTX_SRC_DIR}/apps")
 


### PR DESCRIPTION
I was not able to resolve this via any cmake dependencies, so just did this...