### PR TITLE
Critical action support disabling when no MOI module available

### DIFF
--- a/platforms/common/CriticalAction.cpp
+++ b/platforms/common/CriticalAction.cpp
@@ -50,7 +50,11 @@ const uint32_t CRIT_ACT_CMD_RELEASE = vehicle_command_s::VEHICLE_CMD_CUSTOM_2;
 
 bool CriticalAction::request(uint8_t comp_id)
 {
-	if (!_enabled) {
+#ifdef CONFIG_MODULES_MOI_AGENT
+
+	if (!_enabled)
+#endif
+	{
 		return true;
 	}
 
@@ -112,7 +116,11 @@ bool CriticalAction::request(uint8_t comp_id)
 
 void CriticalAction::release(uint8_t comp_id)
 {
-	if (!_enabled) {
+#ifdef CONFIG_MODULES_MOI_AGENT
+
+	if (!_enabled)
+#endif
+	{
 		return;
 	}
 

--- a/src/drivers/cdcacm_autostart/cdcacm_autostart.cpp
+++ b/src/drivers/cdcacm_autostart/cdcacm_autostart.cpp
@@ -530,7 +530,12 @@ bool CdcAcmAutostart::start_mavlink()
 	bool success = false;
 	char mavlink_mode_string[3];
 	snprintf(mavlink_mode_string, sizeof(mavlink_mode_string), "%" PRId32, _usb_mav_mode.get());
-	static const char *argv[] {"mavlink", "start", "-d", USB_DEVICE_PATH, "-m", mavlink_mode_string, nullptr};
+	static const char *argv[] {"mavlink", "start",
+#ifdef CONFIG_MODULES_MOI_AGENT
+				   "-y",
+#endif
+				   "-d", USB_DEVICE_PATH, "-m", mavlink_mode_string, nullptr
+				  };
 
 	if (execute_process((char **)argv) > 0) {
 		success = true;

--- a/src/modules/mavlink/mavlink_main.cpp
+++ b/src/modules/mavlink/mavlink_main.cpp
@@ -2967,6 +2967,7 @@ Mavlink::display_status()
 	printf("\tForwarding: %s\n", get_forwarding_on() ? "On" : "Off");
 	printf("\tMAVLink version: %" PRId32 "\n", _protocol_version);
 
+	printf("\tCriticalAction support: %s\n", is_crit_act_enabled() ? "On" : "Off");
 	printf("\ttransport protocol: ");
 
 	switch (_protocol) {

--- a/src/modules/mavlink/module.yaml
+++ b/src/modules/mavlink/module.yaml
@@ -52,6 +52,10 @@ serial_config:
         then
             set MAV_ARGS "${MAV_ARGS} -z"
         fi
+        if param compare MAV_${i}_CRIT_ACT 1
+        then
+            set MAV_ARGS "${MAV_ARGS} -y"
+        fi
         mavlink start ${MAV_ARGS} -x
       port_config_param:
         name: MAV_${i}_CONFIG
@@ -258,3 +262,16 @@ parameters:
             num_instances: *max_num_config_instances
             default: [0, 0, 0]
             requires_ethernet: true
+
+        MAV_${i}_CRIT_ACT:
+            description:
+                short: Enable critical activity support for inteface ${i}
+                long: |
+                    If enabled, MAVLink instance will request approval before starting any
+                    critical activity which prevents system reboot (e.g. log download). Request
+                    and response are transferred via uORB topic messages.
+
+            type: boolean
+            reboot_required: true
+            num_instances: *max_num_config_instances
+            default: [false, false, false]


### PR DESCRIPTION
When there is no MOI module available (build and included in the target) the critical action requests shall not prevent other module functionality.

* Mavlink: critical action support enabled/disabled by MAV_x_CRIT_ACT param for instances started by MAV_x_CONFIG
* Mavlink: Critical action enabled/disabled info in mavlink status print
* cdcacm: usb mavlink critical action support only if MOI module available (CONFIG_MODULES_MOI_AGENT not set)
* CriticalAction: In case module has started with critical action support enabled, skip the check and always allow if MOI module not available (CONFIG_MODULES_MOI_AGENT not set)
