### PR TITLE
platforms/mpfs/hrt_ioctl: Fix deadlock due to spinlock held while entering critical section

### DIFF
--- a/platforms/nuttx/src/px4/common/hrt_ioctl.c
+++ b/platforms/nuttx/src/px4/common/hrt_ioctl.c
@@ -382,9 +382,9 @@ hrt_ioctl(unsigned int cmd, unsigned long arg)
 				kmm_free(deleted);
 			}
 
-			px4_sem_destroy(callback_sem);
-
 			spin_unlock_irqrestore_notrace(&g_hrt_ioctl_lock, flags);
+
+			px4_sem_destroy(callback_sem);
 
 			*(px4_sem_t **)arg = NULL;
 			kmm_free(callback_sem);


### PR DESCRIPTION
sem_destroy enters critical section; if holding the g_hrt_ioctl_lock during this call, there is a change for deadlock since other CPUs might already be in interrupt waiting for the same spinlock.

