### PR TITLE
Add a small SLEW rate for SSRC X500 frame ESC control

### DIFF
--- a/ROMFS/px4fmu_common/init.d/airframes/4400_ssrc_fog_x
+++ b/ROMFS/px4fmu_common/init.d/airframes/4400_ssrc_fog_x
@@ -37,6 +37,13 @@ param set-default CA_ROTOR3_PX -0.175
 param set-default CA_ROTOR3_PY 0.175
 param set-default CA_ROTOR3_KM -0.05
 
+# Some slew rate is needed for ESCs if using
+# high frequency control loops (e.g. with ADIS imus)
+param set-default CA_R0_SLEW 0.1
+param set-default CA_R1_SLEW 0.1
+param set-default CA_R2_SLEW 0.1
+param set-default CA_R3_SLEW 0.1
+
 # PWM functions
 param set-default PWM_MAIN_FUNC1 101
 param set-default PWM_MAIN_FUNC2 102


### PR DESCRIPTION
It has been observed that With higher frequency control loop the ESCs start behaving badly if PWM pulse width changes too rapidly. Take the motors moment of inertia into account and just restrict the change
