### PR TITLE
Fix ioexpander init

### DIFF
--- a/.github/workflows/tiiuae-pixhawk-and-saluki.yaml
+++ b/.github/workflows/tiiuae-pixhawk-and-saluki.yaml
@@ -46,7 +46,7 @@ permissions:
   packages: write
 
 env:
-  saluki_nxp_bootloader: "ghcr.io/tiiuae/saluki_bootloader_v2:2.15.0"
+  saluki_nxp_bootloader: "ghcr.io/tiiuae/saluki_bootloader_v2:2.16.0"
   saluki_fpga_repo: "ghcr.io/tiiuae/saluki-fpga"
   saluki_pi_fpga_version: "4.32.0"
   saluki_v2_fpga_version: "4.32.0"


### PR DESCRIPTION

Fixes: https://jira.tii.ae/browse/SSRCDP-12440, "IMX93 - Random IO expander access warnings in boot"

This fixes the issues with i2c SDA voltages dropping during initialization, while the IO expander initializations are being written.

It was not just about warnings, the IO expander initialization is very likely to fail.
