### PR TITLE
Revert "Remove failing submodule: Tools/simulation/jsbsim/jsbsim_bridge"

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -29,6 +29,9 @@
 [submodule "Tools/flightgear_bridge"]
 	path = Tools/simulation/flightgear/flightgear_bridge
 	url = https://github.com/PX4/PX4-FlightGear-Bridge.git
+[submodule "Tools/simulation/jsbsim/jsbsim_bridge"]
+	path = Tools/simulation/jsbsim/jsbsim_bridge
+	url = https://github.com/PX4/px4-jsbsim-bridge.git
 [submodule "src/drivers/cyphal/libcanard"]
 	path = src/drivers/cyphal/libcanard
 	url = https://github.com/opencyphal/libcanard.git


### PR DESCRIPTION
This reverts commit e3a854d517a7182150a1d02ecac21c2278f4a9c9.

This commit was made long time ago when there was some issues in remote repository and submodule fetch failed. That broke the CI building, so the temporary quick fix was to remove the submodule from px4-firmware build.
Seems that this alternative simulator is used by some parties, so it should be re-enabled.
It is not causing any issues anymore in CI, so the temporary removal commit can be reverted.