### PR TITLE
nuttx/CMake: Fix build more dependencies for kernel mode build

### DIFF
--- a/platforms/nuttx/CMakeLists.txt
+++ b/platforms/nuttx/CMakeLists.txt
@@ -258,7 +258,7 @@ if (CONFIG_BUILD_KERNEL)
 		COMMAND mv ${PX4_BINARY_DIR}/bin/nsh ${PX4_BINARY_DIR}/init
 		COMMAND install -D ${PX4_BINARY_DIR}/init -t ${PX4_BINARY_DIR}/boot
 		COMMAND rm -f ${PX4_BINARY_DIR}/init
-		DEPENDS ${PX4_BINARY_DIR}/bin/nsh
+		DEPENDS nuttx_app_bins
 	)
 	add_custom_target(boot_bins DEPENDS ${PX4_BINARY_DIR}/boot/init)
 

--- a/platforms/nuttx/NuttX/CMakeLists.txt
+++ b/platforms/nuttx/NuttX/CMakeLists.txt
@@ -277,7 +277,6 @@ if (CONFIG_BUILD_KERNEL)
 			ELFLDNAME="${LDSCRIPT}"
 			USERLIBS="${userlibs}" > ${CMAKE_CURRENT_BINARY_DIR}/nuttx_apps_install.log
 		COMMAND touch nuttx_install.stamp
-		BYPRODUCTS ${PX4_BINARY_DIR}/bin/nsh
 		DEPENDS ${nuttx_userlibs} nuttx_startup
 	)
 	add_custom_target(nuttx_app_bins DEPENDS nuttx_install.stamp)

--- a/platforms/nuttx/cmake/bin_romfs.cmake
+++ b/platforms/nuttx/cmake/bin_romfs.cmake
@@ -82,6 +82,8 @@ function(make_bin_romfs)
 
 	# Strip the elf files to reduce romfs image size
 
+	set(stripped_deps)
+
 	if (${STRIPPED} STREQUAL "y")
 		# Preserve the files with debug symbols
 
@@ -97,10 +99,8 @@ function(make_bin_romfs)
 			DEPENDS ${DEPS} debug_${OUTPREFIX}
 			WORKING_DIRECTORY ${BINDIR}
 		)
-	else()
-		add_custom_command(OUTPUT ${OUTPREFIX}_stripped_bins
-			COMMAND touch ${BINDIR}
-		)
+
+		list(APPEND stripped_deps ${OUTPREFIX}_stripped_bins)
 	endif()
 
 	# Make sure we have what we need
@@ -128,7 +128,7 @@ function(make_bin_romfs)
 				${SED} 's/^unsigned char/const unsigned char/g' >${OUTPREFIX}_romfsimg.h
 		COMMAND mv ${OUTPREFIX}_romfsimg.h ${OUTDIR}/${OUTPREFIX}_romfsimg.h
 		COMMAND rm -f ${OUTPREFIX}_romfs.img
-		DEPENDS ${OUTDIR} ${DEPS} ${OUTPREFIX}_stripped_bins
+		DEPENDS ${OUTDIR} ${DEPS} ${stripped_deps}
 	)
 	add_custom_target(${OUTPREFIX}_romfsimg DEPENDS ${OUTDIR}/${OUTPREFIX}_romfsimg.h)
 


### PR DESCRIPTION
If nothing is changed, this cuts down the rebuild steps to 1. This occurs on the first rebuild, after which the rebuild no longer performs any steps.

The reason why the 1 unnecessary step is still executed on the first re-build, is that the kernel mode /bin folder is stripped 'in place'. This confuses the Ninja build system as every file in the folder has been "touched" after Ninja did the build.