### PR TITLE
imx9/px4io: Cleanups

### DIFF
--- a/platforms/nuttx/src/px4/nxp/imx9/include/px4_arch/px4io_serial.h
+++ b/platforms/nuttx/src/px4/nxp/imx9/include/px4_arch/px4io_serial.h
@@ -134,6 +134,10 @@ private:
 
 	px4_sem_t		_recv_sem;
 
+	/** dma error perf counter */
+
+	perf_counter_t		_pc_dmaerrs;
+
 	/**
 	 * DMA completion handler.
 	 */


### PR DESCRIPTION
Stopping tx dma in the short packet receive seems to fix the dma handle corruption issue. I have no idea why. 

- Stop also tx dma in the interrupt / short packet receive
- No need to clear the uart errors in _stop_dma, errors are cleared in uart irq
