### PR TITLE
build_kernel: Preserve debug symbols for nuttx app binaries

### DIFF
--- a/platforms/nuttx/NuttX/CMakeLists.txt
+++ b/platforms/nuttx/NuttX/CMakeLists.txt
@@ -272,7 +272,8 @@ if (CONFIG_BUILD_KERNEL)
 		COMMAND mkdir -p ${PX4_BINARY_DIR}/bin
 		COMMAND make -C ${NUTTX_SRC_DIR}/apps install --no-print-directory --silent
 			ARCHCRT0OBJ="${CRT0_OBJ}"
-			BINDIR="${PX4_BINARY_DIR}/bin"
+			BINDIR="${PX4_BINARY_DIR}/bin_debug"
+			BINDIR_DEBUG="${PX4_BINARY_DIR}/bin"
 			TOPDIR="${NUTTX_DIR}"
 			ELFLDNAME="${LDSCRIPT}"
 			USERLIBS="${userlibs}" > ${CMAKE_CURRENT_BINARY_DIR}/nuttx_apps_install.log


### PR DESCRIPTION
Currently the nuttx app build strips all debug symbols by default, and places them into BINDIR_DEBUG.

Our own build system does it as well, but it expects the un-stripped binaries to be in the /bin folder.

Fix this by putting the debug binaries into /bin so our own toolchain still works as before.