### PR TITLE
platforms/nuttx: Fixes to NuttX CMake rules / dependencies

### DIFF
--- a/platforms/nuttx/CMakeLists.txt
+++ b/platforms/nuttx/CMakeLists.txt
@@ -258,7 +258,7 @@ if (CONFIG_BUILD_KERNEL)
 		COMMAND mv ${PX4_BINARY_DIR}/bin/nsh ${PX4_BINARY_DIR}/init
 		COMMAND install -D ${PX4_BINARY_DIR}/init -t ${PX4_BINARY_DIR}/boot
 		COMMAND rm -f ${PX4_BINARY_DIR}/init
-		DEPENDS nuttx_app_bins
+		DEPENDS ${PX4_BINARY_DIR}/bin/nsh
 	)
 	add_custom_target(boot_bins DEPENDS ${PX4_BINARY_DIR}/boot)
 

--- a/platforms/nuttx/CMakeLists.txt
+++ b/platforms/nuttx/CMakeLists.txt
@@ -254,13 +254,13 @@ if (CONFIG_BUILD_KERNEL)
 	list(APPEND nuttx_userlibs nuttx_crt0)
 
 	# Create the initial boot ROMFS (which contains nsh)
-	add_custom_command(OUTPUT ${PX4_BINARY_DIR}/boot
+	add_custom_command(OUTPUT ${PX4_BINARY_DIR}/boot/init
 		COMMAND mv ${PX4_BINARY_DIR}/bin/nsh ${PX4_BINARY_DIR}/init
 		COMMAND install -D ${PX4_BINARY_DIR}/init -t ${PX4_BINARY_DIR}/boot
 		COMMAND rm -f ${PX4_BINARY_DIR}/init
 		DEPENDS ${PX4_BINARY_DIR}/bin/nsh
 	)
-	add_custom_target(boot_bins DEPENDS ${PX4_BINARY_DIR}/boot)
+	add_custom_target(boot_bins DEPENDS ${PX4_BINARY_DIR}/boot/init)
 
 	make_bin_romfs(
 		BINDIR ${PX4_BINARY_DIR}/boot
@@ -350,7 +350,7 @@ if (CONFIG_BUILD_KERNEL)
 		OUTPREFIX bin
 		LABEL Px4BinVol
 		STRIPPED "y"
-		DEPS nuttx_app_bins ${px4_bins}
+		DEPS nuttx_app_bins boot_bins ${px4_bins}
 	)
 
 	add_custom_command(OUTPUT ${PX4_BINARY_OUTPUT}

--- a/platforms/nuttx/NuttX/CMakeLists.txt
+++ b/platforms/nuttx/NuttX/CMakeLists.txt
@@ -276,6 +276,7 @@ if (CONFIG_BUILD_KERNEL)
 			TOPDIR="${NUTTX_DIR}"
 			ELFLDNAME="${LDSCRIPT}"
 			USERLIBS="${userlibs}" > ${CMAKE_CURRENT_BINARY_DIR}/nuttx_apps_install.log
+		BYPRODUCTS ${PX4_BINARY_DIR}/bin/nsh
 		DEPENDS ${nuttx_userlibs} nuttx_startup
 	)
 endif()

--- a/platforms/nuttx/cmake/bin_romfs.cmake
+++ b/platforms/nuttx/cmake/bin_romfs.cmake
@@ -86,7 +86,7 @@ function(make_bin_romfs)
 		# Preserve the files with debug symbols
 
 		add_custom_target(debug_${OUTPREFIX}
-			COMMAND cp -r ${BINDIR} ${BINDIR}_debug
+			COMMAND cp -r ${BINDIR}/. ${BINDIR}_debug
 			DEPENDS ${DEPS}
 		)
 


### PR DESCRIPTION
An assortment of cmake script fixes for NuttX kernel mode. The highlights are in the commit messages.