### PR TITLE
px4-cmake: Add support for external NuttX apps

### DIFF
--- a/platforms/nuttx/NuttX/CMakeLists.txt
+++ b/platforms/nuttx/NuttX/CMakeLists.txt
@@ -147,7 +147,7 @@ configure_file(${CMAKE_CURRENT_SOURCE_DIR}/px4.pdat.in ${CMAKE_CURRENT_BINARY_DI
 # APPS
 
 # libapps.a
-file(GLOB_RECURSE nuttx_apps_files LIST_DIRECTORIES false
+file(GLOB_RECURSE nuttx_apps_files FOLLOW_SYMLINKS LIST_DIRECTORIES false
 	${APPS_DIR}/*.c
 	${APPS_DIR}/*.h
 )

--- a/platforms/nuttx/NuttX/extern/.gitignore
+++ b/platforms/nuttx/NuttX/extern/.gitignore
@@ -1,0 +1,2 @@
+apps/Kconfig
+apps/.kconfig

--- a/platforms/nuttx/NuttX/extern/apps/CMakeLists.txt
+++ b/platforms/nuttx/NuttX/extern/apps/CMakeLists.txt
@@ -1,0 +1,37 @@
+# ##############################################################################
+# apps/external/CMakeLists.txt
+#
+#   Copyright (c) 2025 Technology Innovation Institute. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+# 1. Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in
+#    the documentation and/or other materials provided with the
+#    distribution.
+# 3. Neither the name PX4 nor the names of its contributors may be
+#    used to endorse or promote products derived from this software
+#    without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+# OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+# AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+# ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+#
+# ##############################################################################
+
+nuttx_add_subdirectory()
+
+nuttx_generate_kconfig(MENUDESC "NuttX external apps")

--- a/platforms/nuttx/NuttX/extern/apps/Make.defs
+++ b/platforms/nuttx/NuttX/extern/apps/Make.defs
@@ -1,0 +1,35 @@
+############################################################################
+# apps/external/Make.defs
+#
+#   Copyright (c) 2025 Technology Innovation Institute. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+# 1. Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in
+#    the documentation and/or other materials provided with the
+#    distribution.
+# 3. Neither the name PX4 nor the names of its contributors may be
+#    used to endorse or promote products derived from this software
+#    without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+# OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+# AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+# ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+#
+############################################################################
+
+include $(wildcard $(APPDIR)/external/*/Make.defs)

--- a/platforms/nuttx/NuttX/extern/apps/Makefile
+++ b/platforms/nuttx/NuttX/extern/apps/Makefile
@@ -1,0 +1,37 @@
+############################################################################
+# apps/external/Makefile
+#
+#   Copyright (c) 2025 Technology Innovation Institute. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+# 1. Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in
+#    the documentation and/or other materials provided with the
+#    distribution.
+# 3. Neither the name PX4 nor the names of its contributors may be
+#    used to endorse or promote products derived from this software
+#    without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+# OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+# AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+# ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+#
+############################################################################
+
+MENUDESC = "NuttX external apps"
+
+include $(APPDIR)/Directory.mk

--- a/platforms/nuttx/cmake/init.cmake
+++ b/platforms/nuttx/cmake/init.cmake
@@ -68,6 +68,9 @@ execute_process(
 px4_add_git_submodule(TARGET git_nuttx PATH "${NUTTX_SRC_DIR}/nuttx")
 px4_add_git_submodule(TARGET git_nuttx_apps PATH "${NUTTX_SRC_DIR}/apps")
 
+# Link out-of-(nuttx)-tree apps into apps/external
+file(CREATE_LINK ${NUTTX_SRC_DIR}/extern/apps ${NUTTX_APPS_DIR}/external SYMBOLIC)
+
 # make olddefconfig (inflate defconfig to full .config)
 execute_process(COMMAND ${CMAKE_COMMAND} -E make_directory ${NUTTX_CONFIG_DIR}/src) # needed for NuttX build
 execute_process(COMMAND ${CMAKE_COMMAND} -E copy_if_different ${NUTTX_SRC_DIR}/Make.defs.in ${NUTTX_DIR}/Make.defs) # Create a temporary Toplevel Make.defs for the oldconfig step


### PR DESCRIPTION
This allows us to include external, out-of-tree NuttX Apps as git submodules. It does so by linking the directory platforms/nuttx/NuttX/extern/apps to platforms/nuttx/NuttX/apps/external.

The rationale is I've been developing a little attestation daemon as a plain NuttX app that I would like to contribute to px4-firmware as a private git repo.

If you think we should only have apps as PX4 modules in px4-firmware, please feel free to drop this.

NuttX reference: https://nuttx.apache.org/docs/latest/guides/building_nuttx_with_app_out_of_src_tree.html#special-apps-external-directory

### Changelog Entry
For release notes:
```
Support for external, out-of-tree NuttX Apps
```

### Alternatives
We can also include git submodule apps as PX4 modules (as we already do for some) but this might make sense for apps that do not need/use PX4 facilities.
