### PR TITLE
mavlink: Initialize MavlinkCommandSenderLock only once

### DIFF
--- a/src/modules/mavlink/mavlink_command_sender.cpp
+++ b/src/modules/mavlink/mavlink_command_sender.cpp
@@ -48,9 +48,8 @@ px4_sem_t MavlinkCommandSender::_lock;
 
 void MavlinkCommandSender::initialize()
 {
-	px4_mutex_init(&_lock, 0);
-
 	if (_instance == nullptr) {
+		px4_mutex_init(&_lock, 0);
 		_instance = new MavlinkCommandSender();
 	}
 }


### PR DESCRIPTION
There is a bug that _lock is initialized at every instance startup, even though there is just one lock for the MavlinkCommandSender singleton.

Fixes: https://jira.tii.ae/browse/SSRCDP-11562
