### PR TITLE
telem_test: extend UART loopback test

### DIFF
--- a/src/systemcmds/telem_test/telem_test.cpp
+++ b/src/systemcmds/telem_test/telem_test.cpp
@@ -41,6 +41,8 @@
 #include <px4_platform_common/module.h>
 #include <drivers/drv_hrt.h>
 
+constexpr int CHAIN_UART_COUNT = 3;
+
 static void usage(const char *reason)
 {
 	if (reason != nullptr) {
@@ -52,19 +54,44 @@ static void usage(const char *reason)
 	PRINT_MODULE_USAGE_NAME("telem_test", "command");
 	PRINT_MODULE_USAGE_COMMAND_DESCR("flush", "Flush UART");
 	PRINT_MODULE_USAGE_ARG("<dev>", "Uart device", false);
-	PRINT_MODULE_USAGE_COMMAND_DESCR("loopback", "Loopback test between uarts");
+	PRINT_MODULE_USAGE_COMMAND_DESCR("chain_loopback", "Loopback test for max. 3 uarts");
 	PRINT_MODULE_USAGE_ARG("<dev1>", "First UART device", false);
 	PRINT_MODULE_USAGE_ARG("<dev2>", "Second UART device", false);
+	PRINT_MODULE_USAGE_ARG("<dev3>", "Third UART device", false);
 	PRINT_MODULE_USAGE_COMMAND_DESCR("send", "Send string to UART");
 	PRINT_MODULE_USAGE_ARG("<dev>", "Uart device", false);
 	PRINT_MODULE_USAGE_COMMAND_DESCR("recv", "Receive string from UART");
 	PRINT_MODULE_USAGE_ARG("<dev>", "UART device", false);
+	PRINT_MODULE_USAGE_COMMAND_DESCR("set_port", "Set UART port to 115200 baud");
+	PRINT_MODULE_USAGE_ARG("<dev>", "UART device", false);
+}
+
+static int set_port_param(int fd)
+{
+	struct termios uart_config = {0};
+
+	if (tcgetattr(fd, &uart_config) < 0) {
+		PX4_ERR("tcgetattr");
+		return 1;
+	}
+
+	if (cfsetspeed(&uart_config, 115200) < 0) {
+		PX4_ERR("cfsetspeed");
+		return 1;
+	}
+
+	if (tcsetattr(fd, TCSANOW, &uart_config) < 0) {
+		PX4_ERR("tcsetattr");
+		return 1;
+	}
+
+	return 0;
 }
 
 static int test_recv(int uart_recv, char *recv_buf, size_t buf_len)
 {
 	if (read(uart_recv, recv_buf, buf_len) < 0) {
-		printf("ERROR read: %d\n", errno);
+		PX4_ERR("    ERROR read: %d", errno);
 		return 1;
 	}
 
@@ -74,7 +101,7 @@ static int test_recv(int uart_recv, char *recv_buf, size_t buf_len)
 static int test_send(int uart_send, const char *send_buf)
 {
 	if (write(uart_send, send_buf, strlen(send_buf)) < 0) {
-		printf("ERROR write: %d\n", errno);
+		PX4_ERR("    ERROR write: %d", errno);
 		return 1;
 	}
 
@@ -83,7 +110,7 @@ static int test_send(int uart_send, const char *send_buf)
 	return 0;
 }
 
-static int loopback(int uart_send, int uart_recv, const char *send_buf)
+static int send_receive_verify(int uart_send, int uart_recv, const char *send_buf)
 {
 	char recv_buf[15] = {0};
 
@@ -96,113 +123,172 @@ static int loopback(int uart_send, int uart_recv, const char *send_buf)
 	}
 
 	if (strncmp(send_buf, recv_buf, strlen(send_buf)) != 0) {
-		printf("ERROR: send != recv\n");
-		printf("    send '%s'\n", send_buf);
-		printf("    recv '%s'\n", recv_buf);
+		PX4_ERR("    ERROR: send != recv");
+		PX4_ERR("        send '%s'", send_buf);
+		PX4_ERR("        recv '%s'", recv_buf);
 		return 1;
 	}
 
 	return 0;
 }
 
-static int test_loopback(int uart1, int uart2)
+static int test_chain_loopback(int uart[CHAIN_UART_COUNT])
 {
-	const char *send_str1 = "send_uart_1";
-	const char *send_str2 = "send_uart_2";
+	int last_idx = -1;
 
-	printf("send: first -> second\n");
-
-	if (loopback(uart1, uart2, send_str1)) {
+	if (uart[1] < 0) {
+		usage("ERROR: uart loopback configuration");
 		return 1;
 	}
 
-	printf("send: second -> first\n");
+	char send_str[] = "send_uart_0";
 
-	if (loopback(uart2, uart1, send_str2)) {
+	for (int i = 0; i < CHAIN_UART_COUNT - 1; i++) {
+		if (uart[i + 1] < 0) {
+			break;
+		}
+
+		// change send string content
+		send_str[strlen(send_str) - 1] = '0' + i;
+
+		PX4_INFO("send: %d. UART -> %d. UART", i + 1, i + 2);
+
+		if (send_receive_verify(uart[i], uart[i + 1], send_str)) {
+			return 1;
+		}
+
+		last_idx = i + 1;
+	}
+
+	// Complete loop: last -> first
+	send_str[strlen(send_str) - 1] = '0' + last_idx;
+
+	PX4_INFO("send: %d. UART -> %d. UART", last_idx + 1, 1);
+
+	if (send_receive_verify(uart[last_idx], uart[0], send_str)) {
 		return 1;
 	}
 
 	return 0;
+}
+
+static int open_uarts(const char *dev[CHAIN_UART_COUNT], int uart[CHAIN_UART_COUNT])
+{
+	for (int i = 0; i < CHAIN_UART_COUNT; i++) {
+		if (dev[i] == nullptr) {
+			uart[i] = -1;
+			continue;
+		}
+
+		uart[i] = open(dev[i], O_RDWR | O_NONBLOCK | O_NOCTTY);
+
+		if (uart[i] < 0) {
+			PX4_ERR("ERROR: failed to open %s: %d", dev[i], errno);
+			return 1;
+		}
+
+		if (set_port_param(uart[i])) {
+			PX4_ERR("%s set_port_param", dev[i]);
+			return 1;
+		}
+
+		if (tcflush(uart[i], TCIOFLUSH) < 0) {
+			PX4_ERR("%s tcflush: %d", dev[i], errno);
+			return 1;
+		}
+
+		PX4_INFO("%d. UART %s opened [%d]", i + 1, dev[i], uart[i]);
+	}
+
+	return 0;
+}
+
+static void cleanup(int uart[CHAIN_UART_COUNT])
+{
+	for (int i = 0; i < CHAIN_UART_COUNT; i++) {
+		if (uart[i] < 0) {
+			continue;
+		}
+
+		close(uart[i]);
+	}
 }
 
 extern "C" __EXPORT int telem_test_main(int argc, char *argv[])
 {
 	int res = 1;
 
-	if (argc < 3) {
+	const char *test_type = NULL;
+
+	const char *uart_dev[CHAIN_UART_COUNT] = { nullptr };
+	int uart_fd[CHAIN_UART_COUNT] = { 0 };
+
+	switch (argc) {
+	case 5:
+		uart_dev[2] = argv[4];
+
+	// fall through
+
+	case 4:
+		uart_dev[1] = argv[3];
+
+	// fall through
+
+	case 3:
+		test_type = argv[1];
+		uart_dev[0] = argv[2];
+		break;
+
+	default:
 		usage(nullptr);
 		return 1;
 	}
 
-	const char *test_type = argv[1];
-	const char *uart1_dev = argv[2];
-	const char *uart2_dev = NULL;
+	PX4_INFO("test type: %s", test_type);
 
-	if (argc > 3) {
-		uart2_dev = argv[3];
-	}
-
-	printf("test type: %s\n", test_type);
-
-	int uart1 = open(uart1_dev, O_RDWR | O_NONBLOCK | O_NOCTTY);
-
-	if (uart1 < 0) {
-		printf("ERROR: %s open\n", uart1_dev);
+	if (open_uarts(uart_dev, uart_fd)) {
 		return 1;
 	}
 
-	if (strcmp(test_type, "loopback") == 0) {
-		printf("first uart: %s\n", uart1_dev);
+	// At minimum single UART must be defined
+	if (uart_fd[0] < 0) {
+		usage("ERROR: no UARTs defined");
+		return 1;
+	}
 
-		if (!uart2_dev) {
-			usage("ERROR: second uart not specified");
-			close(uart1);
-			return 1;
-		}
+	if (strcmp(test_type, "chain_loopback") == 0) {
+		res = test_chain_loopback(uart_fd);
 
-		int uart2 = open(uart2_dev, O_RDWR | O_NONBLOCK | O_NOCTTY);
-
-		if (uart2 < 0) {
-			printf("ERROR: %s open\n", uart2_dev);
-			close(uart1);
-			return 1;
-		}
-
-		printf("second uart: %s\n", uart2_dev);
-
-		res = test_loopback(uart1, uart2);
-
-		close(uart2);
+		cleanup(uart_fd);
 
 	} else if (strcmp(test_type, "flush") == 0) {
-		printf("flush uart: %s\n", uart1_dev);
+		PX4_INFO("flush uart: %s", uart_dev[0]);
 
-		res = tcflush(uart1, TCIOFLUSH);
+		res = tcflush(uart_fd[0], TCIOFLUSH);
 
 		if (res < 0) {
-			printf("ERROR tcflush: %d\n", errno);
+			PX4_ERR("ERROR tcflush: %d", errno);
 		}
 
 	} else if (strcmp(test_type, "send") == 0) {
-		printf("uart: %s\n", uart1_dev);
-
 		const char *send_str = "send_uart";
-		res = test_send(uart1, send_str);
+		res = test_send(uart_fd[0], send_str);
 
-		printf("sent: '%s'\n", send_str);
+		PX4_INFO("sent: '%s'", send_str);
 
 	} else if (strcmp(test_type, "recv") == 0) {
-		printf("uart: %s\n", uart1_dev);
-
 		char recv_buf[20] = {0};
-		res = test_recv(uart1, recv_buf, sizeof(recv_buf) - 1);
+		res = test_recv(uart_fd[0], recv_buf, sizeof(recv_buf) - 1);
 
-		printf("recv: '%s'\n", recv_buf);
+		PX4_INFO("recv: '%s'", recv_buf);
+
+	} else if (strcmp(test_type, "set_port") == 0) {
+		res = set_port_param(uart_fd[0]);
 
 	} else {
 		usage("ERROR: test type not supported");
 	}
 
-	close(uart1);
+	close(uart_fd[0]);
 	return res;
 }


### PR DESCRIPTION
Loopback test works with max. 3 chained UARTs.

UART TX/RX pins must be chained to establish a loop, in which UART TX pin is connected to the next UART RX pin. The loop is completed by connecting the last UART the first UART.

"Full" setup w. saluki v2:

- telem 1 TX -> telem 2 RX
- telem 2 TX -> telem 3 RX
- telem 3 TX -> telem 1 RX
- stop mavlink in telem1 (/dev/ttyS1)

```
saluki> mavlink stop -d /dev/ttyS1
INFO  [mavlink] exiting channel 0
saluki>
saluki> telem_test chain_loopback /dev/ttyS1 /dev/ttyS3 /dev/ttyS5
INFO  [telem_test] test type: chain_loopback
INFO  [telem_test] 1. UART /dev/ttyS1 opened [3]
INFO  [telem_test] 2. UART /dev/ttyS3 opened [4]
INFO  [telem_test] 3. UART /dev/ttyS5 opened [5]
INFO  [telem_test] send: 1. UART -> 2. UART
INFO  [telem_test] send: 2. UART -> 3. UART
INFO  [telem_test] send: 3. UART -> 1. UART
saluki> 
```

Loopback between 2 uarts:
- telem 2 TX -> telem 3 RX
- telem 3 TX -> telem 2 RX

```
saluki> telem_test chain_loopback /dev/ttyS3 /dev/ttyS5
INFO  [telem_test] test type: chain_loopback
INFO  [telem_test] 1. UART /dev/ttyS3 opened [3]
INFO  [telem_test] 2. UART /dev/ttyS5 opened [4]
INFO  [telem_test] send: 1. UART -> 2. UART
INFO  [telem_test] send: 2. UART -> 1. UART
```