### PR TITLE
Update mpfs toc

### DIFF
--- a/src/include/image_toc.h
+++ b/src/include/image_toc.h
@@ -51,6 +51,9 @@
 #define TOC_FLAG1_ICFG 0x40
 #define TOC_FLAG1_RDCT 0x80
 
+#define TOC_FLAG2_USE_SBI 0x1
+#define TOC_FLAG2_RELATIVE_ADRESSES 0x2
+
 #define TOC_START_MAGIC 0x00434f54 /* "TOC" */
 #define TOC_END_MAGIC 0x00444e45 /* "END" */
 


### PR DESCRIPTION
This changes the MPFS TOC to have similar structure as IMX9;

- START and END addresses are indexies to the file
- There is a separate load address into where the part of the file is loaded
- It is no longer necessary to load TOC into memory
- Removed RDCT TOC entries; these don't quite work, but fixed a small issue enabling to load RDCT from a separate file later.

The current bootloader, which has been in use for some time, supports this change already. This allows cleaning up the bootloader later, by removing some MPFS specific ifdefs.
