### PR TITLE
drivers/imu/adis16470: Publish gyro sample before accelerometer

### DIFF
--- a/src/drivers/imu/analog_devices/adis16470/ADIS16470.cpp
+++ b/src/drivers/imu/analog_devices/adis16470/ADIS16470.cpp
@@ -371,8 +371,8 @@ void ADIS16470::RunImpl()
 			if (success) {
 				// Publish data if there was no errors
 
-				_px4_accel.update(timestamp_sample, accel_x, accel_y, accel_z);
 				_px4_gyro.update(timestamp_sample, gyro_x, gyro_y, gyro_z);
+				_px4_accel.update(timestamp_sample, accel_x, accel_y, accel_z);
 			}
 		}
 


### PR DESCRIPTION
Due to logic in Sensors/VehicleIMU, there is a potential race condition where accelerometer samples might be skipped by the condition

  "(_accel_timestamp_sample_last < (_gyro_timestamp_sample_last - 0.5f * _accel_interval_us)"

This would happen in a case where the VehicleIMU code gets to run right in between the lines "_px4_accel.update" and "_px4_gyro.update".

Changing the order of updating the accelerometer and gyro samples so that gyro is published first ensures that even in this race condition the gyro sample will be newer than accelerometer sample, thus fixing an issue of accelerometer sample getting skipped the next round.

