### PR TITLE
LoadMon.cpp: Add px4_ prefix to enter/exit_critical() calls

### DIFF
--- a/src/modules/load_mon/LoadMon.cpp
+++ b/src/modules/load_mon/LoadMon.cpp
@@ -140,18 +140,18 @@ void LoadMon::cpuload()
 #elif defined(__PX4_NUTTX)
 
 	if (_last_idle_time == 0) {
-		irqstate_t irqstate = enter_critical_section();
+		irqstate_t irqstate = px4_enter_critical_section();
 		// Just get the time in the first iteration */
 		_last_idle_time = system_load.tasks[0].total_runtime;
 		_last_idle_time_sample = system_load.tasks[0].curr_start_time;
-		leave_critical_section(irqstate);
+		px4_leave_critical_section(irqstate);
 		return;
 	}
 
-	irqstate_t irqstate = enter_critical_section();
+	irqstate_t irqstate = px4_enter_critical_section();
 	const hrt_abstime now = system_load.tasks[0].curr_start_time;
 	const hrt_abstime total_runtime = system_load.tasks[0].total_runtime;
-	leave_critical_section(irqstate);
+	px4_leave_critical_section(irqstate);
 
 	if ((now == _last_idle_time_sample) || (total_runtime == _last_idle_time)) {
 		return;


### PR DESCRIPTION
Just for consistency, use the prefix for all calls.
