### PR TITLE
Crypto and guid fix

### DIFF
--- a/platforms/common/include/px4_platform_common/crypto_backend.h
+++ b/platforms/common/include/px4_platform_common/crypto_backend.h
@@ -398,6 +398,17 @@ typedef struct cryptoiocgenkeypair {
 	bool ret;
 } cryptoiocgenkeypair_t;
 
+#define CRYPTOIOCSETKEY _CRYPTOIOC(13)
+typedef struct cryptoiocsetkey {
+	crypto_session_handle_t *handle;
+	uint8_t authentication_key_idx;
+	const uint8_t *signature;
+	const uint8_t *key;
+	size_t key_len;
+	uint8_t key_idx;
+	bool ret;
+} cryptoiocsetkey_t;
+
 #if defined(__cplusplus)
 } // extern "C"
 #endif

--- a/platforms/nuttx/src/px4/common/px4_crypto.cpp
+++ b/platforms/nuttx/src/px4/common/px4_crypto.cpp
@@ -253,6 +253,13 @@ int PX4Crypto::crypto_ioctl(unsigned int cmd, unsigned long arg)
 		}
 		break;
 
+	case CRYPTOIOCSETKEY: {
+			cryptoiocsetkey_t *data = (cryptoiocsetkey_t *)arg;
+			data->ret = crypto_set_key(*(data->handle), data->authentication_key_idx, data->signature, data->key,
+						   data->key_len, data->key_idx);
+		}
+		break;
+
 	case CRYPTOIOCGETKEY: {
 			cryptoiocgetkey_t *data = (cryptoiocgetkey_t *)arg;
 			data->ret = crypto_get_encrypted_key(*(data->handle), data->key_idx, data->key, data->max_len,

--- a/platforms/nuttx/src/px4/common/px4_usr_crypto.cpp
+++ b/platforms/nuttx/src/px4/common/px4_usr_crypto.cpp
@@ -156,6 +156,17 @@ bool PX4Crypto::get_nonce(uint8_t *nonce,
 	return data.ret;
 }
 
+bool PX4Crypto::set_key(uint8_t authentication_key_idx,
+			const uint8_t *signature,
+			const uint8_t *key,
+			size_t key_len,
+			uint8_t key_idx)
+{
+	cryptoiocsetkey_t data = {&_crypto_handle, authentication_key_idx, signature, key, key_len, key_idx, false};
+	boardctl(CRYPTOIOCSETKEY, reinterpret_cast<unsigned long>(&data));
+	return data.ret;
+}
+
 bool PX4Crypto::get_encrypted_key(uint8_t key_idx,
 				  uint8_t *key,
 				  size_t *key_len,

--- a/platforms/nuttx/src/px4/common/usr_mcu_version.cpp
+++ b/platforms/nuttx/src/px4/common/usr_mcu_version.cpp
@@ -150,6 +150,9 @@ int board_get_px4_guid_formated(char *format_buffer, int size)
 	board_get_px4_guid(px4_guid);
 	int offset  = 0;
 
+	/* Size must be equal or less than GUID string len to make reversed copy work */
+	if (size > PX4_GUID_FORMAT_SIZE) { size = PX4_GUID_FORMAT_SIZE; }
+
 	/* size should be 2 per byte + 1 for termination
 	 * So it needs to be odd
 	 */

--- a/platforms/nuttx/src/px4/microchip/mpfs/version/board_mcu_version.c
+++ b/platforms/nuttx/src/px4/microchip/mpfs/version/board_mcu_version.c
@@ -175,6 +175,9 @@ int board_get_px4_guid_formated(char *format_buffer, int size)
 	board_get_px4_guid(px4_guid);
 	int offset  = 0;
 
+	/* Size must be equal or less than GUID string len to make reversed copy work */
+	if (size > PX4_GUID_FORMAT_SIZE) { size = PX4_GUID_FORMAT_SIZE; }
+
 	/* size should be 2 per byte + 1 for termination
 	 * So it needs to be odd
 	 */

--- a/platforms/nuttx/src/px4/nxp/imx9/version/board_mcu_version.c
+++ b/platforms/nuttx/src/px4/nxp/imx9/version/board_mcu_version.c
@@ -193,6 +193,9 @@ int board_get_px4_guid_formated(char *format_buffer, int size)
 	board_get_px4_guid(px4_guid);
 	int offset  = 0;
 
+	/* Size must be equal or less than GUID string len to make reversed copy work */
+	if (size > PX4_GUID_FORMAT_SIZE) { size = PX4_GUID_FORMAT_SIZE; }
+
 	/* size should be 2 per byte + 1 for termination
 	 * So it needs to be odd
 	 */


### PR DESCRIPTION
- Crypto: Fix usr support for set_key in kernel mode builds
- board_get_px4_guid_formated: Fix the format_buffer size, which caused source index to be negative if buffer was bigger than the formatted guid string.
- Update px4/common/process submodule to make "make format" happy.