### PR TITLE
platforms/nuttx/src/px4/common/px4_24xxxx_mtd.c: Add BIOC_FLUSH

### DIFF
--- a/platforms/nuttx/src/px4/common/px4_24xxxx_mtd.c
+++ b/platforms/nuttx/src/px4/common/px4_24xxxx_mtd.c
@@ -551,6 +551,11 @@ static int at24c_ioctl(FAR struct mtd_dev_s *dev, int cmd, unsigned long arg)
 		ret = at24c_eraseall(priv);
 		break;
 
+	case BIOC_FLUSH:
+		/* bchlib has already taken care of writing the pages */
+		ret = OK;
+		break;
+
 	default:
 		ret = -ENOTTY; /* Bad command */
 		break;


### PR DESCRIPTION
There is nothing left to do after bchlib, but this needs to return OK in order for "fsync" not to fail.
