### PR TITLE
Fix redundancy mode control

### DIFF
--- a/msg/RedundancyStatus.msg
+++ b/msg/RedundancyStatus.msg
@@ -4,6 +4,7 @@ uint64 timestamp # time since system start (microseconds)
 
 uint8 fc_number # Number of this FC, 1-4, matches MAV_COMP_ID
 uint8 fc_in_act_control # Which FC is in actuator control, 0 - unknown
+uint8 target_nav_state # Redundancy requested navigation state lock, NAVIGATION_STATE_MAX when inactive
 
 uint8 FC_UNKNOWN = 0
 uint8 FC1 = 1

--- a/src/modules/commander/Commander.cpp
+++ b/src/modules/commander/Commander.cpp
@@ -742,6 +742,22 @@ Commander::handle_command(const vehicle_command_s &cmd)
 		return false;
 	}
 
+#ifdef CONFIG_MODULES_REDUNDANCY
+	redundancy_status_s redundancy_status;
+
+	/* If redundancy_status.target_nav_state is set to anything else than
+	 * NAVIGATION_STATE_MAX, commands are not handled; the FC is entirely
+	 * in the redundancy module's control
+	 */
+
+	if (_redundancy_status_sub.copy(&redundancy_status) &&
+	    redundancy_status.target_nav_state < vehicle_status_s::NAVIGATION_STATE_MAX) {
+		answer_command(cmd, vehicle_command_ack_s::VEHICLE_CMD_RESULT_TEMPORARILY_REJECTED);
+		return true;
+	}
+
+#endif
+
 	/* result of the command */
 	unsigned cmd_result = vehicle_command_ack_s::VEHICLE_CMD_RESULT_UNSUPPORTED;
 
@@ -2914,6 +2930,21 @@ void Commander::battery_status_check()
 
 void Commander::manualControlCheck()
 {
+#ifdef CONFIG_MODULES_REDUNDANCY
+	redundancy_status_s redundancy_status;
+
+	/* If redundancy_status.target_nav_state is set to anything else than
+	 * NAVIGATION_STATE_MAX, manual controls are not handled; the FC is entirely
+	 * in the redundancy module's control
+	 */
+
+	if (_redundancy_status_sub.copy(&redundancy_status) &&
+	    redundancy_status.target_nav_state < vehicle_status_s::NAVIGATION_STATE_MAX) {
+		return;
+	}
+
+#endif
+
 	manual_control_setpoint_s manual_control_setpoint;
 	const bool manual_control_updated = _manual_control_setpoint_sub.update(&manual_control_setpoint);
 

--- a/src/modules/commander/Commander.hpp
+++ b/src/modules/commander/Commander.hpp
@@ -76,6 +76,9 @@
 #include <uORB/topics/offboard_control_mode.h>
 #include <uORB/topics/parameter_update.h>
 #include <uORB/topics/power_button_state.h>
+#ifdef CONFIG_MODULES_REDUNDANCY
+#include <uORB/topics/redundancy_status.h>
+#endif
 #include <uORB/topics/rtl_time_estimate.h>
 #include <uORB/topics/sensor_gps.h>
 #include <uORB/topics/system_power.h>
@@ -310,6 +313,9 @@ private:
 
 	uORB::SubscriptionData<mission_result_s>		_mission_result_sub{ORB_ID(mission_result)};
 	uORB::SubscriptionData<offboard_control_mode_s>		_offboard_control_mode_sub{ORB_ID(offboard_control_mode)};
+#ifdef CONFIG_MODULES_REDUNDANCY
+	uORB::Subscription					_redundancy_status_sub {ORB_ID(redundancy_status)};
+#endif
 
 	// Publications
 	uORB::Publication<actuator_armed_s>			_actuator_armed_pub{ORB_ID(actuator_armed)};


### PR DESCRIPTION
Fixes: 

https://jira.tii.ae/browse/SSRCDP-12393, FT redundancy baseboard module flight modes can not be changed after failover mode via RC
https://jira.tii.ae/browse/SSRCDP-12392, Saluki FT: PX4 failsafe parameters are not synchronized to FC2 (from FC1)

This locks the commander from accepting requests while flying and FC1 is in control.
This also adds syncronizing parameters COM_FLTMODE*, COM_RCL_EXCEPT and NAV_RCL_ACT from FC1 to FC2.
