### PR TITLE
mavlink: critical action enable check fixed

### DIFF
--- a/src/modules/mavlink/mavlink_log_handler.cpp
+++ b/src/modules/mavlink/mavlink_log_handler.cpp
@@ -83,9 +83,6 @@ stat_file(const char *file, time_t *date = nullptr, uint32_t *size = nullptr)
 MavlinkLogHandler::MavlinkLogHandler(Mavlink *mavlink)
 	: _mavlink(mavlink)
 {
-	if (_mavlink->is_crit_act_enabled()) {
-		_crit_action.enable(true);
-	}
 }
 MavlinkLogHandler::~MavlinkLogHandler()
 {
@@ -144,6 +141,11 @@ MavlinkLogHandler::_log_request_list(const mavlink_message_t *msg)
 {
 	mavlink_log_request_list_t request;
 	mavlink_msg_log_request_list_decode(msg, &request);
+
+	// Check if CriticalActivity support is enabled
+	if (_mavlink->is_crit_act_enabled()) {
+		_crit_action.enable(true);
+	}
 
 	//-- Check for re-requests (data loss) or new request
 	if (_current_status != LogHandlerState::Inactive) {


### PR DESCRIPTION
MavlinkLogHandler is constructed before the parent Mavlink object, so the MavlinkLogHandler constructor can't read any MAvlink object states because it is not yet constructed and variables are uninitialized.

is_crit_act_enabled() is now called when the first log_request_list msg is received.