### PR TITLE
disable uae jfrog upload

### DIFF
--- a/.github/workflows/tiiuae-pixhawk-and-saluki.yaml
+++ b/.github/workflows/tiiuae-pixhawk-and-saluki.yaml
@@ -418,7 +418,8 @@ jobs:
 
   artifactory-uae:
     name: upload builds to UAE artifactory
-    if: ${{ github.event_name != 'workflow_dispatch' || inputs.jfrog-upload == true }}
+    # disabled as token has expired
+    if: false
     runs-on: ubuntu-latest
     needs:
       - px4fwupdater


### PR DESCRIPTION
UAE jfrog token has expired so disabling this step until we receive new token.
This is to avoid all builds failing. Binaries are available in docker also for UAE