### PR TITLE
Update bootloader into px4-firmware docker image

### DIFF
--- a/.github/workflows/tiiuae-pixhawk-and-saluki.yaml
+++ b/.github/workflows/tiiuae-pixhawk-and-saluki.yaml
@@ -46,7 +46,7 @@ permissions:
   packages: write
 
 env:
-  saluki_nxp_bootloader: "ghcr.io/tiiuae/saluki_bootloader_v2:2.8.0"
+  saluki_nxp_bootloader: "ghcr.io/tiiuae/saluki_bootloader_v2:sha-adbe187"
   saluki_fpga_repo: "ghcr.io/tiiuae/saluki-fpga"
   saluki_pi_fpga_version: "4.28.0"
   saluki_v2_fpga_version: "4.28.0"


### PR DESCRIPTION
Current bootloader version linked into px4-firmware docker image does not work with latest px4 firmware with optee support enabled. Update new optee enabled bootloader (from current master head) into the docker image.