### PR TITLE
Update 4430_ssrc_strivermini

### DIFF
--- a/ROMFS/px4fmu_common/init.d/airframes/4430_ssrc_strivermini
+++ b/ROMFS/px4fmu_common/init.d/airframes/4430_ssrc_strivermini
@@ -1,5 +1,5 @@
 #!/bin/sh
-#
+# 
 # @name SSRC Striver Mini
 #
 # @type Standard VTOL
@@ -150,8 +150,8 @@ param set-default VTO_LOITER_ALT 40
 param set-default VT_FW_MIN_ALT 10
 
 # QuadChute angle limits
-param set-default VT_FW_QC_P 25
-param set-default VT_FW_QC_R 45
+param set-default VT_FW_QC_P 50
+param set-default VT_FW_QC_R 80
 
 param set-default VT_TRANS_MIN_TM 5.00
 param set-default VT_FWD_THRUST_EN 3


### PR DESCRIPTION
VT_FW_QC needs to be higher to not trigger undesired QuadChute actions.

<!--

Thank you for your contribution!

Get early feedback through
- Dronecode Discord: https://discord.gg/dronecode
- PX4 Discuss: http://discuss.px4.io/
- opening a draft pr and sharing the link

-->

### Solved Problem
When ... I found that ...

Fixes #{Github issue ID}

### Solution
- Add ... for ...
- Refactor ...

### Changelog Entry
For release notes:
```
Feature/Bugfix XYZ
New parameter: XYZ_Z
Documentation: Need to clarify page ... / done, read docs.px4.io/...
```

### Alternatives
We could also ...

### Test coverage
- Unit/integration test: ...
- Simulation/hardware testing logs: https://review.px4.io/

### Context
Related links, screenshot before/after, video
