### PR TITLE
board_reset.cpp: Hartid must be read with local interrupts disabled

### DIFF
--- a/platforms/nuttx/src/px4/microchip/mpfs/board_reset/board_reset.cpp
+++ b/platforms/nuttx/src/px4/microchip/mpfs/board_reset/board_reset.cpp
@@ -96,11 +96,15 @@ static void board_reset_enter_bootloader_and_continue_boot()
 
 static int board_reset_enter_app(FAR void *arg)
 {
-	uintptr_t hartid = riscv_mhartid();
+	uintptr_t hartid;
 
 	/* Mask local interrupts */
 
 	up_irq_save();
+
+	/* It is now safe to read and hold hartid locally (CPU cannot change) */
+
+	hartid = riscv_mhartid();
 
 #ifdef CONFIG_SMP
 	/* Notify that this CPU is paused */


### PR DESCRIPTION
We cannot allow the running task to switch to another CPU after reading hartid, otherwise we will use a stale value. Fix this by reading hartid after disabling local interrupts.