### PR TITLE
Adding the mavsdk docker image for tesing FC in sitl and hitl mode

### DIFF
--- a/Tools/run_docker_hitl_gzsim_mavsdk_server.sh
+++ b/Tools/run_docker_hitl_gzsim_mavsdk_server.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+
+#This script is designed to run HITL simulation and MAVSDK testing through a docker image.
+
+#usage example
+#./Tools/run_docker_hitl_gzsim_mavsdk_server.sh <docker_image> <script_and_arguments>
+
+#examples
+#To run hitl simulation
+#./Tools/run_docker_hitl_gzsim_mavsdk_server.sh local_hitl_gzsim_server ./Tools/simulation/gz/hitl_run.sh ssrc_holybro_x500/model_hitl.sdf
+#To run mavsdk testing
+#./Tools/run_docker_hitl_gzsim_mavsdk_server.sh local_hitl_gzsim_server ./test/mavsdk_tests/mavsdk_test_runner.py test/mavsdk_tests/configs/hitl_gz_harm.json --gui --case "Takeoff and Land"
+
+#command for local building the docker image
+#docker build -t local_hitl_gzsim_server -f px4-firmware/packaging/Dockerfile.hitl_gzsim_mavsdk .
+
+
+YELLOW='\033[0;33m'
+GREEN='\033[0;32m'
+RED='\033[0;31m'
+NC='\033[0m'
+
+if [ "$#" -eq 0 ]; then
+    echo -e "You should specify ${RED}a docker image${NC} and ${YELLOW}a script for running.${NC}"
+    echo -e "${GREEN}Usage example:${NC}"
+    echo -e "  ./Tools/run_docker_hitl_gzsim_mavsdk_server.sh ${RED}<docker_image>${NC} ${YELLOW}<script_and_arguments>${NC}"
+    echo
+    echo -e "${GREEN}Examples ${NC}"
+    echo -e "  1.To run hitl simulation"
+    echo -e "    ./Tools/run_docker_hitl_gzsim_mavsdk_server.sh ${RED}local_hitl_gzsim_server ${YELLOW}./Tools/simulation/gz/hitl_run.sh ssrc_holybro_x500/model_hitl.sdf${NC}"
+    echo
+    echo -e "  2.To run mavsdk testing"
+    echo -e "    ./Tools/run_docker_hitl_gzsim_mavsdk_server.sh ${RED}local_hitl_gzsim_server ${YELLOW}./test/mavsdk_tests/mavsdk_test_runner.py test/mavsdk_tests/configs/hitl_gz_harm.json --gui --case \"Takeoff and Land\"${NC}"
+    echo
+    echo -e "${GREEN}command for local building the docker image${NC}"
+    echo -e "docker build -t ${RED}local_hitl_gzsim_server${NC} -f px4-firmware/packaging/Dockerfile.hitl_gzsim_mavsdk ."
+    exit 1
+fi
+
+BASE_COMMAND=(
+    docker run -it --rm
+    --network host
+    --env DISPLAY=${DISPLAY}
+    --volume /tmp/.docker.xauth:/tmp/.docker.xauth
+    --volume /tmp/.X11-unix:/tmp/.X11-unix
+    --privileged
+)
+
+xhost si:localuser:root
+${BASE_COMMAND[@]} "$@"

--- a/packaging/Dockerfile.hitl_gzsim_mavsdk
+++ b/packaging/Dockerfile.hitl_gzsim_mavsdk
@@ -1,0 +1,91 @@
+FROM docker.io/ros:humble-ros-base as builder
+
+# Install build dependencies
+RUN apt update
+RUN DEBIAN_FRONTEND=noninteractive TZ=Etc/UTC apt install -y \
+	git \
+	curl \
+	lsb-release \
+	gnupg \
+	astyle \
+	build-essential \
+	cmake \
+	cppcheck \
+	file \
+	g++ \
+	gcc \
+	gdb \
+	git \
+	lcov \
+	libfuse2 \
+	libxml2-dev \
+	libxml2-utils \
+	make \
+	ninja-build \
+	python3 \
+	python3-dev \
+	python3-pip \
+	python3-setuptools \
+	python3-wheel \
+	rsync \
+	shellcheck \
+	unzip \
+	ros-humble-fastrtps \
+	ros-humble-rmw-fastrtps-cpp \
+	fastddsgen \
+	wget \
+	libboost-filesystem-dev
+
+RUN curl http://packages.osrfoundation.org/gazebo.key | apt-key add -
+RUN sh -c 'echo "deb http://packages.osrfoundation.org/gazebo/ubuntu-stable `lsb_release -cs` main" > /etc/apt/sources.list.d/gazebo-stable.list'
+
+RUN wget https://packages.osrfoundation.org/gazebo.gpg -O /usr/share/keyrings/pkgs-osrf-archive-keyring.gpg
+RUN echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/pkgs-osrf-archive-keyring.gpg] http://packages.osrfoundation.org/gazebo/ubuntu-stable $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/gazebo-stable.list > /dev/null
+
+RUN apt update
+RUN DEBIAN_FRONTEND=noninteractive TZ=Etc/UTC apt install -y \
+	gz-harmonic
+
+RUN wget --no-check-certificate  https://github.com/mavlink/MAVSDK/releases/download/v1.3.1/libmavsdk-dev_1.3.1_ubuntu20.04_amd64.deb && \
+dpkg -i libmavsdk-dev_1.3.1_ubuntu20.04_amd64.deb && \
+rm libmavsdk-dev_1.3.1_ubuntu20.04_amd64.deb
+
+# Copy source from host
+COPY px4-firmware px4-firmware
+RUN python3 -m pip install -r px4-firmware/Tools/setup/requirements.txt
+RUN cp px4-firmware/packaging/build_px4_hitl_gzsim_mavsdk.sh ./build.sh
+RUN ./build.sh
+
+
+FROM ghcr.io/tiiuae/gz-sim-server:sha-954fefc
+
+RUN apt update
+RUN apt install -y \
+	curl \
+	wget \
+	lsb-release \
+	gnupg \
+	python3 \
+	python3-dev \
+	python3-pip \
+	python3-setuptools \
+	python3-wheel \
+	libboost-filesystem-dev
+
+RUN wget --no-check-certificate  https://github.com/mavlink/MAVSDK/releases/download/v1.3.1/libmavsdk-dev_1.3.1_ubuntu20.04_amd64.deb && \
+dpkg -i libmavsdk-dev_1.3.1_ubuntu20.04_amd64.deb && \
+rm libmavsdk-dev_1.3.1_ubuntu20.04_amd64.deb
+
+COPY px4-firmware/packaging/entrypoint_hitl_gzsim_mavsdk.sh /px4-firmware/entrypoint.sh
+COPY px4-firmware/Tools/setup/requirements.txt /px4-firmware/Tools/setup/requirements.txt
+RUN python3 -m pip install -r /px4-firmware/Tools/setup/requirements.txt
+
+WORKDIR /px4-firmware
+
+COPY --from=builder /px4-firmware/build/px4_sitl_default /px4-firmware/build/px4_sitl_default
+COPY --from=builder /px4-firmware/test/mavsdk_tests /px4-firmware/test/mavsdk_tests
+COPY --from=builder /px4-firmware/Tools/simulation/gz /px4-firmware/Tools/simulation/gz
+
+ENTRYPOINT [ "/px4-firmware/entrypoint.sh" ]
+
+CMD [ "echo", "Available scripts for run: ./Tools/simulation/gz/hitl_run.sh and test/mavsdk_tests/mavsdk_test_runner.py" ]

--- a/packaging/build_px4_hitl_gzsim_mavsdk.sh
+++ b/packaging/build_px4_hitl_gzsim_mavsdk.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+source /opt/ros/humble/setup.sh
+
+pushd px4-firmware
+	rm -rf build
+	make clean
+	make px4_sitl_default
+	make px4_sitl mavsdk_tests
+	make px4_sitl gzsim-plugins
+popd

--- a/packaging/entrypoint_hitl_gzsim_mavsdk.sh
+++ b/packaging/entrypoint_hitl_gzsim_mavsdk.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+exec "$@"


### PR DESCRIPTION
Added Dockerfile for HITL simulation and MAVSDK testing of FC, along with a helper script for easier container usage.

- The primary target device is SalukiV2, with support for SalukiV3 in a reduced configuration (FC only).
- Successfully tested with SalukiV2.

Changes to be committed:
	new file:   Tools/run_docker_hitl_gzsim_mavsdk_server.sh
	new file:   packaging/entrypoint_hitl_gzsim_mavsdk.sh
	new file:   packaging/Dockerfile.hitl_gzsim_mavsdk
	new file:   packaging/build_px4_hitl_gzsim_mavsdk.sh


Usage:
```
./Tools/run_docker_hitl_gzsim_mavsdk_server.sh <docker_image> <script_and_arguments>

```
  Run HITL simulation:
```
./Tools/run_docker_hitl_gzsim_mavsdk_server.sh <docker_image> ./Tools/simulation/gz/hitl_run.sh ssrc_holybro_x500/model_hitl.sdf
```
  Run MAVSDK tests:
```
./Tools/run_docker_hitl_gzsim_mavsdk_server.sh <docker_image> ./test/mavsdk_tests/mavsdk_test_runner.py test/mavsdk_tests/configs/hitl_gz_harm.json --gui --case "Takeoff and Land"
```
help

![image](https://github.com/user-attachments/assets/93422d57-3e84-40a5-92cb-2710d131d56a)

