### PR TITLE
Vtol surface fix

### DIFF
--- a/ROMFS/px4fmu_common/init.d/airframes/4430_ssrc_strivermini
+++ b/ROMFS/px4fmu_common/init.d/airframes/4430_ssrc_strivermini
@@ -70,8 +70,7 @@ param set-default PWM_AUX_FUNC4 204
 param set-default PWM_AUX_FUNC5 205
 param set-default PWM_AUX_FUNC6 105
 
-param set-default PWM_MAIN_REV 6
-param set-default PWM_MAIN_REV 8
+param set-default PWM_MAIN_REV 160
 
 # Start airspeed sensor driver
 param set-default SENS_EN_MS4525DO 1

--- a/ROMFS/px4fmu_common/init.d/airframes/4430_ssrc_strivermini
+++ b/ROMFS/px4fmu_common/init.d/airframes/4430_ssrc_strivermini
@@ -44,11 +44,11 @@ param set-default CA_SV_CS_COUNT 5
 param set-default CA_SV_CS0_TYPE 1
 param set-default CA_SV_CS0_TRQ_R -0.5
 param set-default CA_SV_CS1_TYPE 2
-param set-default CA_SV_CS1_TRQ_R -0.5
+param set-default CA_SV_CS1_TRQ_R 0.5
 param set-default CA_SV_CS2_TYPE 3
 param set-default CA_SV_CS2_TRQ_P 1.0
 param set-default CA_SV_CS3_TYPE 3
-param set-default CA_SV_CS3_TRQ_P -1.0
+param set-default CA_SV_CS3_TRQ_P 1.0
 param set-default CA_SV_CS4_TYPE 4
 param set-default CA_SV_CS4_TRQ_Y 1.0
 
@@ -69,6 +69,9 @@ param set-default PWM_AUX_FUNC3 203
 param set-default PWM_AUX_FUNC4 204
 param set-default PWM_AUX_FUNC5 205
 param set-default PWM_AUX_FUNC6 105
+
+param set-default PWM_MAIN_REV 6
+param set-default PWM_MAIN_REV 8
 
 # Start airspeed sensor driver
 param set-default SENS_EN_MS4525DO 1


### PR DESCRIPTION
<!--

Thank you for your contribution!

Get early feedback through
- Dronecode Discord: https://discord.gg/dronecode
- PX4 Discuss: http://discuss.px4.io/
- opening a draft pr and sharing the link

-->

### Solved Problem
When trying to trim the surfaces control I found that the gain values get in a situation where all the surfaces behaves oddly. 

Fixes #{Github issue ID}

### Solution
- Add PWM_MAIN_REV param with the motors that have a negative gain, indicating a reverse rotation for solve the issue.

### Changelog Entry
For release notes:
```
Feature/Bugfix XYZ
New parameter: XYZ_Z
Documentation: Need to clarify page ... / done, read docs.px4.io/...
```

### Alternatives
We could also ...

### Test coverage
- Unit/integration test: ...
- Simulation/hardware testing logs: https://review.px4.io/

### Context
Related links, screenshot before/after, video
