### PR TITLE
src/drivers/magnetometer/bosch/bmm350/BMM350.cpp: Publish initial 0 d…

### DIFF
--- a/src/lib/drivers/magnetometer/PX4Magnetometer.cpp
+++ b/src/lib/drivers/magnetometer/PX4Magnetometer.cpp
@@ -40,6 +40,7 @@ PX4Magnetometer::PX4Magnetometer(uint32_t device_id, enum Rotation rotation) :
 	_device_id{device_id},
 	_rotation{rotation}
 {
+	_sensor_pub.advertise();
 }
 
 PX4Magnetometer::~PX4Magnetometer()


### PR DESCRIPTION
…ata to register mags in module start order

Magnetometer numbers are allocated in the order when the first data gets published to sesors module.

It is problematic if the magnetometers get different IDs on different HW even if the start order of the drivers in the init scripts is the same.

Therefor, publish some dummy data right after successful probe of the driver
