### PR TITLE
px4/common/cpuload: Manage task restart in cpuload hash table

### DIFF
--- a/platforms/nuttx/src/px4/common/cpuload.cpp
+++ b/platforms/nuttx/src/px4/common/cpuload.cpp
@@ -105,9 +105,9 @@ retry:
 
 	hash = HASH(pid);
 
-	/* Check if the entry is available */
+	/* Check if the entry is available or has this pid already (task restart case) */
 
-	if (hashtab[hash] == NULL) {
+	if (hashtab[hash] == NULL || task_info->tcb->pid == hashtab[hash]->tcb->pid) {
 		hashtab[hash] = task_info;
 		px4_leave_critical_section(flags);
 		return OK;


### PR DESCRIPTION
In task restart case, the sched note is not stopped before started again; in this case the tcb already exists in the hash table. Check this before growing the hash table size.

This was found in ostest, where hash table size suddenly explodes.
