### PR TITLE
Removed LED definitions from ssrc_config/config_indoor.txt

### DIFF
--- a/ssrc_config/config_indoor.txt
+++ b/ssrc_config/config_indoor.txt
@@ -48,12 +48,6 @@ param set MPC_XY_TRAJ_P 0.7
 # Limit upward movement speed for safety
 param set MPC_Z_VEL_MAX_UP 1.0
 
-# LEDS
-param set SER_TEL2_BAUD 57600
-param set MAV_1_CONFIG 102
-param set MAV_1_MODE 7
-param set MAV_1_RATE 1000
-
 # Smoothing trajectory a bit when using AutoLineSmoothVel
 param set MPC_JERK_AUTO 8
 param set MPC_ACC_HOR 3


### PR DESCRIPTION
Removed obsolete LED definitions from config_indoor.txt
