### PR TITLE
[HACKS DO NOT MERGE] Debug adis imu accel data gaps

### DIFF
--- a/src/modules/sensors/vehicle_imu/VehicleIMU.cpp
+++ b/src/modules/sensors/vehicle_imu/VehicleIMU.cpp
@@ -81,6 +81,7 @@ VehicleIMU::~VehicleIMU()
 
 	perf_free(_accel_generation_gap_perf);
 	perf_free(_gyro_generation_gap_perf);
+	perf_free(_integrator_update_perf);
 
 	_vehicle_imu_pub.unadvertise();
 	_vehicle_imu_status_pub.unadvertise();
@@ -299,6 +300,7 @@ bool VehicleIMU::UpdateAccel()
 						if (!PX4_ISFINITE(_accel_interval_us) || diff_exceeds_stddev) {
 							// update integrator configuration if interval has changed by more than 10%
 							_update_integrator_config = true;
+							perf_count(_integrator_update_perf);
 						}
 					}
 				}
@@ -428,6 +430,7 @@ bool VehicleIMU::UpdateGyro()
 						if (!PX4_ISFINITE(_gyro_interval_us) || diff_exceeds_stddev) {
 							// update integrator configuration if interval has changed by more than 10%
 							_update_integrator_config = true;
+							perf_count(_integrator_update_perf);
 						}
 					}
 				}
@@ -762,6 +765,7 @@ void VehicleIMU::PrintStatus()
 
 	perf_print_counter(_accel_generation_gap_perf);
 	perf_print_counter(_gyro_generation_gap_perf);
+	perf_print_counter(_integrator_update_perf);
 
 	_accel_calibration.PrintStatus();
 	_gyro_calibration.PrintStatus();

--- a/src/modules/sensors/vehicle_imu/VehicleIMU.cpp
+++ b/src/modules/sensors/vehicle_imu/VehicleIMU.cpp
@@ -223,7 +223,7 @@ void VehicleIMU::Run()
 		// update accel until integrator ready and caught up to gyro
 		while (_sensor_accel_sub.updated()
 		       && (!_accel_integrator.integral_ready() || !_intervals_configured || _data_gap
-			   || (_accel_timestamp_sample_last < (_gyro_timestamp_sample_last - 0.5f * _accel_interval_us)))
+			   || _accel_timestamp_sample_last < _gyro_timestamp_sample_last)
 		      ) {
 
 			if (UpdateAccel()) {

--- a/src/modules/sensors/vehicle_imu/VehicleIMU.hpp
+++ b/src/modules/sensors/vehicle_imu/VehicleIMU.hpp
@@ -195,6 +195,7 @@ private:
 
 	perf_counter_t _accel_generation_gap_perf{perf_alloc(PC_COUNT, MODULE_NAME": accel data gap")};
 	perf_counter_t _gyro_generation_gap_perf{perf_alloc(PC_COUNT, MODULE_NAME": gyro data gap")};
+	perf_counter_t _integrator_update_perf{perf_alloc(PC_COUNT, MODULE_NAME": integrator updates")};
 
 	DEFINE_PARAMETERS(
 		(ParamInt<px4::params::IMU_INTEG_RATE>) _param_imu_integ_rate,


### PR DESCRIPTION
A few patches to debug why accel data gaps start growing eventually on ADIS IMU at 2KHz sample rate