### PR TITLE
Update 4401_ssrc_fog_x_tmotor mag0 prio

### DIFF
--- a/ROMFS/px4fmu_common/init.d/airframes/4401_ssrc_fog_x_tmotor
+++ b/ROMFS/px4fmu_common/init.d/airframes/4401_ssrc_fog_x_tmotor
@@ -78,9 +78,6 @@ param set-default BAT2_CAPACITY 22000
 # Enable LL40LS in i2c
 param set-default SENS_EN_LL40LS 2
 
-# Low priority for internal magnetometer
-param set-default CAL_MAG0_PRIO 25
-
 # LEDs on TELEMETRY 1
 param set-default SER_TEL1_BAUD 57600
 param set-default MAV_1_CONFIG 101


### PR DESCRIPTION
Param should be set as default so it is changeable by user. Further I propose setting it to a lower priority than external one. This makes the drone usable without external mag but will still prioritize the external one if it is installed.