### PR TITLE
Update 4421_ssrc_skywalker airframe parameters

### DIFF
--- a/ROMFS/px4fmu_common/init.d/airframes/4421_ssrc_skywalker
+++ b/ROMFS/px4fmu_common/init.d/airframes/4421_ssrc_skywalker
@@ -16,15 +16,23 @@ param set-default CA_AIRFRAME 1
 param set-default CA_ROTOR_COUNT 1
 param set-default CA_SV_CS0_TYPE 5
 param set-default CA_SV_CS1_TYPE 6
+param set-default CA_SV_CS_COUNT 2
+param set-default CA_SV_CS0_TRQ_P 0.5
+param set-default CA_SV_CS0_TRQ_R -0.5
+param set-default CA_SV_CS1_TRQ_P 0.5
+param set-default CA_SV_CS1_TRQ_R 0.5
 
 # PWM
 param set-default PWM_MAIN_FUNC1 201
 param set-default PWM_MAIN_FUNC2 202
+
+param set-default PWM_MAIN_REV 2
+
 param set-default PWM_MAIN_FUNC4 101
 
 # Airspeed parameters
 param set-default SENS_EN_MS4525DO 1
-param set-default ASPD_DO_CHECKS 15
+param set-default ASPD_DO_CHECKS 7
 param set-default FW_AIRSPD_MAX 25.0
 param set-default FW_AIRSPD_MIN 13.0
 param set-default FW_AIRSPD_STALL 10.0
@@ -32,27 +40,24 @@ param set-default FW_AIRSPD_TRIM 18.0
 
 # Mission parameters
 param set-default MIS_TAKEOFF_ALT 25.0
-param set-default MIS_TKO_LAND_REQ 4
-param set-default NAV_LOITER_RAD 40.0
 
 # Battery parameters
 param set-default BAT1_N_CELLS 6
+param set-default BAT1_CAPACITY 6800
 param set-default BAT1_V_EMPTY 3.7000
+param set-default BAT1_V_CHARGED 4.2
 
-# Disable internal magnetometer
-param set-default CAL_MAG0_PRIO 1
-param set-default CAL_MAG0_ROT 0
-param set-default CAL_MAG1_PRIO 100
-param set-default CAL_MAG1_ROT 0
-
-param set-default SENS_MAG_MODE 0
+# Takeoff parameters
+param set-default FW_T_CLMB_MAX 10.0
+param set-default FW_T_CLMB_R_SP 6.0
+param set-default FW_TKO_PITCH_MIN 17
 
 # Launch detection
 param set-default FW_LAUN_AC_T 0.0
-param set-default FW_LAUN_AC_THLD 0.0
+param set-default FW_LAUN_AC_THLD 3.0
 param set-default FW_LAUN_DETCN_ON 1
 
-# Launch detection
+# Landing
 param set-default FW_LND_ANG 15.0
 param set-default FW_LND_ABORT 0
 


### PR DESCRIPTION
1. Updated CA parameters as the setup is always same in all builds. 
3. Removed the line which disables internal mag. 
4. Added battery parameters.
5. Changed ASPD_DO_CHECKS as currently the Saluki has to be rebooted after landing as bit 3: Load factor check (triggers if measurement is below stall speed) triggers airspeed failure after each landing.
6. Changed the loiter radius as it was too tight.
7. Removed the parameter that required a takeoff and a landing pattern for a mission.
8. Changed launch detection acceleration value to 3 from 0.
9. Added some parameters for more successful takeoffs. 