### PR TITLE
src/modules/mavlink: Increase mavlink_shell stack size

### DIFF
--- a/src/modules/mavlink/CMakeLists.txt
+++ b/src/modules/mavlink/CMakeLists.txt
@@ -149,6 +149,7 @@ px4_add_module(
 px4_add_module(
 	MODULE modules__mavlink_shell
 	MAIN mavlink_shell
+	STACK_MAIN 3072
 	NO_DAEMON
 	SRCS
 		mavlink_shell_main.cpp


### PR DESCRIPTION
This increases the mavlink shell stack size to 3K on 32-bit targets and to 6K on 64-bit targets

