### PR TITLE
hrt_ioctl.c: Init sq_queue_t in hrt_ioctl() before use

### DIFF
--- a/platforms/nuttx/src/px4/common/hrt_ioctl.c
+++ b/platforms/nuttx/src/px4/common/hrt_ioctl.c
@@ -370,6 +370,8 @@ hrt_ioctl(unsigned int cmd, unsigned long arg)
 			struct usr_hrt_call *e;
 			irqstate_t flags;
 
+			sq_init(&deleted);
+
 			flags = spin_lock_irqsave_notrace(&g_hrt_ioctl_lock);
 
 			sq_for_every(&callout_queue, queued) {


### PR DESCRIPTION
The deleted queue in HRT_UNREGISTER case was not initialized before use which caused crash during system boot up.

