### PR TITLE
cmake: Fix some dependencies for kernel mode build

### DIFF
--- a/ROMFS/CMakeLists.txt
+++ b/ROMFS/CMakeLists.txt
@@ -142,15 +142,16 @@ set(extras_dependencies)
 
 # sysinit script for kernel mode
 if(CONFIG_BUILD_KERNEL)
-	add_custom_command(OUTPUT ${romfs_gen_root_dir}/init.d/rc.sysinit
+	add_custom_command(OUTPUT ${romfs_gen_root_dir}/init.d/rc.sysinit rc.sysinit.stamp
 		COMMAND ${CMAKE_COMMAND} -E copy_if_different ${PX4_BINARY_DIR}/NuttX/rc.sysinit ${romfs_gen_root_dir}/init.d/rc.sysinit
+		COMMAND ${CMAKE_COMMAND} -E touch rc.sysinit.stamp
 		DEPENDS
 			${PX4_BINARY_DIR}/NuttX/rc.sysinit
 			romfs_copy.stamp
 		COMMENT "ROMFS: copying rc.sysinit"
 	)
 	list(APPEND extras_dependencies
-		${romfs_gen_root_dir}/init.d/rc.sysinit
+		rc.sysinit.stamp
 	)
 endif()
 

--- a/platforms/nuttx/CMakeLists.txt
+++ b/platforms/nuttx/CMakeLists.txt
@@ -284,7 +284,8 @@ if (CONFIG_BUILD_KERNEL)
 		# Build module.a into module.elf
 		set(BIN px4-${MAIN}.elf)
 		add_executable(${BIN} ${PX4_SOURCE_DIR}/platforms/nuttx/src/px4/common/process/main.cpp)
-		set_target_properties(${BIN} PROPERTIES OUTPUT_NAME ${BIN})
+		set_target_properties(${BIN} PROPERTIES OUTPUT_NAME ${MAIN})
+		set_target_properties(${BIN} PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${PX4_BINARY_DIR}/bin)
 		add_dependencies(${BIN} nuttx_crt0 ${module})
 		target_compile_options(${BIN} PRIVATE -Dentry=${MAIN}_main)
 
@@ -328,19 +329,11 @@ if (CONFIG_BUILD_KERNEL)
 		# The individual module deps are FUBAR, so this cannot be done
 		#target_link_libraries(${BIN} PRIVATE ${module})
 		target_link_libraries(${BIN} INTERFACE perf nuttx_c)
+
 		# Some global deps are also FUBAR, so this must be done
 		target_link_libraries(px4_platform board_bus_info)
 
-		# Install the executable to /bin
-		add_custom_target(${BIN}_install
-			COMMAND mkdir -p ${PX4_BINARY_DIR}/bin
-			COMMAND install -D ${PX4_BINARY_DIR}/${BIN} -t ${PX4_BINARY_DIR}/bin
-			COMMAND mv ${PX4_BINARY_DIR}/bin/${BIN} ${PX4_BINARY_DIR}/bin/${MAIN}
-			COMMAND rm -f ${PX4_BINARY_DIR}/${BIN}
-			DEPENDS ${BIN}
-		)
-
-		list(APPEND px4_bins ${BIN}_install)
+		list(APPEND px4_bins ${BIN})
 	endforeach()
 
 	# Create the /bin ROMFS

--- a/platforms/nuttx/NuttX/CMakeLists.txt
+++ b/platforms/nuttx/NuttX/CMakeLists.txt
@@ -268,7 +268,7 @@ if (CONFIG_BUILD_KERNEL)
 
 	get_property(CRT0_OBJ TARGET nuttx_crt0 PROPERTY IMPORTED_OBJECTS)
 
-	add_custom_target(nuttx_app_bins
+	add_custom_command(OUTPUT nuttx_install.stamp
 		COMMAND mkdir -p ${PX4_BINARY_DIR}/bin
 		COMMAND make -C ${NUTTX_SRC_DIR}/apps install --no-print-directory --silent
 			ARCHCRT0OBJ="${CRT0_OBJ}"
@@ -276,9 +276,11 @@ if (CONFIG_BUILD_KERNEL)
 			TOPDIR="${NUTTX_DIR}"
 			ELFLDNAME="${LDSCRIPT}"
 			USERLIBS="${userlibs}" > ${CMAKE_CURRENT_BINARY_DIR}/nuttx_apps_install.log
+		COMMAND touch nuttx_install.stamp
 		BYPRODUCTS ${PX4_BINARY_DIR}/bin/nsh
 		DEPENDS ${nuttx_userlibs} nuttx_startup
 	)
+	add_custom_target(nuttx_app_bins DEPENDS nuttx_install.stamp)
 endif()
 
 ###############################################################################


### PR DESCRIPTION
This fixes some dependencies reducing unnecessary rebuild steps from ~90 to ~10.

The remaining steps are also unnecessary but I did not figure out which rule is causing them to trigger.