### PR TITLE
Perform PMIC reset after kernel panic

### DIFF
--- a/platforms/common/include/px4_platform_common/shutdown.h
+++ b/platforms/common/include/px4_platform_common/shutdown.h
@@ -75,6 +75,7 @@ typedef enum {
 	REBOOT_TO_BOOTLOADER = 1,    ///< Reboot to PX4 bootloader
 	REBOOT_TO_ISP = 2,           ///< Reboot to ISP bootloader
 	REBOOT_TO_BOOTLOADER_CONTINUE = 3, // < Reboot to bootloader and continue TODO!
+	REBOOT_FROM_PANIC = 4,
 } reboot_request_t;
 
 /**

--- a/platforms/nuttx/src/px4/nxp/imx9/board_reset/CMakeLists.txt
+++ b/platforms/nuttx/src/px4/nxp/imx9/board_reset/CMakeLists.txt
@@ -33,6 +33,9 @@
 
 px4_add_library(arch_board_reset
 	board_reset.cpp
+	post_panic_routines/panic_lpi2c.cpp
+	post_panic_routines/panic_pmic_reset.cpp
+	post_panic_routines/panic_flexspi_nor.cpp
 )
 
 if (NOT DEFINED CONFIG_BUILD_FLAT)

--- a/platforms/nuttx/src/px4/nxp/imx9/board_reset/board_reset.cpp
+++ b/platforms/nuttx/src/px4/nxp/imx9/board_reset/board_reset.cpp
@@ -44,6 +44,8 @@
 #include <nuttx/board.h>
 #include <nuttx/sched.h>
 #include "imx9_pmic.h"
+#include "post_panic_routines/panic_pmic_reset.h"
+#include "post_panic_routines/panic_flexspi_nor.h"
 
 #ifdef CONFIG_SMP
 /* The CPU mask for all (valid) CPUs */
@@ -62,7 +64,7 @@ static struct smp_call_data_s g_reboot_data;
 extern "C" void __start(void);
 extern "C" int psci_cpu_off(void);
 
-static void board_reset_enter_bootloader()
+static void board_reset_enter_bootloader(int status)
 {
 	/* WDOG_B pin is unused in current HW design.
 	* Related configuration bits (WDOG_B_CFG) from PMIC RESET_CTRL
@@ -71,35 +73,26 @@ static void board_reset_enter_bootloader()
 	* stay in bootloader: WDOG_B_CFG 11b
 	*/
 
+	switch (status) {
+	case 1: /* REBOOT_TO_BOOTLOADER */
+		imx9_pmic_set_reset_ctrl(IMX9_PMIC_RESET_CTRL_DEFAULT |
+					 IMX9_PMIC_RESET_CTRL_WDOG_COLD_RESET_MASK);
+		break;
+
+	case 4: /* REBOOT_FROM_PANIC */
+		/* Reset NOR flash first to prevent USB flashing mode */
+		px4_imx9_flexspi_nor_panic_reset(IMX9_FLEXSPI_BASE, 0);
+		px4_imx9_pmic_panic_reset_with_ctrl(IMX9_PMIC_RESET_CTRL_DEFAULT);
+
+		while (1);
+
+	default: /* REBOOT_TO_BOOTLOADER_CONTINUE */
+		imx9_pmic_set_reset_ctrl(IMX9_PMIC_RESET_CTRL_DEFAULT);
+	}
+
 #if defined(BOARD_HAS_ON_RESET)
 	board_on_reset(REBOOT_TO_BOOTLOADER);
 #endif
-
-	imx9_pmic_set_reset_ctrl(IMX9_PMIC_RESET_CTRL_DEFAULT |
-				 IMX9_PMIC_RESET_CTRL_WDOG_COLD_RESET_MASK);
-
-	/* Reset the whole SoC */
-
-	imx9_pmic_reset();
-
-	while (1);
-}
-
-static void board_reset_enter_bootloader_and_continue_boot()
-{
-	/* WDOG_B pin is unused in current HW design.
-	* Related configuration bits (WDOG_B_CFG) from PMIC RESET_CTRL
-	* register are borrowed for stay in bootloader reason delivery.
-	*
-	* With PMIC register power on value system will boot normally.
-	*/
-
-#if defined(BOARD_HAS_ON_RESET)
-	board_on_reset(REBOOT_TO_BOOTLOADER_CONTINUE);
-#endif
-
-	imx9_pmic_set_reset_ctrl(IMX9_PMIC_RESET_CTRL_DEFAULT);
-
 	/* Reset the whole SoC */
 
 	imx9_pmic_reset();
@@ -145,25 +138,8 @@ static int board_reset_enter_app(FAR void *arg)
 	return 0;
 }
 
-int board_reset(int status)
+int board_reset_warm()
 {
-	DEBUGASSERT(!up_interrupt_context());
-
-	/* First check if doing a PMIC reset */
-
-	if (status == REBOOT_TO_BOOTLOADER) {
-		/* PMIC reset, stay in bootloader */
-
-		board_reset_enter_bootloader();
-
-	} else if (status == REBOOT_TO_BOOTLOADER_CONTINUE) {
-		/* PMIC reset, reboot */
-
-		board_reset_enter_bootloader_and_continue_boot();
-	}
-
-	/* If we and up here, continue with warm boot */
-
 	/* Disable local interrupts */
 
 	up_irq_save();
@@ -193,6 +169,22 @@ int board_reset(int status)
 	/* Enter reboot function */
 
 	board_reset_enter_app(NULL);
+
+	return 0;
+}
+
+int board_reset(int status)
+{
+	if (status != REBOOT_FROM_PANIC) {
+		DEBUGASSERT(!up_interrupt_context());
+	}
+
+	if (status == REBOOT_REQUEST) {
+		board_reset_warm();
+
+	} else {
+		board_reset_enter_bootloader(status);
+	}
 
 	return 0;
 }

--- a/platforms/nuttx/src/px4/nxp/imx9/board_reset/post_panic_routines/panic_flexspi_nor.cpp
+++ b/platforms/nuttx/src/px4/nxp/imx9/board_reset/post_panic_routines/panic_flexspi_nor.cpp
@@ -1,0 +1,233 @@
+/****************************************************************************
+ *
+ *   Copyright (C) 2026 Technology Innovation Institute. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+/**
+ * @file panic_flexspi_nor.cpp
+ * Implementation of NXP IMX9 FlexSPI NOR panic mode reset for safe recovery
+ * during kernel panic to prevent USB flashing mode entry.
+ */
+
+#include "panic_flexspi_nor.h"
+#include <errno.h>
+#include <nuttx/arch.h>
+
+/* Register access macros */
+
+#ifndef getreg32
+static inline uint32_t getreg32(uintptr_t addr)
+{
+	return *(volatile uint32_t *)addr;
+}
+#endif
+
+#ifndef putreg32
+static inline void putreg32(uint32_t val, uintptr_t addr)
+{
+	*(volatile uint32_t *)addr = val;
+}
+#endif
+
+/**
+ * @brief Modify a 32-bit register with mask and set bits
+ */
+static inline void px4_imx9_flexspi_nor_modifyreg(uint32_t addr,
+		uint32_t clearbits,
+		uint32_t setbits)
+{
+	putreg32((getreg32(addr) & ~clearbits) | setbits, addr);
+}
+
+/* FlexSPI register offsets */
+
+#define FLEXSPI_MCR0_OFFSET      0x00
+#define FLEXSPI_IPCR0_OFFSET     0xa0
+#define FLEXSPI_IPCR1_OFFSET     0xa4
+#define FLEXSPI_IPCMD_OFFSET     0xb0
+#define FLEXSPI_STS0_OFFSET      0xe0
+
+/* MCR0 register bits */
+
+#define FLEXSPI_MCR0_SWRESET     (1 << 0)
+
+/* IPCR1 register bits - command sequence indices */
+
+#define FLEXSPI_IPCR1_ISEQID_SHIFT   16
+#define FLEXSPI_IPCR1_ISEQNUM_SHIFT  24
+
+/* STS0 register bits */
+
+#define FLEXSPI_STS0_SEQIDLE     (1 << 0)
+#define FLEXSPI_STS0_ARBIDLE     (1 << 1)
+
+/* IPCMD register bits */
+
+#define FLEXSPI_IPCMD_TRG        (1 << 0)
+
+/* Command sequence indices from imx9_flexspi_nor.c */
+
+#define CMD_RESET_ENABLE         10  /* Index in LUT for RESET_ENABLE */
+#define CMD_RESET_MEMORY         11  /* Index in LUT for RESET_MEMORY */
+
+/* Timeout for busy wait loops (prevent infinite loops) */
+
+#define FLEXSPI_PANIC_TIMEOUT    1000000
+
+/**
+ * @brief Wait for FlexSPI sequence to complete
+ *
+ * Busy-waits until the sequence completes or timeout occurs.
+ * No OS services required.
+ */
+static int px4_imx9_flexspi_nor_wait_idle(uint32_t flexspi_base)
+{
+	uint32_t status_addr = flexspi_base + FLEXSPI_STS0_OFFSET;
+	uint32_t timeout = FLEXSPI_PANIC_TIMEOUT;
+
+	while ((getreg32(status_addr) & FLEXSPI_STS0_SEQIDLE) == 0 && timeout-- > 0) {
+		/* Busy wait - no OS services */
+	}
+
+	if (timeout == 0) {
+		return -ETIMEDOUT;
+	}
+
+	return 0;
+}
+
+/**
+ * @brief Issue a command sequence to FlexSPI NOR device
+ *
+ * Configures and triggers an IP command on the NOR flash device.
+ * This is a panic-safe operation using only direct register access.
+ */
+static int px4_imx9_flexspi_nor_issue_cmd(uint32_t flexspi_base,
+		int port,
+		int seq_index)
+{
+	uint32_t ipcr0_addr = flexspi_base + FLEXSPI_IPCR0_OFFSET;
+	uint32_t ipcr1_addr = flexspi_base + FLEXSPI_IPCR1_OFFSET;
+	uint32_t ipcmd_addr = flexspi_base + FLEXSPI_IPCMD_OFFSET;
+	int ret;
+
+	/* Set device address to 0 (not used for these commands) */
+
+	putreg32(0, ipcr0_addr);
+
+	/* Set data size to 0 and sequence parameters:
+	 * - ISEQID: sequence index for the command
+	 * - ISEQNUM: number of sequences (1 for simple commands)
+	 * - IPAREN: no parity
+	 */
+
+	uint32_t ipcr1 = ((seq_index & 0xf) << FLEXSPI_IPCR1_ISEQID_SHIFT) |
+			 ((1 & 0x7) << FLEXSPI_IPCR1_ISEQNUM_SHIFT);
+
+	putreg32(ipcr1, ipcr1_addr);
+
+	/* Trigger the IP command */
+
+	putreg32(FLEXSPI_IPCMD_TRG, ipcmd_addr);
+
+	/* Wait for sequence to complete */
+
+	ret = px4_imx9_flexspi_nor_wait_idle(flexspi_base);
+
+	if (ret < 0) {
+		return ret;
+	}
+
+	return 0;
+}
+
+/**
+ * @brief Busy-wait delay without OS services
+ *
+ * Simple microsecond delay using busy-wait loop.
+ * Timing is approximate but sufficient for NOR reset requirements.
+ */
+static void px4_imx9_flexspi_nor_panic_delay_us(uint32_t microseconds)
+{
+	/* Rough estimate: ~1000 loops per microsecond on typical ARM Cortex-A
+	 * This is conservative and will result in longer delays than requested
+	 */
+
+	volatile uint32_t loop_count = microseconds * 500;
+
+	while (loop_count-- > 0) {
+		/* Empty loop */
+	}
+}
+
+/**
+ * @brief Perform a panic-safe NOR flash reset
+ *
+ * Implementation of NOR reset without using OS services.
+ * Safe to call from interrupt/panic context.
+ */
+int px4_imx9_flexspi_nor_panic_reset(uint32_t flexspi_base, int port)
+{
+	uint32_t mcr0_addr = flexspi_base + FLEXSPI_MCR0_OFFSET;
+	int ret;
+
+	/* Step 1: Send RESET_ENABLE command */
+
+	ret = px4_imx9_flexspi_nor_issue_cmd(flexspi_base, port, CMD_RESET_ENABLE);
+
+	if (ret < 0) {
+		return ret;
+	}
+
+	/* Step 2: Small delay (1 microsecond) */
+
+	px4_imx9_flexspi_nor_panic_delay_us(1);
+
+	/* Step 3: Send RESET_MEMORY command */
+
+	ret = px4_imx9_flexspi_nor_issue_cmd(flexspi_base, port, CMD_RESET_MEMORY);
+
+	if (ret < 0) {
+		return ret;
+	}
+
+	/* Step 4: Wait for bus to be idle (already done in issue_cmd) */
+
+	/* Step 5: Perform FlexSPI software reset */
+
+	px4_imx9_flexspi_nor_modifyreg(mcr0_addr, 0, FLEXSPI_MCR0_SWRESET);
+
+	/* Small delay to allow reset to propagate */
+
+	px4_imx9_flexspi_nor_panic_delay_us(10);
+
+	return 0;
+}

--- a/platforms/nuttx/src/px4/nxp/imx9/board_reset/post_panic_routines/panic_flexspi_nor.h
+++ b/platforms/nuttx/src/px4/nxp/imx9/board_reset/post_panic_routines/panic_flexspi_nor.h
@@ -1,0 +1,66 @@
+/****************************************************************************
+ *
+ *   Copyright (C) 2026 Technology Innovation Institute. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+/**
+ * @file panic_flexspi_nor.h
+ * IMX9 FlexSPI NOR panic mode reset operations for safe recovery during kernel panic.
+ */
+
+#ifndef __IMX9_FLEXSPI_NOR_PANIC_H__
+#define __IMX9_FLEXSPI_NOR_PANIC_H__
+
+#include <stdint.h>
+
+/**
+ * @brief Perform a panic-safe NOR flash reset
+ *
+ * This function resets the NOR flash memory using direct hardware register access
+ * without relying on OS services. This is essential for panic recovery to prevent
+ * the NXP ROM from entering USB flashing mode.
+ *
+ * The operation sequence:
+ * - Sends RESET_ENABLE command to NOR flash
+ * - Sends RESET_MEMORY command to perform the actual reset
+ * - Waits for device ready status
+ * - Performs FlexSPI controller software reset
+ *
+ * @param flexspi_base Base address of FlexSPI controller
+ * @param port FlexSPI port number (typically 0 for primary NOR device)
+ * @return 0 on success, negative errno on failure
+ *
+ * @note This function is designed for use during kernel panic when OS services
+ *       may be unavailable. It uses only direct hardware register access.
+ */
+int px4_imx9_flexspi_nor_panic_reset(uint32_t flexspi_base, int port);
+
+#endif /* __IMX9_FLEXSPI_NOR_PANIC_H__ */

--- a/platforms/nuttx/src/px4/nxp/imx9/board_reset/post_panic_routines/panic_lpi2c.cpp
+++ b/platforms/nuttx/src/px4/nxp/imx9/board_reset/post_panic_routines/panic_lpi2c.cpp
@@ -1,0 +1,422 @@
+/****************************************************************************
+ *
+ *   Copyright (C) 2026 Technology Innovation Institute. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+/**
+ * @file panic_lpi2c.cpp
+ * Implementation of NXP IMX9 LPI2C panic mode operations for kernel panic
+ * recovery scenarios.
+ */
+
+#include "panic_lpi2c.h"
+
+extern "C"
+{
+#include "imx9_ccm.h"
+#include "imx9_clockconfig.h"
+}
+
+#include "hardware/imx9_ccm.h"
+#include "hardware/imx9_lpi2c.h"
+
+#include <errno.h>
+#include <nuttx/arch.h>
+#include <nuttx/i2c/i2c_master.h>
+
+#define IMX9_LPI2C_PANIC_TIMEOUT  1000000
+#define PMIC_I2C_FREQ_HZ  400000
+
+#ifndef getreg32
+static inline uint32_t getreg32(uintptr_t addr)
+{
+	return *(volatile uint32_t *)addr;
+}
+#endif
+
+#ifndef putreg32
+static inline void putreg32(uint32_t val, uintptr_t addr)
+{
+	*(volatile uint32_t *)addr = val;
+}
+#endif
+
+/**
+ * @brief Modify a 32-bit register with mask and set bits
+ */
+static inline void px4_imx9_lpi2c_raw_modifyreg(uint32_t addr,
+		uint32_t clearbits,
+		uint32_t setbits)
+{
+	putreg32((getreg32(addr) & ~clearbits) | setbits, addr);
+}
+
+/**
+ * @brief Configure LPI2C controller based on port number
+ */
+int px4_imx9_lpi2c_raw_config(int port, struct px4_imx9_lpi2c_panic_ctx_s *ctx)
+{
+	switch (port) {
+#ifdef CONFIG_IMX9_LPI2C1
+
+	case 1:
+		ctx->base = IMX9_LPI2C1_BASE;
+		ctx->clk_root = CCM_CR_LPI2C1;
+		ctx->clk_gate = CCM_LPCG_LPI2C1;
+		ctx->busy_idle = CONFIG_IMX9_LPI2C1_BUSYIDLE;
+		ctx->filtscl = CONFIG_IMX9_LPI2C1_FILTSCL;
+		ctx->filtsda = CONFIG_IMX9_LPI2C1_FILTSDA;
+		return OK;
+#endif
+#ifdef CONFIG_IMX9_LPI2C2
+
+	case 2:
+		ctx->base = IMX9_LPI2C2_BASE;
+		ctx->clk_root = CCM_CR_LPI2C2;
+		ctx->clk_gate = CCM_LPCG_LPI2C2;
+		ctx->busy_idle = CONFIG_IMX9_LPI2C2_BUSYIDLE;
+		ctx->filtscl = CONFIG_IMX9_LPI2C2_FILTSCL;
+		ctx->filtsda = CONFIG_IMX9_LPI2C2_FILTSDA;
+		return OK;
+#endif
+#ifdef CONFIG_IMX9_LPI2C3
+
+	case 3:
+		ctx->base = IMX9_LPI2C3_BASE;
+		ctx->clk_root = CCM_CR_LPI2C3;
+		ctx->clk_gate = CCM_LPCG_LPI2C3;
+		ctx->busy_idle = CONFIG_IMX9_LPI2C3_BUSYIDLE;
+		ctx->filtscl = CONFIG_IMX9_LPI2C3_FILTSCL;
+		ctx->filtsda = CONFIG_IMX9_LPI2C3_FILTSDA;
+		return OK;
+#endif
+#ifdef CONFIG_IMX9_LPI2C4
+
+	case 4:
+		ctx->base = IMX9_LPI2C4_BASE;
+		ctx->clk_root = CCM_CR_LPI2C4;
+		ctx->clk_gate = CCM_LPCG_LPI2C4;
+		ctx->busy_idle = CONFIG_IMX9_LPI2C4_BUSYIDLE;
+		ctx->filtscl = CONFIG_IMX9_LPI2C4_FILTSCL;
+		ctx->filtsda = CONFIG_IMX9_LPI2C4_FILTSDA;
+		return OK;
+#endif
+#ifdef CONFIG_IMX9_LPI2C5
+
+	case 5:
+		ctx->base = IMX9_LPI2C5_BASE;
+		ctx->clk_root = CCM_CR_LPI2C5;
+		ctx->clk_gate = CCM_LPCG_LPI2C5;
+		ctx->busy_idle = CONFIG_IMX9_LPI2C5_BUSYIDLE;
+		ctx->filtscl = CONFIG_IMX9_LPI2C5_FILTSCL;
+		ctx->filtsda = CONFIG_IMX9_LPI2C5_FILTSDA;
+		return OK;
+#endif
+#ifdef CONFIG_IMX9_LPI2C6
+
+	case 6:
+		ctx->base = IMX9_LPI2C6_BASE;
+		ctx->clk_root = CCM_CR_LPI2C6;
+		ctx->clk_gate = CCM_LPCG_LPI2C6;
+		ctx->busy_idle = CONFIG_IMX9_LPI2C6_BUSYIDLE;
+		ctx->filtscl = CONFIG_IMX9_LPI2C6_FILTSCL;
+		ctx->filtsda = CONFIG_IMX9_LPI2C6_FILTSDA;
+		return OK;
+#endif
+#ifdef CONFIG_IMX9_LPI2C7
+
+	case 7:
+		ctx->base = IMX9_LPI2C7_BASE;
+		ctx->clk_root = CCM_CR_LPI2C7;
+		ctx->clk_gate = CCM_LPCG_LPI2C7;
+		ctx->busy_idle = CONFIG_IMX9_LPI2C7_BUSYIDLE;
+		ctx->filtscl = CONFIG_IMX9_LPI2C7_FILTSCL;
+		ctx->filtsda = CONFIG_IMX9_LPI2C7_FILTSDA;
+		return OK;
+#endif
+#ifdef CONFIG_IMX9_LPI2C8
+
+	case 8:
+		ctx->base = IMX9_LPI2C8_BASE;
+		ctx->clk_root = CCM_CR_LPI2C8;
+		ctx->clk_gate = CCM_LPCG_LPI2C8;
+		ctx->busy_idle = CONFIG_IMX9_LPI2C8_BUSYIDLE;
+		ctx->filtscl = CONFIG_IMX9_LPI2C8_FILTSCL;
+		ctx->filtsda = CONFIG_IMX9_LPI2C8_FILTSDA;
+		return OK;
+#endif
+
+	default:
+		return -ENODEV;
+	}
+}
+
+/****************************************************************************
+ * Name: px4_imx9_lpi2c_raw_setclock
+ *
+ * Description:
+ *   Set the I2C clock
+ *   This function is partly a copy of NuttX arch imx9_lpi2c_setclock
+ *
+ ****************************************************************************/
+
+static int px4_imx9_lpi2c_raw_setclock(struct px4_imx9_lpi2c_panic_ctx_s *ctx,
+				       uint32_t frequency)
+{
+	uint32_t src_freq = 0;
+	uint32_t regval;
+	uint32_t men;
+	uint32_t prescale;
+	uint32_t best_prescale = 0;
+	uint32_t best_clk_hi = 0;
+	uint32_t abs_error = 0;
+	uint32_t best_error = UINT32_MAX;
+	uint32_t clk_hi_cycle;
+	uint32_t computed_rate;
+	uint32_t count;
+	int ret;
+
+	ret = imx9_get_rootclock(ctx->clk_root, &src_freq);
+
+	if (ret < 0 || src_freq == 0) {
+		return -ENODEV;
+	}
+
+	/* Disable the selected LPI2C peripheral to configure the new clock. */
+
+	men = getreg32(ctx->base + IMX9_LPI2C_MCR_OFFSET) & LPI2C_MCR_MEN;
+
+	if (men != 0) {
+		px4_imx9_lpi2c_raw_modifyreg(ctx->base + IMX9_LPI2C_MCR_OFFSET,
+					     LPI2C_MCR_MEN, 0);
+	}
+
+	/* LPI2C output frequency = (Source Clock (Hz)/ 2^prescale) /
+	 *   (CLKLO + 1 + CLKHI + 1 + ALIGN_DOWN((2 + FILTSCL)/2^prescale)
+	 *
+	 * Assume  CLKLO = 2 * CLKHI, SETHOLD = CLKHI, DATAVD = CLKHI / 2
+	 */
+
+	for (prescale = 1; (prescale <= 128) && (best_error != 0); prescale *= 2) {
+		for (clk_hi_cycle = 1; clk_hi_cycle < 32; clk_hi_cycle++) {
+			if (clk_hi_cycle == 1) {
+				computed_rate = (src_freq / prescale) / (6 + (2 / prescale));
+
+			} else {
+				computed_rate = (src_freq / prescale) /
+						((3 * clk_hi_cycle + 2) + (2 / prescale));
+			}
+
+			if (frequency > computed_rate) {
+				abs_error = frequency - computed_rate;
+
+			} else {
+				abs_error = computed_rate - frequency;
+			}
+
+			if (abs_error < best_error) {
+				best_prescale = prescale;
+				best_clk_hi = clk_hi_cycle;
+				best_error = abs_error;
+
+				if (abs_error == 0) {
+					break;
+				}
+			}
+		}
+	}
+
+	regval = LPI2C_MCCR0_CLKHI(best_clk_hi);
+
+	if (best_clk_hi < 2) {
+		regval |= LPI2C_MCCR0_CLKLO(3) | LPI2C_MCCR0_SETHOLD(2) |
+			  LPI2C_MCCR0_DATAVD(1);
+
+	} else {
+		regval |= LPI2C_MCCR0_CLKLO(2 * best_clk_hi) |
+			  LPI2C_MCCR0_SETHOLD(best_clk_hi) |
+			  LPI2C_MCCR0_DATAVD(best_clk_hi / 2);
+	}
+
+	putreg32(regval, ctx->base + IMX9_LPI2C_MCCR0_OFFSET);
+
+	for (count = 0; count < 8; count++) {
+		if (best_prescale == (1u << count)) {
+			best_prescale = count;
+			break;
+		}
+	}
+
+	px4_imx9_lpi2c_raw_modifyreg(ctx->base + IMX9_LPI2C_MCFGR1_OFFSET,
+				     LPI2C_MCFGR1_PRESCALE_MASK,
+				     LPI2C_MCFGR1_PRESCALE(best_prescale));
+
+	/* Re-enable LPI2C */
+
+	if (men != 0) {
+		px4_imx9_lpi2c_raw_modifyreg(ctx->base + IMX9_LPI2C_MCR_OFFSET,
+					     0, LPI2C_MCR_MEN);
+	}
+
+	return OK;
+}
+
+/**
+ * @brief Wait for LPI2C status conditions
+ */
+static int px4_imx9_lpi2c_raw_wait_status(uint32_t base, uint32_t set_mask,
+		uint32_t clear_mask)
+{
+	uint32_t status;
+
+	for (int timeout = IMX9_LPI2C_PANIC_TIMEOUT; timeout > 0; timeout--) {
+		status = getreg32(base + IMX9_LPI2C_MSR_OFFSET);
+
+		if ((status & LPI2C_MSR_ERROR_MASK) != 0) {
+			putreg32(status & LPI2C_MSR_ERROR_MASK, base + IMX9_LPI2C_MSR_OFFSET);
+			return -EIO;
+		}
+
+		if ((status & set_mask) == set_mask && (status & clear_mask) == 0) {
+			return OK;
+		}
+	}
+
+	return -ETIMEDOUT;
+}
+
+/**
+ * @brief Prepare LPI2C controller for operation
+ */
+int px4_imx9_lpi2c_raw_prepare(int port, struct px4_imx9_lpi2c_panic_ctx_s *ctx)
+{
+	int ret;
+
+	ret = px4_imx9_lpi2c_raw_config(port, ctx);
+
+	if (ret < 0) {
+		return ret;
+	}
+
+	imx9_ccm_gate_on(ctx->clk_gate, true);
+
+	putreg32(0, ctx->base + IMX9_LPI2C_MIER_OFFSET);
+	putreg32(0, ctx->base + IMX9_LPI2C_MDER_OFFSET);
+	putreg32(LPI2C_MCR_RST, ctx->base + IMX9_LPI2C_MCR_OFFSET);
+	putreg32(0, ctx->base + IMX9_LPI2C_MCR_OFFSET);
+	putreg32(LPI2C_MCR_DOZEN | LPI2C_MCR_RTF | LPI2C_MCR_RRF,
+		 ctx->base + IMX9_LPI2C_MCR_OFFSET);
+	putreg32(LPI2C_MCR_DOZEN, ctx->base + IMX9_LPI2C_MCR_OFFSET);
+
+	px4_imx9_lpi2c_raw_modifyreg(ctx->base + IMX9_LPI2C_MCFGR0_OFFSET,
+				     LPI2C_MCFG0_HREN | LPI2C_MCFG0_HRSEL,
+				     LPI2C_MCFG0_HRPOL);
+	px4_imx9_lpi2c_raw_modifyreg(ctx->base + IMX9_LPI2C_MCFGR1_OFFSET,
+				     LPI2C_MCFGR1_IGNACK | LPI2C_MCFGR1_AUTOSTOP, 0);
+	putreg32(LPI2C_MFCR_TXWATER(0) | LPI2C_MFCR_RXWATER(0),
+		 ctx->base + IMX9_LPI2C_MFCR_OFFSET);
+	putreg32(LPI2C_MCFG2_BUSIDLE(ctx->busy_idle) |
+		 LPI2C_MCFG2_FILTSCL_CYCLES(ctx->filtscl) |
+		 LPI2C_MCFG2_FILTSDA_CYCLES(ctx->filtsda),
+		 ctx->base + IMX9_LPI2C_MCFGR2_OFFSET);
+	putreg32(LPI2C_MCFG3_PINLOW_CYCLES(0), ctx->base + IMX9_LPI2C_MCFGR3_OFFSET);
+
+	ret = px4_imx9_lpi2c_raw_setclock(ctx, PMIC_I2C_FREQ_HZ);
+
+	if (ret < 0) {
+		return ret;
+	}
+
+	putreg32(0xffffffff, ctx->base + IMX9_LPI2C_MSR_OFFSET);
+	px4_imx9_lpi2c_raw_modifyreg(ctx->base + IMX9_LPI2C_MCR_OFFSET,
+				     0, LPI2C_MCR_MEN);
+
+	return OK;
+}
+
+/**
+ * @brief Perform I2C transfer
+ */
+int px4_imx9_lpi2c_raw_transfer(struct px4_imx9_lpi2c_panic_ctx_s *ctx, uint8_t addr,
+				const uint8_t *buffer, int buflen)
+{
+	int ret;
+
+	ret = px4_imx9_lpi2c_raw_wait_status(ctx->base, LPI2C_MSR_TDF, 0);
+
+	if (ret < 0) {
+		return ret;
+	}
+
+	putreg32(LPI2C_MTDR_CMD_START | LPI2C_MTDR_DATA(I2C_WRITEADDR8(addr)),
+		 ctx->base + IMX9_LPI2C_MTDR_OFFSET);
+
+	for (int i = 0; i < buflen; i++) {
+		ret = px4_imx9_lpi2c_raw_wait_status(ctx->base, LPI2C_MSR_TDF, 0);
+
+		if (ret < 0) {
+			return ret;
+		}
+
+		putreg32(LPI2C_MTDR_CMD_TXD | LPI2C_MTDR_DATA(buffer[i]),
+			 ctx->base + IMX9_LPI2C_MTDR_OFFSET);
+	}
+
+	ret = px4_imx9_lpi2c_raw_wait_status(ctx->base, LPI2C_MSR_TDF, 0);
+
+	if (ret < 0) {
+		return ret;
+	}
+
+	putreg32(LPI2C_MTDR_CMD_STOP, ctx->base + IMX9_LPI2C_MTDR_OFFSET);
+
+	ret = px4_imx9_lpi2c_raw_wait_status(ctx->base, LPI2C_MSR_SDF, LPI2C_MSR_MBF);
+
+	if (ret < 0) {
+		return ret;
+	}
+
+	putreg32(LPI2C_MSR_SDF | LPI2C_MSR_EPF | LPI2C_MSR_ERROR_MASK,
+		 ctx->base + IMX9_LPI2C_MSR_OFFSET);
+	return OK;
+}
+
+/**
+ * @brief Abort pending I2C transfer
+ */
+void px4_imx9_lpi2c_raw_abort(struct px4_imx9_lpi2c_panic_ctx_s *ctx)
+{
+	putreg32(LPI2C_MTDR_CMD_STOP, ctx->base + IMX9_LPI2C_MTDR_OFFSET);
+	putreg32(LPI2C_MCR_DOZEN | LPI2C_MCR_RTF | LPI2C_MCR_RRF |
+		 LPI2C_MCR_MEN,
+		 ctx->base + IMX9_LPI2C_MCR_OFFSET);
+	putreg32(0xffffffff, ctx->base + IMX9_LPI2C_MSR_OFFSET);
+}

--- a/platforms/nuttx/src/px4/nxp/imx9/board_reset/post_panic_routines/panic_lpi2c.h
+++ b/platforms/nuttx/src/px4/nxp/imx9/board_reset/post_panic_routines/panic_lpi2c.h
@@ -1,0 +1,101 @@
+/****************************************************************************
+ *
+ *   Copyright (C) 2026 Technology Innovation Institute. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+/**
+ * @file panic_lpi2c.h
+ * IMX9 LPI2C panic mode operations for accessing devices during kernel panic.
+ */
+
+#ifndef __IMX9_LPI2C_PANIC_H__
+#define __IMX9_LPI2C_PANIC_H__
+
+#include <stdint.h>
+
+/**
+ * @brief IMX9 LPI2C panic context structure
+ *
+ * Contains configuration and state for LPI2C operation in panic mode.
+ */
+struct px4_imx9_lpi2c_panic_ctx_s {
+	uint32_t base;       /**< LPI2C base address */
+	int clk_root;        /**< Clock root configuration */
+	int clk_gate;        /**< Clock gate configuration */
+	uint16_t busy_idle;  /**< Busy idle timing */
+	uint8_t filtscl;     /**< SCL filter cycles */
+	uint8_t filtsda;     /**< SDA filter cycles */
+};
+
+/**
+ * @brief Configure LPI2C controller in panic mode
+ *
+ * @param port LPI2C port number (1-8)
+ * @param ctx Panic context structure to populate
+ * @return OK on success, negative errno on failure
+ */
+int px4_imx9_lpi2c_raw_config(int port, struct px4_imx9_lpi2c_panic_ctx_s *ctx);
+
+/**
+ * @brief Prepare LPI2C controller for panic mode operation
+ *
+ * Initializes and configures the specified LPI2C controller with panic-safe
+ * settings and sets up the bus for communication.
+ *
+ * @param port LPI2C port number (1-8)
+ * @param ctx Panic context structure to populate
+ * @return OK on success, negative errno on failure
+ */
+int px4_imx9_lpi2c_raw_prepare(int port, struct px4_imx9_lpi2c_panic_ctx_s *ctx);
+
+/**
+ * @brief Perform I2C transfer in panic mode
+ *
+ * Sends a START condition, address, data bytes, and STOP condition
+ * without interrupts or blocking operations.
+ *
+ * @param ctx Panic context structure
+ * @param addr I2C device address
+ * @param buffer Data buffer to transmit
+ * @param buflen Number of bytes to transmit
+ * @return OK on success, negative errno on failure
+ */
+int px4_imx9_lpi2c_raw_transfer(struct px4_imx9_lpi2c_panic_ctx_s *ctx, uint8_t addr,
+				const uint8_t *buffer, int buflen);
+
+/**
+ * @brief Abort pending I2C transfer
+ *
+ * @param ctx Panic context structure
+ */
+void px4_imx9_lpi2c_raw_abort(struct px4_imx9_lpi2c_panic_ctx_s *ctx);
+
+#endif /* __IMX9_LPI2C_PANIC_H__ */

--- a/platforms/nuttx/src/px4/nxp/imx9/board_reset/post_panic_routines/panic_pmic_reset.cpp
+++ b/platforms/nuttx/src/px4/nxp/imx9/board_reset/post_panic_routines/panic_pmic_reset.cpp
@@ -1,0 +1,98 @@
+/****************************************************************************
+ *
+ *   Copyright (C) 2026 Technology Innovation Institute. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+/**
+ * @file panic_pmic_reset.cpp
+ * Implementation of NXP imx9 based PMIC reset functionality for kernel panic
+ * recovery.
+ */
+
+#include "panic_lpi2c.h"
+#include "imx9_pmic.h"
+
+/* PCA9451A PMIC register map used by panic reset path. */
+
+#define PCA9451A_I2C_ADDR 0x25
+#define REG_SW_RST        0x06
+#define REG_RESET_CTRL    0x08
+#define COLD_RESET        0x64
+
+/**
+ * @brief Write a register to the PCA9451A PMIC via I2C
+ */
+static int px4_imx9_pmic_panic_write_reg(struct px4_imx9_lpi2c_panic_ctx_s *ctx, uint8_t reg,
+		uint8_t val)
+{
+	uint8_t buffer[2] = {reg, val};
+
+	return px4_imx9_lpi2c_raw_transfer(ctx, PCA9451A_I2C_ADDR, buffer, 2);
+}
+
+/****************************************************************************
+ * Name: px4_imx9_pmic_panic_reset_with_ctrl
+ *
+ * Description:
+ *   Program PMIC reset control and trigger reset with a single panic I2C
+ *   controller setup.
+ *
+ ****************************************************************************/
+
+int px4_imx9_pmic_panic_reset_with_ctrl(uint8_t reset_ctrl)
+{
+	struct px4_imx9_lpi2c_panic_ctx_s ctx;
+	int ret;
+
+	// Initialize lpi2c bus for transfer
+	ret = px4_imx9_lpi2c_raw_prepare(CONFIG_IMX9_PMIC_I2C, &ctx);
+
+	if (ret < 0) {
+		return ret;
+	}
+
+	// Write reset control register to configure reset behavior
+	ret = px4_imx9_pmic_panic_write_reg(&ctx, REG_RESET_CTRL, reset_ctrl);
+
+	if (ret < 0) {
+		px4_imx9_lpi2c_raw_abort(&ctx);
+		return ret;
+	}
+
+	// Trigger cold reset by writing to software reset register
+	ret = px4_imx9_pmic_panic_write_reg(&ctx, REG_SW_RST, COLD_RESET);
+
+	if (ret < 0) {
+		px4_imx9_lpi2c_raw_abort(&ctx);
+	}
+
+	return ret;
+}

--- a/platforms/nuttx/src/px4/nxp/imx9/board_reset/post_panic_routines/panic_pmic_reset.h
+++ b/platforms/nuttx/src/px4/nxp/imx9/board_reset/post_panic_routines/panic_pmic_reset.h
@@ -1,0 +1,48 @@
+/****************************************************************************
+ *
+ *   Copyright (c) 2026 Technology Innovation Institute. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *	notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *	notice, this list of conditions and the following disclaimer in
+ *	the documentation and/or other materials provided with the
+ *	distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *	used to endorse or promote products derived from this software
+ *	without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+#pragma once
+
+/****************************************************************************
+ * Name: px4_imx9_pmic_panic_reset_with_ctrl
+ *
+ * Description:
+ *  Set reset control register and trigger PMIC cold reset using a single
+ *  panic-safe raw I2C controller setup sequence.
+ *
+ * Returned Value:
+ *   Zero on success or error code
+ *
+ ****************************************************************************/
+
+int px4_imx9_pmic_panic_reset_with_ctrl(uint8_t reset_ctrl);


### PR DESCRIPTION
In kernel panic context the OS services are not available anymore, so the PMIC reset shall be performed using dedicated post-panic sub routines containing direct register accesses.
- New reboot status value REBOOT_FROM_PANIC added to separate post-panic reset case.
- pmic_reset functions uses i2c helper functions.
- FlexNOR reset functions are needed to avoid system to randomly enter into USB flash mode.
