### PR TITLE
px4_24xxxx_mtd.c: Fix mass erase in case device is not responding

### DIFF
--- a/platforms/nuttx/src/px4/common/px4_24xxxx_mtd.c
+++ b/platforms/nuttx/src/px4/common/px4_24xxxx_mtd.c
@@ -211,6 +211,7 @@ static int at24c_eraseall(FAR struct at24c_dev_s *priv)
 {
 	int startblock = 0;
 	uint8_t buf[AT24XX_PAGESIZE + 2];
+	int tries;
 
 	struct i2c_msg_s msgv[1] = {
 		{
@@ -235,9 +236,15 @@ static int at24c_eraseall(FAR struct at24c_dev_s *priv)
 		buf[1] = offset & 0xff;
 		buf[0] = (offset >> 8) & 0xff;
 
+		tries = 10;
+
 		while (I2C_TRANSFER(priv->dev, &msgv[0], 1) < 0) {
 			fwarn("erase stall\n");
 			px4_usleep(10000);
+
+			if (--tries == 0) {
+				return -ENODEV;
+			}
 		}
 	}
 


### PR DESCRIPTION
Return -ENODEV if the device is not responding in mass erase

This fixes device not booting in case sensor board is not attached