### PR TITLE
SW Crypto: P384 support

### DIFF
--- a/platforms/common/include/px4_platform_common/crypto_algorithms.h
+++ b/platforms/common/include/px4_platform_common/crypto_algorithms.h
@@ -45,6 +45,7 @@ typedef enum {
 	CRYPTO_RSA_OAEP = 4,
 	CRYPTO_ECDSA_P256 = 5,
 	CRYPTO_RSA_SIG = 6,    /* openssl dgst -sha256 -sign */
+	CRYPTO_ECDSA_P384 = 7,
 } px4_crypto_algorithm_t;
 
 /* Define the expected size of the signature for signing algorithms */

--- a/src/drivers/sw_crypto/crypto.c
+++ b/src/drivers/sw_crypto/crypto.c
@@ -309,7 +309,7 @@ bool crypto_signature_check(crypto_session_handle_t handle,
 						int stat = 0;
 
 						if (rsa_verify_hash_ex(
-							    signature, 256, hash, hash_len, padding, hash_idx, saltlen, &stat, &key)
+							    signature, rsa_get_size(&key), hash, hash_len, padding, hash_idx, saltlen, &stat, &key)
 						    == CRYPT_OK
 						    && stat) {
 							ret = true;

--- a/src/lib/crypto/CMakeLists.txt
+++ b/src/lib/crypto/CMakeLists.txt
@@ -68,6 +68,8 @@ libtomcrypt_wrappers.c
 	${PK_SRC}
 	${MATH_SRC}
 	libtomcrypt/src/hashes/sha2/sha256.c
+	libtomcrypt/src/hashes/sha2/sha384.c
+	libtomcrypt/src/hashes/sha2/sha512.c
 	libtomcrypt/src/hashes/helper/hash_memory.c
 	libtomcrypt/src/prngs/sprng.c
 	libtomcrypt/src/misc/crypt/crypt_ltc_mp_descriptor.c

--- a/src/lib/crypto/libtomcrypt_wrappers.c
+++ b/src/lib/crypto/libtomcrypt_wrappers.c
@@ -17,6 +17,22 @@ struct ltc_hash_descriptor hash_descriptor[] = {
 		&sha256_done,
 		&sha256_test,
 		NULL
+	},
+	{
+		"sha384",
+		4,
+		48,
+		128,
+
+		/* OID */
+		{ 2, 16, 840, 1, 101, 3, 4, 2, 2,  },
+		9,
+
+		&sha384_init,
+		&sha512_process,
+		&sha384_done,
+		&sha384_test,
+		NULL
 	}
 };
 


### PR DESCRIPTION
Add sw_crypto support for ECDSA secp384r1 signature verification for Device Assembly Card authentication